### PR TITLE
Use GNotification instead of libnotify

### DIFF
--- a/com.usebottles.bottles.dev.json
+++ b/com.usebottles.bottles.dev.json
@@ -14,7 +14,6 @@
     "--socket=pulseaudio",
     "--device=all",
     "--system-talk-name=org.freedesktop.UDisks2",
-    "--talk-name=org.freedesktop.Notifications",
     "--env=LD_LIBRARY_PATH=/app/lib:/app/lib32",
     "--env=PATH=/app/bin:/app/utils/bin:/usr/bin",
     "--require-version=1.1.2"

--- a/data/com.usebottles.bottles.desktop.in
+++ b/data/com.usebottles.bottles.desktop.in
@@ -10,3 +10,4 @@ StartupNotify=true
 StartupWMClass=bottles
 MimeType=application/x-ms-dos-executable;application/x-msi;application/x-ms-shortcut;application/x-wine-extension-msp;
 Keywords=wine;windows;
+X-GNOME-UsesNotifications=true

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,14 +34,12 @@ parts:
       - gsettings-desktop-schemas-dev
       - python3-pytoml
       - python3-requests
-      - libnotify-dev
       - libgtk-3-dev
     stage-packages:
       - python3-gi
       - python3-gi-cairo
       - python3-markdown
       - gir1.2-gtk-3.0
-      - libnotify4
       - gamemode
       - libgamemode0
       - winbind

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,6 @@ import subprocess
 from os import path
 gi.require_version('Gtk', '3.0')
 gi.require_version('Handy', '1')
-gi.require_version('Notify', '0.7')
 gi.require_version('WebKit2', '4.0')
 from gi.repository import Gtk, Gio, Gdk, GLib, GObject
 

--- a/src/window.py
+++ b/src/window.py
@@ -19,7 +19,7 @@ import os
 import time
 import webbrowser
 from gettext import gettext as _
-from gi.repository import Gtk, Gio, Notify, Handy
+from gi.repository import Gtk, Gio, Handy
 from pathlib import Path
 
 from bottles.params import * # pyright: reportMissingImports=false
@@ -78,9 +78,6 @@ class MainWindow(Handy.ApplicationWindow):
     default_settings = Gtk.Settings.get_default()
     settings = Gio.Settings.new(APP_ID)
     argument_executed = False
-
-    # Notify instance
-    Notify.init(APP_ID)
 
     def __init__(self, arg_exe, arg_bottle, arg_passed, **kwargs):
         super().__init__(**kwargs)
@@ -237,13 +234,18 @@ class MainWindow(Handy.ApplicationWindow):
     def send_notification(self, title, text, image="", ignore_user=True):
         '''
         This method is used to send a notification to the user using
-        the Notify instance. The notification is sent only if the
+        Gio.Notification. The notification is sent only if the
         user has enabled it in the settings. It is possibile to ignore the
         user settings by passing the argument ignore_user=False.
         '''
         if ignore_user or self.settings.get_boolean("notifications"):
-            notification = Notify.Notification.new(title, text, image)
-            notification.show()
+            notification = Gio.Notification.new(title)
+            notification.set_body(text)
+            if image:
+                icon = Gio.ThemedIcon.new(image)
+                notification.set_icon(icon)
+
+            self.props.application.send_notification(None, notification)
 
     def set_previous_page_status(self):
         '''


### PR DESCRIPTION
This is more sandbox friendly and does not require and extra library.

We also add X-GNOME-UsesNotifications=true so that GNOME Software and
similar can pick this piece of metainfo.

Ill test in a bit.