### PR TITLE
Fix getting the first Vulkan ICD gpu vendor 

### DIFF
--- a/src/backend/runner.py
+++ b/src/backend/runner.py
@@ -485,7 +485,7 @@ class Runner:
                 System doesn't support PRIME, so using the first result
                 from the gpu vendors list.
                 '''
-                _first = gpu["vendors"].keys()[0]
+                _first = list(gpu["vendors"].keys())[0]
                 env["VK_ICD_FILENAMES"] = gpu["vendors"][_first]["icd"]
                 
 


### PR DESCRIPTION
# Description
After a292d5a692bf69623e47150b086c9df2bf264e07, getting the first gpu vendor was failing with the following stack trace:

```
(19:44:55) INFO Using Xwayland.. 
(19:44:55) ERROR Error while running async job: <function Runner.run_command at 0x7fbf787a4280>
Exception: 'dict_keys' object is not subscriptable 
  File "/app/share/bottles/bottles/utils.py", line 337, in __target
    result = self.task_func(*args, **kwargs)
  File "/app/share/bottles/bottles/backend/runner.py", line 488, in run_command
    _first = gpu["vendors"].keys()[0]
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- After the change, the error does not occur anymore and applications start as expected.

