### PR TITLE
Add horizontal fill to bottle title and set max lenght 128

### DIFF
--- a/src/ui/details-bottle.ui
+++ b/src/ui/details-bottle.ui
@@ -315,9 +315,8 @@
                       <object class="GtkEntry" id="entry_name">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="halign">start</property>
                         <property name="editable">False</property>
-                        <property name="max-length">20</property>
+                        <property name="max-length">128</property>
                         <property name="has-frame">False</property>
                         <property name="text" translatable="yes">Bottle name</property>
                         <property name="shadow-type">none</property>


### PR DESCRIPTION
# Description
* Changed halign on entry_name to fill which is the default and therefore the XML element is removed.
* Increased title lenght to 128 characters from 20. This only affects editing.

Fixes  #1390

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Create a bottle with a really long name e.g. 128 characters.

* Observe that the title now fill the parent container, but also doesn't exceed its parent. Instead the title can be scrolled to view it in entirety.
* Try to edit the title and notice that it works as expected.

