### PR TITLE
Fix/appimage package

### DIFF
--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           mv Bottles-*-x86_64.AppImage Bottles-devel-x86_64.AppImage
           mv Bottles-*-x86_64.AppImage.zsync Bottles-devel-x86_64.AppImage.zsync
-          mv ../com.usebottles.bottles*.deb com.usebottles.bottles-unstable.deb
+          # mv ../com.usebottles.bottles*.deb com.usebottles.bottles-unstable.deb
 
       - name: Upload AppImage to Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -22,21 +22,21 @@ jobs:
 
       # AppImage Build
       # --------------------------------------
-      #- name: Install appimagetool
-      #  run: |
-      #     sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
-      #     sudo chmod +x /usr/local/bin/appimagetool
+      - name: Install appimagetool
+        run: |
+           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+           sudo chmod +x /usr/local/bin/appimagetool
 
-      #- name: Setup Python
-      #  uses: actions/setup-python@v2
-      #  with:
-      #    python-version: 3.9
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
 
-      #- name: Install appimage-builder tool
-      #  run: yes | sudo pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git
+      - name: Install appimage-builder tool
+        run: yes | sudo pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git
 
-      #- name: Build AppImage
-      #  run: appimage-builder --recipe AppImageBuilder.yml --skip-test
+      - name: Build AppImage
+        run: appimage-builder --recipe AppImageBuilder.yml --skip-test
 
       # Deb Build
       # --------------------------------------
@@ -54,29 +54,32 @@ jobs:
 
       # Rename and release packages
       # --------------------------------------
-      #- name: Rename packages
-      #  run: |
-      #    mv Bottles-*-x86_64.AppImage Bottles-devel-x86_64.AppImage
-      #    mv Bottles-*-x86_64.AppImage.zsync Bottles-devel-x86_64.AppImage.zsync
-      #    mv ../com.usebottles.bottles*.deb com.usebottles.bottles-unstable.deb
+      - name: Rename packages
+        run: |
+          mv Bottles-*-x86_64.AppImage Bottles-devel-x86_64.AppImage
+          mv Bottles-*-x86_64.AppImage.zsync Bottles-devel-x86_64.AppImage.zsync
+          mv ../com.usebottles.bottles*.deb com.usebottles.bottles-unstable.deb
 
-      #- name: Upload AppImage to Artifacts
-      #  uses: actions/upload-artifact@v2
-      #  with:
-      #    name: Unstable Build - Appimage
-      #    path: Bottles-devel-x86_64.AppImage
+      - name: Upload AppImage to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unstable Build - Appimage
+          path: Bottles-devel-x86_64.AppImage
+          
       # - name: Upload Debian Package to Artifacts
       #   uses: actions/upload-artifact@v2
       #   with:
       #     name: Unstable Build - Debian Package
       #     path: com.usebottles.bottles-unstable.deb
+      
       - name: Upload Flatpak to Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Unstable Build - Flatpak
           path: com.usebottles.bottles-unstable.flatpak
-      #- name: Upload zsync to Artifacts
-      #  uses: actions/upload-artifact@v2
-      #  with:
-      #    name: Unstable Build - Zsync
-      #    path: Bottles-devel-x86_64.AppImage.zsync
+          
+      - name: Upload zsync to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unstable Build - Zsync
+          path: Bottles-devel-x86_64.AppImage.zsync

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -5,11 +5,12 @@ script:
   - rm -rf build  | true
   # Building with meson and ninja
   - mkdir build
-  - meson build --prefix=/usr/bin/
+  - meson build --prefix=/usr
   - cd build
   - ninja
-  - ninja bottles-pot
-  - ninja bottles-update-po
+  - DESTDIR=$APPDIR ninja install
+  # - ninja bottles-pot
+  # - ninja bottles-update-po
   - cd ..
   # Preparing directories
   - mkdir -p AppDir/usr AppDir/usr/local/share/bottles AppDir/usr/bin AppDir/usr/share/glib-2.0/schemas AppDir/usr/share/applications AppDir/usr/share/metainfo AppDir/usr/share/icons
@@ -37,7 +38,9 @@ script:
   - glib-compile-schemas AppDir/usr/share/glib-2.0/schemas/
   # Copying appdata
   - cp -a data/com.usebottles.bottles.appdata.xml.in AppDir/usr/share/metainfo/com.usebottles.bottles.appdata.xml
-
+  # Set bash as default shell
+  - mkdir -p $APPDIR/bin
+  - ln -s bash $APPDIR/bin/sh
 
 AppDir:
   path: ./AppDir
@@ -59,6 +62,8 @@ AppDir:
         key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
 
     include:
+    - bash
+    - coreutils
     - gsettings-desktop-schemas
     - dconf-gsettings-backend
     - gsettings-backend
@@ -88,6 +93,7 @@ AppDir:
     - python3-requests
     - python3-markdown
     - gir1.2-gtk-3.0
+    - gir1.2-gtksource-4
     - gir1.2-handy-1
     - gir1.2-notify-0.7
     - ibus-gtk3
@@ -110,7 +116,7 @@ AppDir:
      rm -rf $APPDIR/usr/share/doc
      rm -rf $APPDIR/usr/share/man
      mkdir -p $APPDIR/usr/local/lib/p7zip/ 
-     ln -s $APPDIR/usr/lib/p7zip/ $APPDIR/usr/local/lib/p7zip/ 
+     ln -s $APPDIR/usr/lib/p7zip/ $APPDIR/usr/local/lib/p7zip/
 
   files:
     include:
@@ -129,13 +135,14 @@ AppDir:
     env:
       GDK_BACKEND: x11
       # Set python home
