### PR TITLE
style: change deb naming for v1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-com.github.mirkobrombin.bottles (0.2.6) precise; urgency=low
+com.usebottles.bottles (0.2.6) precise; urgency=low
 
   * Fix for elementary hera
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: com.github.mirkobrombin.bottles
+Source: com.usebottles.bottles
 Section: utils
 Priority: optional
 Maintainer: Mirko Brombin <send@mirko.pm>
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 10),
 X-Python3-Version: >= 3.6.9
 Standards-Version: 3.9.3
 
-Package: com.github.mirkobrombin.bottles
+Package: com.usebottles.bottles
 Architecture: any
 Depends: ${python3:Depends},
          ${misc:Depends},


### PR DESCRIPTION
# Description
Using the longer deb name doesn't work out well in some ways and plus the name for bottles on the master branch is com.usebottles.bottles anyway which works out much better for Debian packaging.

Fixes #(issue)
Fixes installing on Debian in some ways.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update