### PR TITLE
Adding support to run executable from bottle container drive by default

### DIFF
--- a/src/views/bottle_details.py
+++ b/src/views/bottle_details.py
@@ -309,7 +309,7 @@ class BottleView(Gtk.ScrolledWindow):
             _("Cancel")
         )
 
-        file_dialog.set_current_folder(ManagerUtils.get_bottle_path(self.config) + '/drive_c/');
+        file_dialog.set_current_folder(ManagerUtils.get_bottle_path(self.config) + '/drive_c/')
 
         response = file_dialog.run()
         _execs = self.config.get("Latest_Executables")

--- a/src/views/bottle_details.py
+++ b/src/views/bottle_details.py
@@ -309,6 +309,8 @@ class BottleView(Gtk.ScrolledWindow):
             _("Cancel")
         )
 
+        file_dialog.set_current_folder(ManagerUtils.get_bottle_path(self.config) + '/drive_c/');
+
         response = file_dialog.run()
         _execs = self.config.get("Latest_Executables")
 


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed (if available). 
Please also include relevant motivation and context.

The default for running an executable should be the bottle container, for flatpak sandboxed environments. This change makes more sense than the default location for the operating system as the user can quickly navigate to another folder easily, but cannot find the bottle folder easily.

Fixes #(issue)
None

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x ] Tested on Fedora Silverblue through Toolbox
- [ ] Test B
