### PR TITLE
Add a return value to do_command_line function

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -167,6 +167,8 @@ class Bottles(Gtk.Application):
 
         self.do_activate()
 
+        return 0
+
     def do_startup(self):
         '''
         This function is called when the application is started.


### PR DESCRIPTION
# Description
Hello everyone. The code change is tiny but it took me some hours on `pdb` and search engines to find the solution.

Reference documentation:

- https://pygobject.readthedocs.io/en/latest/guide/api/signals.html - with the signals currently available for the Python library. This includes `command-line` and `handle-local-options`.

- https://gitlab.gnome.org/GNOME/pygobject/-/blob/master/tests/test_gio.py - to check some examples of `do_command_line`. I couldn't find the error string in the source code, though.

- https://docs.python.org/3/library/pdb.html#debugger-commands - the `pdb` manual because it helped.

- https://python-gtk-3-tutorial.readthedocs.io/en/latest/application.html#example - more `do_command_line` examples.

- https://wiki.gnome.org/HowDoI/GtkApplication - `GtkApplication` documentation, check section "Dealing with the command line", which links to:

- https://wiki.gnome.org/HowDoI/GtkApplication/CommandLine - More documentation about command line arguments.

After reading all that and more pages (when I was at the wrong track), my understanding is that we need to add a return value to the `do_command_line` function.

Fixes #469

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I tested this change by building the Flatpak with the manifest from this repository (`com.usebottles.bottles.dev.json`) and running a bottled application that was already installed.

## Test 1
1. Build the Flatpak.
2. Run with `flatpak run --branch=master com.usebottles.bottles`.
3. Check that the issue happens: yes, the error line appeared.

## Test 2
1. Set `-1` as the return value for the `do_command_line` function.
2. Build the Flatpak.
3. Run with `flatpak run --branch=master com.usebottles.bottles`.
4. Confirm that the issue doesn't happen: the error line didn't appear anymore.
5. Run with `flatpak run --branch=master com.usebottles.bottles -b <bottlename> -e <path-to-exe>`.
6. Confirm that the issue doesn't happen: the error line didn't appear.

## Test 3
1. Set `0` as the return value for the `do_command_line` function.
2. Build the Flatpak.
3. Run with `flatpak run --branch=master com.usebottles.bottles`.
4. Confirm that the issue doesn't happen: the error line didn't appear.
5. Run with `flatpak run --branch=master com.usebottles.bottles -b <bottlename> -e <path-to-exe>`.
6. Confirm that the issue doesn't happen: the error line didn't appear.

I couldn't clearly understand the reason for using `-1` (as per GTK docs), so I chose to use `0` as the return value.