### PR TITLE
Fixed Steam apps scanning on non-Flatpak systems

### DIFF
--- a/src/backend/managers/steam.py
+++ b/src/backend/managers/steam.py
@@ -182,8 +182,8 @@ class SteamManager:
         apps = local_config.get("UserLocalConfigStore", {}) \
             .get("Software", {}) \
             .get("Valve", {}) \
-            .get("Steam", {}) \
-            .get("Apps", {})
+            .get("Steam", {})
+        apps = apps.get("apps") if apps.get("apps") else apps.get("Apps")
 
         for appid, appdata in apps.items():
             _library_path = SteamManager.get_appid_library_path(appid)
@@ -268,8 +268,8 @@ class SteamManager:
         apps = local_config.get("UserLocalConfigStore", {}) \
             .get("Software", {}) \
             .get("Valve", {}) \
-            .get("Steam", {}) \
-            .get("Apps", {})
+            .get("Steam", {})
+        apps = apps.get("apps") if apps.get("apps") else apps.get("Apps")
 
         if len(apps) == 0 or prefix not in apps:
             logging.warning(_fail_msg)
@@ -343,8 +343,13 @@ class SteamManager:
             launch_options += f"{e}={v} "
 
         launch_options += f"{command} %command% {original_launch_options['args']}"
-        local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["Apps"][
-            prefix]["LaunchOptions"] = launch_options
+
+        try:
+            local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][
+                prefix]["LaunchOptions"] = launch_options
+        except:
+            local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["Apps"][
+                prefix]["LaunchOptions"] = launch_options
 
         SteamManager.save_local_config(local_config)
 
@@ -376,8 +381,12 @@ class SteamManager:
             launch_options += f"{e}={v} "
 
         launch_options += f"{original_launch_options['command']} %command% {original_launch_options['args']}"
-        local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][
-            prefix]["LaunchOptions"] = launch_options
+        try:
+            local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][
+                prefix]["LaunchOptions"] = launch_options
+        except:
+            local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["Apps"][
+                prefix]["LaunchOptions"] = launch_options
 
         SteamManager.save_local_config(local_config)
 

--- a/src/backend/managers/steam.py
+++ b/src/backend/managers/steam.py
@@ -183,7 +183,7 @@ class SteamManager:
             .get("Software", {}) \
             .get("Valve", {}) \
             .get("Steam", {}) \
-            .get("apps", {})
+            .get("Apps", {})
 
         for appid, appdata in apps.items():
             _library_path = SteamManager.get_appid_library_path(appid)
@@ -241,7 +241,10 @@ class SteamManager:
     def update_bottles():
         prefixes = SteamManager.list_prefixes()
 
-        shutil.rmtree(Paths.steam)  # generate new configs at start
+        try:
+            shutil.rmtree(Paths.steam)  # generate new configs at start
+        except:
+            pass
 
         for prefix in prefixes.items():
             _name, _conf = prefix
@@ -266,7 +269,7 @@ class SteamManager:
             .get("Software", {}) \
             .get("Valve", {}) \
             .get("Steam", {}) \
-            .get("apps", {})
+            .get("Apps", {})
 
         if len(apps) == 0 or prefix not in apps:
             logging.warning(_fail_msg)
@@ -340,7 +343,7 @@ class SteamManager:
             launch_options += f"{e}={v} "
 
         launch_options += f"{command} %command% {original_launch_options['args']}"
-        local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][
+        local_config["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["Apps"][
             prefix]["LaunchOptions"] = launch_options
 
         SteamManager.save_local_config(local_config)


### PR DESCRIPTION
# Description

Fixes #1274

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.


- Launched `bottles` on a direct-from-Git install, apps which couldn't be scanned before now show up on the bottles list.
- Please test on Flatpak, Steam imports appeared to work before my fix on there.
