### PR TITLE
 Adding more logging to download process plus some code cleanups

### DIFF
--- a/src/backend/managers/component.py
+++ b/src/backend/managers/component.py
@@ -127,8 +127,8 @@ class ComponentManager:
             self,
             download_url: str,
             file: str,
-            rename: bool = False,
-            checksum: bool = False,
+            rename: str = "",
+            checksum: str = "",
             func=False
     ) -> bool:
         """Download a component from the Bottles repository."""

--- a/src/backend/managers/component.py
+++ b/src/backend/managers/component.py
@@ -198,6 +198,7 @@ class ComponentManager:
                 download_url = response.url
                 req_code = response.status_code
             except requests.exceptions.RequestException:
+                logging.exception(f"Failed to download [{download_url}]")
                 GLib.idle_add(self.__operation_manager.remove_task, task_id)
                 return False
 
@@ -224,6 +225,7 @@ class ComponentManager:
 
                 just_downloaded = True
             else:
+                logging.warning(f"Failed to download [{download_url}] with code: {req_code} != 200")
                 GLib.idle_add(self.__operation_manager.remove_task, task_id)
                 return False
 

--- a/src/backend/managers/component.py
+++ b/src/backend/managers/component.py
@@ -227,13 +227,12 @@ class ComponentManager:
                 GLib.idle_add(self.__operation_manager.remove_task, task_id)
                 return False
 
+        file_path = f"{Paths.temp}/{existing_file}"
         if rename and just_downloaded:
             """Renaming the downloaded file if requested."""
             logging.info(f"Renaming [{file}] to [{rename}].", )
             file_path = f"{Paths.temp}/{rename}"
             os.rename(f"{Paths.temp}/{file}", file_path)
-        else:
-            file_path = f"{Paths.temp}/{existing_file}"
 
         if checksum:
             """

--- a/src/backend/managers/component.py
+++ b/src/backend/managers/component.py
@@ -245,7 +245,7 @@ class ComponentManager:
             checksum = checksum.lower()
             local_checksum = FileUtils().get_checksum(file_path)
 
-            if local_checksum != checksum:
+            if local_checksum and local_checksum != checksum:
                 logging.error(f"Downloaded file [{file}] looks corrupted.", )
                 logging.error(f"Source cksum: [{checksum}] downloaded: [{local_checksum}]", )
                 logging.info(f"Removing corrupted file [{file}].", )

--- a/src/backend/utils/file.py
+++ b/src/backend/utils/file.py
@@ -43,7 +43,7 @@ class FileUtils:
                     checksum.update(chunk)
             return checksum.hexdigest().lower()
         except FileNotFoundError:
-            return False
+            return None
 
     @staticmethod
     def use_insensitive_ext(string):


### PR DESCRIPTION
# Description
This contributes to my problem of not being able to download any files - winebridge, runners, dxvk, etc.
For details on why stuff has been made, check out the commit messages!

Helps to debug: #1220

## Type of change
- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (Eventually yes... Needs testing!)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Not all at the moment. Need instructions on how to run Bottles from source.
- [ ] Running from source
- [ ] Running from Flathub (beta)
