### PR TITLE
add samba, rpcsvc-proto, parse-yapp  dependencies to flatpak

### DIFF
--- a/com.usebottles.bottles.dev.json
+++ b/com.usebottles.bottles.dev.json
@@ -752,6 +752,72 @@
       ]
     },
     {
+      "name": "rpcsvc-proto",
+      "buildsystem": "autotools",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/thkukuk/rpcsvc-proto/archive/v1.4.3.tar.gz",
+          "sha256": "6906e0f81bb016bd0216460fc879d3d9f2f6d743be7dfb0d8b32d140226d5ef8"
+        }
+      ]
+    },
+    {
+      "name": "parse-yapp",
+      "buildsystem": "simple",
+      "build-commands": [
+        "perl Makefile.PL",
+        "make install"
+      ],
+      "build-options": {
+        "env": {
+          "PERL5LIB": "/app/lib/perl5/",
+          "PERL_MM_OPT": "INSTALL_BASE=/app"
+        }
+      },
+      "cleanup": [
+        "*"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz",
+          "sha256": "3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5"
+        }
+      ]
+    },
+    {
+      "name": "samba",
+      "buildsystem": "autotools",
+      "config-opts": [
+        "--prefix=/app",
+        "--sbindir=/app/bin",
+        "--libdir=/app/lib",
+        "--enable-fhs",
+        "--disable-python",
+        "--without-json",
+        "--without-ad-dc",
+        "--without-ads",
+        "--without-pam",
+        "--without-ldap",
+        "--without-acl-support",
+        "--without-systemd"
+      ],
+      "build-options": {
+        "env": {
+          "PERL5LIB": "/app/lib/perl5/",
+          "PERL_MM_OPT": "INSTALL_BASE=/app"
+        }
+      },
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.samba.org/pub/samba/samba-4.15.5.tar.gz",
+          "sha256": "69115e33831937ba5151be0247943147765aece658ba743f44741672ad68d17f"
+        }
+      ]
+    },
+    {
       "name": "EasyTerm",
       "buildsystem": "simple",
       "build-commands": [

--- a/com.usebottles.bottles.dev.yml
+++ b/com.usebottles.bottles.dev.yml
@@ -425,6 +425,53 @@ modules:
     config-opts: *faudio_opts
     sources: *faudio_sources
 
+  - name: rpcsvc-proto
+    buildsystem: autotools
+    sources:
+    - type: archive
+      url: https://github.com/thkukuk/rpcsvc-proto/archive/v1.4.3.tar.gz
+      sha256: 6906e0f81bb016bd0216460fc879d3d9f2f6d743be7dfb0d8b32d140226d5ef8
+
+  - name: parse-yapp
+    buildsystem: simple
+    build-commands:
+    - perl Makefile.PL
+    - make install
+    build-options:
+      env:
+        PERL5LIB: "/app/lib/perl5/"
+        PERL_MM_OPT: INSTALL_BASE=/app
+    cleanup:
+    - "*"
+    sources:
+    - type: archive
+      url: https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz
+      sha256: 3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5
+
+  - name: samba
+    buildsystem: autotools
+    config-opts:
+    - --prefix=/app
+    - --sbindir=/app/bin
+    - --libdir=/app/lib
+    - --enable-fhs
+    - --disable-python
+    - --without-json
+    - --without-ad-dc
+    - --without-ads
+    - --without-pam
+    - --without-ldap
+    - --without-acl-support
+    - --without-systemd
+    build-options:
+      env:
+        PERL5LIB: "/app/lib/perl5/"
+        PERL_MM_OPT: INSTALL_BASE=/app
+    sources:
+      - type: archive
+        url: https://download.samba.org/pub/samba/samba-4.15.5.tar.gz
+        sha256: 69115e33831937ba5151be0247943147765aece658ba743f44741672ad68d17f
+
   # Bottles components
   # ----------------------------------------------------------------------------
   - name: EasyTerm


### PR DESCRIPTION
Bundle samba and its dependencies (rpcsv-proto and parse-yapp) with flatpak.
A lot of the tools that the Samba suite provides, such as winbind, ntlm_auth, etc. are needed when running certain applications.

# Description
Fixes #1001
[ntlm_auth](https://www.samba.org/samba/docs/current/man-html/ntlm_auth.1.html) is part of the [samba](https://www.samba.org/samba/docs/current/man-html/samba.7.html) suite. This PR bundles samba and its required dependencies with flatpak.  Resources I used that helped me with bundling Samba:

- [Samba Wiki](https://wiki.samba.org/index.php/Build_Samba_from_Source)
- [gnome control center](https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/master/build-aux/flatpak/org.gnome.Settings.json)
- [Dolphin](https://github.com/flathub/org.kde.dolphin/blob/master/org.kde.dolphin.json)
- [Kodi](https://github.com/flathub/tv.kodi.Kodi/blob/master/modules/samba/samba.json)
- [Nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-21.11/pkgs/servers/samba/4.x.nix)

I have tried to disable features that seemed unnecessary, but still, bundling samba increases the build time noticeably.
Samba provides a ton of build options, maybe more features can be disabled.

I wasn't sure about the 32-bit stuff so I haven't added any 32-bit modules.

Samba creates a directory called  `var`  to store its local state. The build help describes an option concerning this directory:
```
    --localstatedir=LOCALSTATEDIR
            variable data [PREFIX/var]
```
Maybe this directory can be added to the cleanup targets. (the above sources don't seem to care about it)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Compiled and ran the flatpak version of Bottles with no errors (Linux x86_64). 
- [x] Did not come across the issues regarding ntlm_auth.
