### PR TITLE
Add foot as a terminal option

### DIFF
--- a/src/backend/utils/terminal.py
+++ b/src/backend/utils/terminal.py
@@ -37,6 +37,7 @@ class TerminalUtils:
 
     terminals = [
         ['easyterm.py', '-d -p "%s" -c %s'],
+        ['foot', '%s'],
         ['kitty', '%s'],
         ['xterm', '-e %s'],
         ['konsole', '-e --noclose %s'],
@@ -84,7 +85,7 @@ class TerminalUtils:
                 command = ' '.join(self.terminal) % (colors, f"bash")
         elif self.terminal[0] == 'xfce4-terminal':
             command = ' '.join(self.terminal) % "'sh -c %s'" % f'"{command}"'
-        elif self.terminal[0] == 'kitty':
+        elif self.terminal[0] in ['kitty', 'foot']:
             command = ' '.join(self.terminal) % "sh -c %s" % f'"{command}"'
         else:
             command = ' '.join(self.terminal) % f"'bash -c {command}'"


### PR DESCRIPTION
# Description
Add foot as a terminal option 
Fixes #1110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Pressing "Command line" now opens a foot terminal if foot is present.
