### PR TITLE
Added libffi8ubuntu1 and libhandy-1-0 with libraries included

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -82,6 +82,8 @@ AppDir:
     - libglib2.0-0
     - libglib2.0-bin
     - libgee-0.8-2
+    - libffi8ubuntu1
+    - libhandy-1-0
     - python3-gi-cairo
     - python3-certifi
     - python3-yaml
@@ -110,7 +112,9 @@ AppDir:
      rm -rf $APPDIR/usr/share/man
 
   files:
-    include: []
+    include:
+      - AppDir/usr/lib/x86_64-linux-gnu/libffi.so.8
+      - AppDir/usr/lib/x86_64-linux-gnu/libhandy-1.so.0
 
     exclude:
       - AppDir/usr/lib/x86_64-linux-gnu/gconv


### PR DESCRIPTION
# Description
Fix the AppImage being unable to run on Ubuntu 20.04 LTS by including the missing libraries libffi8 and libhandy in the AppImage Builder, since the AppImage should be portable enough to still run on Ubuntu 20.04 LTS. 

Fixes #(issue)
#756 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] Confirmed that it no longer errors out for the missing libffi and libhandy libraries on Ubuntu 20.04 LTS and does run now.
