### PR TITLE
Destroy AboutDialog on clicking the Close button

### DIFF
--- a/src/dialogs/generic.py
+++ b/src/dialogs/generic.py
@@ -297,3 +297,7 @@ class AboutDialog(Gtk.AboutDialog):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+    def do_response(self, response_id):
+        if (response_id == Gtk.ResponseType.DELETE_EVENT):
+            self.destroy()

--- a/src/window.py
+++ b/src/window.py
@@ -375,7 +375,7 @@ class MainWindow(Handy.ApplicationWindow):
 
     @staticmethod
     def show_about_dialog(widget):
-        AboutDialog().show_all()
+        AboutDialog().run()
 
     @staticmethod
     def open_url(widget, url):


### PR DESCRIPTION
# Description
Fixes the "Close" button of AboutDialog doesn't close the dialog. This also hides the "License" button which does nothing too (widgets in GTK+3 are invisible by default, and using `Gtk.Dialog.run()` instead of `show_all()` results this).

### Before
![Screenshot from 2022-03-09 14-45-26](https://user-images.githubusercontent.com/26003928/157380557-44060934-ae4f-47f3-a6fe-5f8ec626e988.png)

### After
![Screenshot from 2022-03-09 14-44-20](https://user-images.githubusercontent.com/26003928/157380561-db711686-7fa0-428d-b050-87e2232186a4.png)

This PR was created by referring this page: https://stackoverflow.com/questions/577354/glade-aboutdialog-doesnt-close.

I'm sorry if something wrong because this is the first time I write code in PyGTK and I'm not sure anything about that (though I'm a little familiar with GTK in Vala).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Build and install this branch using flatpak-builder, run the app, and open AboutDialog.
- [ ] Next, click the "Close" button. On `master` branch, anything happens. On this branch, the dialog closes as expected.