-      LD_LIBRARY_PATH: '${APPDIR}/usr/lib:${LD_LIBRARY_PATH}'
       PYTHONPATH: '${APPDIR}/usr/lib/python3/dist-packages'
       # SSL CERTIFICATE_VERIFY_FAILED python3.8 -m pip install --ignore-installed --prefix=/usr --root=$APPDIR install --upgrade certifi
       #SSL_CERT_DIR: "/etc/ssl/certs:/etc/pki/ca-trust/extracted/pem:/etc/pki/ca-trust/extracted/openssl:/etc/ssl:/etc/pki/tls:/etc/pki:/etc/pki/ca-trust:/usr/local/share/certs:/usr/share/pki/ca-trust-source:/etc/openssl/certs:/var/ssl/certs"
       SSL_CERT_FILE: "$APPDIR/usr/lib/python3/dist-packages/certifi/cacert.pem"
       # if you want to use Adwaita just uncomment bellow
       # GTK_THEME: Adwaita
+    path_mappings:
+      - /usr/share/bottles:$APPDIR/usr/local/share/bottles
 
   test:
     fedora:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -9,8 +9,8 @@ script:
   - cd build
   - ninja
   - DESTDIR=$APPDIR ninja install
-  # - ninja bottles-pot
-  # - ninja bottles-update-po
+  - ninja bottles-pot
+  - ninja bottles-update-po
   - cd ..
   # Preparing directories
   - mkdir -p AppDir/usr AppDir/usr/local/share/bottles AppDir/usr/bin AppDir/usr/share/glib-2.0/schemas AppDir/usr/share/applications AppDir/usr/share/metainfo AppDir/usr/share/icons
@@ -74,6 +74,7 @@ AppDir:
     - libexpat1
     - libgcc-s1
     - libc6
+    - libc6:i386
     - libgpg-error0
     - libpcre3
     - libprocps8
@@ -108,7 +109,7 @@ AppDir:
     - x11-utils
 
     exclude:
-    - adwaita-icon-theme
+    # - adwaita-icon-theme
     - humanity-icon-theme
 
   after_runtime: |
@@ -135,12 +136,13 @@ AppDir:
     env:
       GDK_BACKEND: x11
       # Set python home
-      PYTHONPATH: '${APPDIR}/usr/lib/python3/dist-packages'
+      PYTHONPATH: '$APPDIR/usr/lib/python3/dist-packages'
       # SSL CERTIFICATE_VERIFY_FAILED python3.8 -m pip install --ignore-installed --prefix=/usr --root=$APPDIR install --upgrade certifi
       #SSL_CERT_DIR: "/etc/ssl/certs:/etc/pki/ca-trust/extracted/pem:/etc/pki/ca-trust/extracted/openssl:/etc/ssl:/etc/pki/tls:/etc/pki:/etc/pki/ca-trust:/usr/local/share/certs:/usr/share/pki/ca-trust-source:/etc/openssl/certs:/var/ssl/certs"
       SSL_CERT_FILE: "$APPDIR/usr/lib/python3/dist-packages/certifi/cacert.pem"
       # if you want to use Adwaita just uncomment bellow
       # GTK_THEME: Adwaita
+      APPDIR_MODULE_DIR: $HOME/.local/share/bottles/
     path_mappings:
       - /usr/share/bottles:$APPDIR/usr/local/share/bottles
 

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -133,6 +133,7 @@ AppDir:
       - AppDir/usr/share/doc/*/TODO.*
 
   runtime:
+    arch: [ x86_64, i386 ]
     env:
       GDK_BACKEND: x11
       # Set python home

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN wget https://github.com/AppImage/AppImageKit/releases/download/continuous/ap
 RUN cd /opt && chmod +x appimagetool-x86_64.AppImage && ./appimagetool-x86_64.AppImage --appimage-extract 
 RUN cd /opt && mv squashfs-root appimagetool-x86_64.AppDir && ls && ln -s /opt/appimagetool-x86_64.AppDir/AppRun /usr/bin/appimagetool 
 
-RUN apt install -y git
+RUN DEBIAN_FRONTEND=noninteractive apt install -y  git libhandy-1-dev appstream-util
 
 RUN pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git
-
-RUN DEBIAN_FRONTEND=noninteractive apt install -y libhandy-1-dev
-RUN apt install -y appstream-util

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:jammy
+
+RUN apt update 
+RUN apt install -y debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget
+
+RUN wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/appimagetool-x86_64.AppImage
+RUN cd /opt && chmod +x appimagetool-x86_64.AppImage && ./appimagetool-x86_64.AppImage --appimage-extract 
+RUN cd /opt && mv squashfs-root appimagetool-x86_64.AppDir && ls && ln -s /opt/appimagetool-x86_64.AppDir/AppRun /usr/bin/appimagetool 
+
+RUN apt install -y git
+
+RUN pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git
+
+RUN DEBIAN_FRONTEND=noninteractive apt install -y libhandy-1-dev
+RUN apt install -y appstream-util


### PR DESCRIPTION
# Description
Fix AppImage package using appimage-builder. Notice that AppImage were not able to share their runtime (libc, et. al) with external applications until now. In this recipe we are using the very latest appimage-builder which includes support for external modules.

External modules are defined by setting their paths using the environment variable `APPDIR_MODULE_DIR`. Additionally the modules needs to be patched after installation so they can use the AppImage runtime. Use the following script to patch the modules https://gist.github.com/azubieta/202c85f1f5a9e5c6be5cb066fcb2d5e2

**Additional changes need to be made in the Bottles module installation to add the patch mentioned above**

Fixes #(issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Create the build environment described by the Dockerfile
- Build the appimage inside the docker file using `appimage-builder --skip-test`

Closes #1272 