### PR TITLE
Add missing return in __get_cwd method

### DIFF
--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -108,6 +108,8 @@ class WineCommand:
             '''
             cwd = bottle
 
+        return cwd
+
     def __get_env(self, environment) -> dict:
         env = WineEnv()
         config = self.config


### PR DESCRIPTION
# Description
Added missing return in `WineCommand.__get_cwd` method.
Some apps crash when process CWD is not set to exe directory on process launch.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update