### PR TITLE
Actually fix #1330: Fix xterm handling in cmd execution

### DIFF
--- a/src/backend/utils/terminal.py
+++ b/src/backend/utils/terminal.py
@@ -40,7 +40,7 @@ class TerminalUtils:
         ['foot', '%s'],
         ['kitty', '%s'],
         ['xfce4-terminal', '-e %s'],
-        ['xterm', '-hold -e %s'],
+        ['xterm', '-e %s'],
         ['konsole', '--noclose -e %s'],
         ['gnome-terminal', '-- %s'],
         ['mate-terminal', '--command %s'],
@@ -88,7 +88,7 @@ class TerminalUtils:
         elif self.terminal[0] in ['kitty', 'foot', 'konsole']:
             command = ' '.join(self.terminal) % "sh -c %s" % f'"{command}"'
         else:
-            command = ' '.join(self.terminal) % f"'bash -c {command}'"
+            command = ' '.join(self.terminal) % "bash -c %s" % f'"{command}"'
 
         subprocess.Popen(
             command,


### PR DESCRIPTION
# Description
Changed xterm handling to be more like other terminals. The difference seems to mostly be in quotation marks.

Fixes #1330 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Ran the changed code and tried using the Command Line utility. Utility pops up with wine cmd active and is close-able with Ctrl+C or by clicking the X in the title bar.