### PR TITLE
Replace deprecated <mimetypes> tag in metainfo

### DIFF
--- a/data/com.usebottles.bottles.appdata.xml.in
+++ b/data/com.usebottles.bottles.appdata.xml.in
@@ -34,12 +34,12 @@
           <li>... and much more that you can find by installing Bottles!</li>
         </ul>
     </description>
-    ​<mimetypes>
-        <mimetype>application/x-ms-dos-executable</mimetype>
-        <mimetype>application/x-msi</mimetype>
-        <mimetype>application/x-ms-shortcut</mimetype>
-        <mimetype>application/x-wine-extension-msp</mimetype>
-    </mimetypes>
+    ​<provides>
+        <mediatype>application/x-ms-dos-executable</mediatype>
+        <mediatype>application/x-msi</mediatype>
+        <mediatype>application/x-ms-shortcut</mediatype>
+        <mediatype>application/x-wine-extension-msp</mediatype>
+    </provides>
     <screenshots>
         <screenshot type="default">
             <image>https://raw.githubusercontent.com/bottlesdevs/Bottles/master/data/appstream/screenshot.png</image>


### PR DESCRIPTION
See the [specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-mimetypes) for reference