### PR TITLE
Fix "WINE" typo

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,8 +40,8 @@ Depends: ${python3:Depends},
          winbind,
          cabextract,
          x11-utils
-Description: Easily manage WINE prefixes using environments
- Bottles is an application that allows you to easily manage WINE prefixes.
+Description: Easily manage Wine prefixes using environments
+ Bottles is an application that allows you to easily manage Wine prefixes.
  .
  Choose between Gaming and Software environments based on the type of software 
  you want to start. More advanced users can choose the Custom environment to 

--- a/po/bottles.pot
+++ b/po/bottles.pot
@@ -1970,11 +1970,11 @@ msgstr ""
 
 #. execute wineboot on the bottle path
 #: src/backend/managers/manager.py:1176
-msgid "The WINE config is being updated…"
+msgid "The Wine config is being updated…"
 msgstr ""
 
 #: src/backend/managers/manager.py:1178
-msgid "WINE config updated!"
+msgid "Wine config updated!"
 msgstr ""
 
 #: src/backend/managers/manager.py:1186

--- a/src/backend/managers/manager.py
+++ b/src/backend/managers/manager.py
@@ -305,7 +305,7 @@ class Manager:
         # check system wine
         if shutil.which("wine") is not None:
             '''
-            If the WINE command is available, get the runner version
+            If the Wine command is available, get the runner version
             and add it to the runners_available list.
             '''
             version = subprocess.Popen(
@@ -1188,9 +1188,9 @@ class Manager:
         wineserver = WineServer(config)
 
         # execute wineboot on the bottle path
-        log_update(_("The WINE config is being updated…"))
+        log_update(_("The Wine config is being updated…"))
         wineboot.init()
-        log_update(_("WINE config updated!"))
+        log_update(_("Wine config updated!"))
 
         if "FLATPAK_ID" in os.environ or sandbox:
             '''

--- a/src/backend/runner.py
+++ b/src/backend/runner.py
@@ -34,7 +34,7 @@ logging = Logger()
 
 class Runner:
     """
-    This class handle everything related to the runner (e.g. WINE, Proton).
+    This class handle everything related to the runner (e.g. Wine, Proton).
     It should not contain any manager logic (e.g. catalogs, checks, etc.) or
     any bottle related stuff (e.g. config handling, etc.), also DXVK, VKD3D,
     NVAPI handling should not performed from here. This class should be kept

--- a/src/backend/wine/cmd.py
+++ b/src/backend/wine/cmd.py
@@ -7,7 +7,7 @@ logging = Logger()
 
 
 class CMD(WineProgram):
-    program = "WINE Command Line"
+    program = "Wine Command Line"
     command = "cmd"
 
     def run_batch(

--- a/src/backend/wine/control.py
+++ b/src/backend/wine/control.py
@@ -7,5 +7,5 @@ logging = Logger()
 
 
 class Control(WineProgram):
-    program = "WINE Control Panel"
+    program = "Wine Control Panel"
     command = "control"

--- a/src/backend/wine/executor.py
+++ b/src/backend/wine/executor.py
@@ -106,7 +106,7 @@ class WineExecutor:
     def run_cli(self):
         """
         We need to launch the application and then exit,
-        so we use WINE Starter, which will exit as soon
+        so we use Wine Starter, which will exit as soon
         as the program is launched
         """
         winepath = WinePath(self.config)

--- a/src/backend/wine/explorer.py
+++ b/src/backend/wine/explorer.py
@@ -7,5 +7,5 @@ logging = Logger()
 
 
 class Explorer(WineProgram):
-    program = "WINE Explorer"
+    program = "Wine Explorer"
     command = "explorer"

--- a/src/backend/wine/msiexec.py
+++ b/src/backend/wine/msiexec.py
@@ -7,7 +7,7 @@ logging = Logger()
 
 
 class MsiExec(WineProgram):
-    program = "WINE MSI Installer"
+    program = "Wine MSI Installer"
     command = "msiexec"
 
     def install(

--- a/src/backend/wine/net.py
+++ b/src/backend/wine/net.py
@@ -7,7 +7,7 @@ logging = Logger()
 
 
 class Net(WineProgram):
-    program = "WINE Services manager"
+    program = "Wine Services manager"
     command = "net"
 
     def start(self, name: str = None):

--- a/src/backend/wine/reg.py
+++ b/src/backend/wine/reg.py
@@ -11,7 +11,7 @@ logging = Logger()
 
 
 class Reg(WineProgram):
-    program = "WINE Registry CLI"
+    program = "Wine Registry CLI"
     command = "reg"
 
     def add(self, key: str, value: str, data: str, key_type: str = False):

--- a/src/backend/wine/regedit.py
+++ b/src/backend/wine/regedit.py
@@ -7,5 +7,5 @@ logging = Logger()
 
 
 class Regedit(WineProgram):
-    program = "WINE Registry Editor"
+    program = "Wine Registry Editor"
     command = "regedit"

--- a/src/backend/wine/start.py
+++ b/src/backend/wine/start.py
@@ -8,7 +8,7 @@ logging = Logger()
 
 
 class Start(WineProgram):
-    program = "WINE Starter"
+    program = "Wine Starter"
     command = "start"
 
     def run(

--- a/src/backend/wine/taskmgr.py
+++ b/src/backend/wine/taskmgr.py
@@ -7,5 +7,5 @@ logging = Logger()
 
 
 class Taskmgr(WineProgram):
-    program = "WINE Task Manager"
+    program = "Wine Task Manager"
     command = "taskmgr"

--- a/src/backend/wine/uninstaller.py
+++ b/src/backend/wine/uninstaller.py
@@ -7,7 +7,7 @@ logging = Logger()
 
 
 class Uninstaller(WineProgram):
-    program = "WINE Uninstaller"
+    program = "Wine Uninstaller"
     command = "uninstaller"
 
     def get_uuid(self, name: str = None):

--- a/src/backend/wine/wineboot.py
+++ b/src/backend/wine/wineboot.py
@@ -9,7 +9,7 @@ logging = Logger()
 
 
 class WineBoot(WineProgram):
-    program = "WINE Runtime tool"
+    program = "Wine Runtime tool"
     command = "wineboot"
 
     def send_status(self, status: int):

--- a/src/backend/wine/winebridge.py
+++ b/src/backend/wine/winebridge.py
@@ -9,7 +9,7 @@ logging = Logger()
 
 
 class WineBridge(WineProgram):
-    program = "WINE Bridge"
+    program = "Wine Bridge"
     command = "WineBridge.exe"
     is_internal = True
     internal_path = "winebridge"

--- a/src/backend/wine/winecfg.py
+++ b/src/backend/wine/winecfg.py
@@ -7,5 +7,5 @@ logging = Logger()
 
 
 class WineCfg(WineProgram):
-    program = "WINE Configuration"
+    program = "Wine Configuration"
     command = "winecfg"

--- a/src/backend/wine/winedbg.py
+++ b/src/backend/wine/winedbg.py
@@ -12,7 +12,7 @@ logging = Logger()
 
 
 class WineDbg(WineProgram):
-    program = "WINE debug tool"
+    program = "Wine debug tool"
     command = "winedbg"
     colors = "debug"
 

--- a/src/backend/wine/winepath.py
+++ b/src/backend/wine/winepath.py
@@ -7,7 +7,7 @@ logging = Logger()
 
 
 class WinePath(WineProgram):
-    program = "WINE path converter"
+    program = "Wine path converter"
     command = "winepath"
 
     @staticmethod

--- a/src/backend/wine/wineserver.py
+++ b/src/backend/wine/wineserver.py
@@ -12,7 +12,7 @@ logging = Logger()
 
 
 class WineServer(WineProgram):
-    program = "WINE Server"
+    program = "Wine Server"
     command = "wineserver"
 
     def is_alive(self):

--- a/src/cli.in
+++ b/src/cli.in
@@ -83,7 +83,7 @@ class CLI:
         programs_parser = subparsers.add_parser("programs", help="List programs")
         programs_parser.add_argument("-b", "--bottle", help="Bottle name", required=True)
 
-        tools_parser = subparsers.add_parser("tools", help="Launch WINE tools")
+        tools_parser = subparsers.add_parser("tools", help="Launch Wine tools")
         tools_parser.add_argument('tool', choices=['cmd', 'winecfg', 'uninstaller', 'regedit', 'taskmgr', 'control',
                                                    'explorer'], help="Tool to launch")
         tools_parser.add_argument("-b", "--bottle", help="Bottle name", required=True)

--- a/src/views/bottle_preferences.py
+++ b/src/views/bottle_preferences.py
@@ -871,7 +871,7 @@ class PreferencesView(Gtk.ScrolledWindow):
         self.config = new_config
 
     def __toggle_fixme(self, widget, state):
-        """Set the WINE logging level to use for the bottle"""
+        """Set the Wine logging level to use for the bottle"""
         new_config = self.manager.update_config(
             config=self.config,
             key="fixme_logs",


### PR DESCRIPTION
"WINE" is incorrectly spelled, as it should be "Wine", per https://www.winehq.org/

Continuation of the broken PR https://github.com/bottlesdevs/Bottles/pull/1407.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Untested.