### PR TITLE
#1315 update desktop entries 

### DIFF
--- a/src/backend/utils/manager.py
+++ b/src/backend/utils/manager.py
@@ -166,7 +166,8 @@ class ManagerUtils:
         ))
 
         if existing_files:
-            [os.remove(file) for file in existing_files]
+            for file in existing_files:
+                os.remove(file)
 
         desktop_file = file_name_template % (
             Paths.applications,

--- a/src/backend/utils/manager.py
+++ b/src/backend/utils/manager.py
@@ -156,16 +156,17 @@ class ManagerUtils:
         if not user_apps_dir:
             return None
 
-        file_name_template = "%s/%s--%s--*.desktop"
+        file_name_template = "%s/%s--%s--%s.desktop"
 
         existing_files = glob(file_name_template % (
             Paths.applications,
             config.get('Name'),
-            program.get("name")
+            program.get("name"),
+            "*"
         ))
 
         if existing_files:
-            return None
+            [os.remove(file) for file in existing_files]
 
         desktop_file = file_name_template % (
             Paths.applications,

--- a/src/backend/utils/manager.py
+++ b/src/backend/utils/manager.py
@@ -18,6 +18,7 @@
 import gi
 import os
 import subprocess
+from glob import glob
 from typing import NewType, Union
 from datetime import datetime
 from gi.repository import GLib
@@ -155,7 +156,18 @@ class ManagerUtils:
         if not user_apps_dir:
             return None
 
-        desktop_file = "%s/%s--%s--%s.desktop" % (
+        file_name_template = "%s/%s--%s--*.desktop"
+
+        existing_files = glob(file_name_template % (
+            Paths.applications,
+            config.get('Name'),
+            program.get("name")
+        ))
+
+        if existing_files:
+            return None
+
+        desktop_file = file_name_template % (
             Paths.applications,
             config.get('Name'),
             program.get("name"),


### PR DESCRIPTION
# Description
- Glob search for existing desktop files matching with the exclusion of timestamp.
- Remove said files before creating a new one.

Fixes #1315

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- Created a few desktop files before the change
- Pressed "Add desktop entry" and observed only one new file
- Pressed it more times and observed the timestamp updating each time
