### PR TITLE
Improve version sorting

### DIFF
--- a/src/backend/utils/generic.py
+++ b/src/backend/utils/generic.py
@@ -18,8 +18,6 @@
 import re
 import sys
 
-from datetime import datetime
-
 
 def validate_url(url: str):
     """Validate a URL."""
@@ -97,7 +95,8 @@ def is_glibc_min_available():
         if version >= '2.32':
             return version
     except:
-        return False
+        pass
+    return False
 
 
 def sort_by_version(_list: list, extra_check: str = "async"):

--- a/src/backend/utils/generic.py
+++ b/src/backend/utils/generic.py
@@ -100,12 +100,11 @@ def is_glibc_min_available():
         return False
 
 
-def sort_by_version(_list: list):
-    def atoi(text):
-        return int(text) if text.isdigit() else text
-
+def sort_by_version(_list: list, extra_check: str = "async"):
     def natural_keys(text):
-        return [ atoi(c) for c in re.split('(\d+)',text) ]
+        result = [int(re.search(extra_check, text) is None)]
+        result.extend([int(c) for c in re.findall(r'\d+', text)])
+        return result
 
     _list.sort(key=natural_keys, reverse=True)
     return _list


### PR DESCRIPTION
# Description
Improve version sorting in generic and add sorting via pattern.
Fix small typos:
For line 100 because there are nothing return when version < '2.32'

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
<details>
<summary>Test A</summary>

```python
from generic import sort_by_version

assert sort_by_version(
    ["dxvk-1.9.2", "dxvk-1.9.4", "dxvk-1.9.1", "dxvk-async-1.9.4", "dxvk-1.10"]
) == ['dxvk-1.10', 'dxvk-1.9.4', 'dxvk-1.9.2', 'dxvk-1.9.1', 'dxvk-async-1.9.4']
```
</details>

- [x] Test A
