### PR TITLE
Update Code Of Conduct using common standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+Welcome to the Bottles community
+
+## Our Pledge
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+* Respecting privacy
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Finding yourselves unable, e-mail send@mirko.pm answered by Mirko Brombin, the project maintainer. 
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,8 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-Finding yourselves unable, e-mail send@mirko.pm answered by Mirko Brombin, the project maintainer. 
+## Contact
+In case you feel unconfortable with an occurred situation, e-mail send@mirko.pm answered by Mirko Brombin, the project maintainer.
 
 ## Attribution
 

--- a/CONTACT.md
+++ b/CONTACT.md
@@ -1,5 +1,0 @@
-Welcome to the Bottles community
-
-Grant and indulge critique constructively, within desired privacy.
-Settle disputes within these confines.
-Finding yourselves unable, e-mail send@mirko.pm answered by Mirko Brombin, the project maintainer. 


### PR DESCRIPTION
The Code Of Conduct called CONTACT.md was too generic and can't be considered a Code Of Conduct.
