### PR TITLE
fix: The AppData files now go to /usr/share/metainfo

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,7 @@ appstream_file = i18n.merge_file(
   output: 'com.usebottles.bottles.appdata.xml',
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
# Description
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By appstream-glib tool https://github.com/hughsie/appstream-glib. It's available on Flathub and Linux distros.