### PR TITLE
Fixed a typo in UI (PluseAudio)

### DIFF
--- a/po/bottles.pot
+++ b/po/bottles.pot
@@ -480,7 +480,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/da.po
+++ b/po/da.po
@@ -505,7 +505,7 @@ msgid "Audio"
 msgstr "Lyd"
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Reducer PulseAudio-forsinkelse"
 
 #: src/ui/details.ui:1300

--- a/po/de.po
+++ b/po/de.po
@@ -498,7 +498,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/es.po
+++ b/po/es.po
@@ -518,7 +518,7 @@ msgstr "Audio"
 
 #: src/ui/details.ui:1299
 #, fuzzy
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Reduce la latencia de PulseAudio"
 
 #: src/ui/details.ui:1300

--- a/po/fr.po
+++ b/po/fr.po
@@ -532,7 +532,7 @@ msgstr "Audio"
 
 #: src/ui/details.ui:1299
 #, fuzzy
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Réduir la latence de PulseAudio"
 
 #: src/ui/details.ui:1300

--- a/po/hr.po
+++ b/po/hr.po
@@ -479,7 +479,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/id.po
+++ b/po/id.po
@@ -513,7 +513,7 @@ msgid "Audio"
 msgstr "Audio"
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/it.po
+++ b/po/it.po
@@ -508,7 +508,7 @@ msgid "Audio"
 msgstr "Audio"
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Riduci la latenza di PulseAudio"
 
 #: src/ui/details.ui:1300

--- a/po/ja.po
+++ b/po/ja.po
@@ -479,7 +479,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/la.po
+++ b/po/la.po
@@ -499,7 +499,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -543,7 +543,7 @@ msgstr "Lyd"
 
 #: src/ui/details.ui:1299
 #, fuzzy
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Reduser PulseAudio-forsinkelse"
 
 #: src/ui/details.ui:1300

--- a/po/nl.po
+++ b/po/nl.po
@@ -535,7 +535,7 @@ msgstr "Audio"
 
 #: src/ui/details.ui:1299
 #, fuzzy
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Verminder latentie PulseAudio"
 
 #: src/ui/details.ui:1300

--- a/po/pl.po
+++ b/po/pl.po
@@ -484,7 +484,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/pt.po
+++ b/po/pt.po
@@ -498,7 +498,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -515,7 +515,7 @@ msgid "Audio"
 msgstr "Áudio"
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Reduza a latência do PulseAudio"
 
 #: src/ui/details.ui:1300

--- a/po/ru.po
+++ b/po/ru.po
@@ -479,7 +479,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/sk.po
+++ b/po/sk.po
@@ -479,7 +479,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/sl.po
+++ b/po/sl.po
@@ -479,7 +479,7 @@ msgid "Audio"
 msgstr ""
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr ""
 
 #: src/ui/details.ui:1300

--- a/po/sv.po
+++ b/po/sv.po
@@ -502,7 +502,7 @@ msgid "Audio"
 msgstr "Ljud"
 
 #: src/ui/details.ui:1299
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "Reducera PulseAudio-latens"
 
 #: src/ui/details.ui:1300

--- a/po/tr.po
+++ b/po/tr.po
@@ -533,7 +533,7 @@ msgstr "Ses"
 
 #: src/ui/details.ui:1299
 #, fuzzy
-msgid "Reduce PluseAudio latency"
+msgid "Reduce PulseAudio latency"
 msgstr "PulseAudio gecikmesini azalt"
 
 #: src/ui/details.ui:1300

--- a/src/ui/details.ui
+++ b/src/ui/details.ui
@@ -1296,7 +1296,7 @@ Disable if you're experiencing graphical glitches.</property>
                           <object class="HdyActionRow">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="title" translatable="yes">Reduce PluseAudio latency</property>
+                            <property name="title" translatable="yes">Reduce PulseAudio latency</property>
                             <property name="subtitle" translatable="yes">Set PulseAudio latency to 60 milliseconds to increase sound quality</property>
                             <child>
                               <object class="GtkBox">


### PR DESCRIPTION
# Description
Fixed a typo in the UI strings (PluseAudio -> PulseAudio). Probably will need replacing that string in Weblate before the next automatic translation PR comes in.

Fixes #(issue)
Typo in the Preferences menu

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)