### PR TITLE
Fix `DLLComponent` installation for 32 bit prefixes

### DIFF
--- a/src/backend/dlls/dll.py
+++ b/src/backend/dlls/dll.py
@@ -90,7 +90,13 @@ class DLLComponent():
         bottle = ManagerUtils.get_bottle_path(config)
         bottle = f"{bottle}/drive_c/windows/"
         source = f"{self.base_path}/{path}/{dll}"
-        target = f"{bottle}/{self.__get_sys_path(config, path)}/{dll_name}"
+
+        path = self.__get_sys_path(config, path)
+        if path is not None:
+            target = f"{bottle}/{path}/{dll_name}"
+        else
+            target = None
+
         #print(f"{source} -> {target}")
         
         if target is not None:


### PR DESCRIPTION
# Description

<details>
<summary>Bottles throws an exception when trying to enable DXVK for 32 bit prefixes with the following error log:</summary>

```
(18:11:56) INFO Setting Key: [dxvk] to [True] for bottle: [x32]… 
(18:11:56) INFO Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [d3d9] and Data: [native,builtin] in x32 registry 
(18:11:57) INFO Using WINE Registry CLI 
(18:11:57) INFO reg: The operation completed successfully
	
 
(18:11:57) INFO Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [d3d10] and Data: [native,builtin] in x32 registry 
(18:11:58) INFO Using WINE debug tool 
(18:11:58) INFO Using WINE Registry CLI 
(18:11:58) INFO reg: The operation completed successfully
	
 
(18:11:58) INFO Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [d3d10_1] and Data: [native,builtin] in x32 registry 
(18:11:59) INFO Using WINE debug tool 
(18:11:59) INFO Using WINE Registry CLI 
(18:11:59) INFO reg: The operation completed successfully
	
 
(18:11:59) INFO Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [d3d10core] and Data: [native,builtin] in x32 registry 
(18:11:59) INFO Using WINE debug tool 
(18:12:00) INFO Using WINE Registry CLI 
(18:12:00) INFO reg: The operation completed successfully
	
 
(18:12:00) INFO Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [d3d11] and Data: [native,builtin] in x32 registry 
(18:12:00) INFO Using WINE debug tool 
(18:12:00) INFO Using WINE Registry CLI 
(18:12:00) INFO reg: The operation completed successfully
	
 
(18:12:00) INFO Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [dxgi] and Data: [native,builtin] in x32 registry 
(18:12:01) INFO Using WINE debug tool 
(18:12:01) INFO Using WINE Registry CLI 
(18:12:01) INFO reg: The operation completed successfully
	
 
(18:12:01) ERROR Error while running async job: <bound method Manager.install_dll_component of <bottles.backend.managers.manager.Manager object at 0x7f371f4e51b0>>
	Exception: [Errno 2] No such file or directory: '/home/ffuugoo/.local/share/bottles/bottles/x32/drive_c/windows//None/d3d9.dll'
 
  File "/usr/share/bottles/bottles/utils.py", line 103, in __target
    result = self.task_func(*args, **kwargs)
  File "/usr/share/bottles/bottles/backend/managers/manager.py", line 1355, in install_dll_component
    manager.install(config, overrides_only, exclude)
  File "/usr/share/bottles/bottles/backend/dlls/dll.py", line 65, in install
    self.__install_dll(config, path, dll, False, overrides_only)
  File "/usr/share/bottles/bottles/backend/dlls/dll.py", line 98, in __install_dll
    shutil.copyfile(source, target)
  File "/usr/lib64/python3.10/shutil.py", line 256, in copyfile
    with open(dst, 'wb') as fdst:

```

</details>

__This is a non-fatal error, it does not cause bottles to crash and DXVK is correctly installed even with the exception...__

...but the error message is misleading, and it causes bottles to show an annoying "report-a-bug" window on next start.

As far as I can tell, it happens cause:

- [`DXVKComponent` has `dlls` dict defined with two keys (`x32` and `x64`) where each key is a list of DLLs][dxvk-component-dlls]
- [`DLLComponent::install` iterates through all "key-subvalue" pairs (e.g., `x32`/`d3d9.dll`, `x32`/`d3d10.dll`, etc) and calls `DLLComponent::__install_dll` for each one of them][dll-component-install]
- [`DLLComponent::__install_dll` calls `DLLComponent::__get_sys_path`][dll-component-install-dll]
- [which returns `None` if the prefix is 32 bit and `path` argument is `x64`][dll-component-get-sys-path]
- which causes `None` to be formatted into DLL's `target` path and ultimately causes an exception

The PR is mostly to illustrate the issue.

[dxvk-component-dlls]: https://github.com/bottlesdevs/Bottles/blob/288d7bf91510cddc3308e96574bd6d139ead2df1/src/backend/dlls/dxvk.py#L23
[dll-component-install]: https://github.com/bottlesdevs/Bottles/blob/0ac293d91b16fdbce53c412cf274e21dd59341c8/src/backend/dlls/dll.py#L65
[dll-component-install-dll]: https://github.com/bottlesdevs/Bottles/blob/0ac293d91b16fdbce53c412cf274e21dd59341c8/src/backend/dlls/dll.py#L93
[dll-component-get-sys-path]: https://github.com/bottlesdevs/Bottles/blob/0ac293d91b16fdbce53c412cf274e21dd59341c8/src/backend/dlls/dll.py#L78

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually: 
- edit `/usr/share/bottles/bottles/backend/dlls/dll.py` on my machine
- restart bottles (from the console to see bottles' logs)
- create 32 bit prefix and enable DXVK in it
