### PR TITLE
Temporary fix for #1104

### DIFF
--- a/src/backend/wine/executor.py
+++ b/src/backend/wine/executor.py
@@ -92,6 +92,23 @@ class WineExecutor:
         logging.error(f"Unsupported executable type: {exec_path}", )
         return False
     
+    def run_cli(self):
+        #We need to launch the application and then exit
+        #so we use WINE Starter, which will exit as soon
+        #as the program is launched
+        start = Start(self.config)
+        res = start.run(
+            file=self.exec_path,
+            terminal=self.terminal,
+            args=self.args,
+            environment=self.environment,
+            cwd=self.cwd
+        )
+        return Result(
+            status=True,
+            data={"output": res}
+        )
+
     def run(self):
         if self.exec_type in ["exe", "msi"]:
             return self.__launch_with_bridge()

--- a/src/window.py
+++ b/src/window.py
@@ -108,7 +108,7 @@ class MainWindow(Handy.ApplicationWindow):
                     exec_path=arg_exe,
                     args=arg_passed
                 )
-                RunAsync(executor.run)
+                executor.run_cli()
                 self.proper_close()
 
         # Pages
@@ -369,10 +369,8 @@ class MainWindow(Handy.ApplicationWindow):
     @staticmethod
     def proper_close():
         '''
-        Properly close Bottles, giving 1s to the wine process to spawn the 
-        window if an executable is passed as argument
+	Properly close Bottles
         '''
-        time.sleep(1)
         quit()
 
     @staticmethod


### PR DESCRIPTION
# Description
Fixes a race condition as described in #1104 by forcing programs launched using the CLI `-e` and `-b` parameters to run using WINE Start instead of being launched asynchronously. The WINE Start subprocess returns once the application is launched, so we can simply wait for it.

Fixes #1104

## Type of change
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Used CLI to run applications in an environment where WINE could not launch the process fast enough to avoid being terminated before the application was ready
- [x] Verified that msi, exe, and lnk targets all function with this method
