### PR TITLE
Change bottle-cli command to use Path

### DIFF
--- a/src/backend/utils/manager.py
+++ b/src/backend/utils/manager.py
@@ -181,7 +181,7 @@ class ManagerUtils:
         with open(desktop_file, "w") as f:
             f.write(f"[Desktop Entry]\n")
             f.write(f"Name={program.get('name')}\n")
-            f.write(f"Exec={cmd} run -p '{program.get('name')}' -b '{config.get('Name')}'\n")
+            f.write(f"Exec={cmd} run -p '{program.get('name')}' -b '{config.get('Path')}'\n")
             f.write(f"Type=Application\n")
             f.write(f"Terminal=false\n")
             f.write(f"Categories=Application;\n")


### PR DESCRIPTION
# Description
There are many cases where the bottle name and path are not the same. Launching a bottle with CLI requires the bottle path not the bottles name. It only works in the case where they are equal.

Fixes #1392  #1325

## Type of change
- [ *] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
*    Create a bottle
*    Install an application
*    Change bottle name
*    Create a desktop entry
*    Click new desktop entry in the DE menu
*    Check that application launches correctly


