### PR TITLE
[Fix] GTK Namespace

### DIFF
--- a/src/dialogs/generic.py
+++ b/src/dialogs/generic.py
@@ -15,6 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import gi
+
+gi.require_version('GtkSource', '4')
+
 from gi.repository import Gtk, GtkSource, Gdk, Handy, Pango, WebKit2
 
 


### PR DESCRIPTION
# Description
Fixed error `gi.RepositoryError: Requiring namespace 'Gtk' version '4.0', but '3.0' is already loaded` with [this package](https://archlinux.org/packages/extra/x86_64/gtksourceview4/)

Fixes https://aur.archlinux.org/packages/bottles/#comment-850104

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] I started bottles and it immediately crashed
- [ ] I've installed gtksourceview4
- [ ] I've updated src/dialogs/generic.py
- [ ] Bottles started without crashing