### PR TITLE
Fix a typo in a registry key.

### DIFF
--- a/src/backend/runner.py
+++ b/src/backend/runner.py
@@ -93,7 +93,7 @@ class Runner:
             "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\ServiceCurrent": "OS",
             "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Windows": "CSDVersion",
             "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\ProductOptions": "ProductType",
-            "HKEY_CURRENT_USER\\Softwarw\\Wine": "Version"
+            "HKEY_CURRENT_USER\\Software\\Wine": "Version"
         }
         for d in del_keys:
             reg.remove(d, del_keys[d])


### PR DESCRIPTION
# Description
Fixes a typo in one of the registry keys provided in `runner.py` 


Fixes no issues that i know of.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
This has no behaviour changes, so it doesn't need testing, as it only affects borderline cases.
