### PR TITLE
i18n: add regional variants of Chinese as symbolic links

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -35,3 +35,7 @@ ckb
 fa
 th
 ar
+zh_CN
+zh_HK
+zh_SG
+zh_TW

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,1 @@
+zh_Hans.po

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -1,0 +1,1 @@
+zh_Hant.po

--- a/po/zh_SG.po
+++ b/po/zh_SG.po
@@ -1,0 +1,1 @@
+zh_Hans.po

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,0 +1,1 @@
+zh_Hant.po


### PR DESCRIPTION
This will allow users with LANGUAGE=zh_CN/zh_SG/zh_HK/zh_TW to see the correct translation.

# Description

Create symlinks to `zh_Hans` or `zh_Hant` for language codes `zh_CN` / `zh_SG` / `zh_HK` / `zh_TW` so that distributions using these language codes load translation files normally.

Fixes https://github.com/bottlesdevs/Bottles/issues/574

Existing Chinese translations for Bottles cannot be found for distros using the `zh_CN` / `zh_SG` / `zh_HK` / `zh_TW` language codes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.

```
# These two always display normally
LANGUAGE=zh_Hans flatpak run com.usebottles.bottles
LANGUAGE=zh_Hant flatpak run com.usebottles.bottles

# These four require my commits to load the language files correctly
# Otherwise they are only displayed in English (Flatpak 1.2.5)
## link to zh_Hans
LANGUAGE=zh_CN flatpak run com.usebottles.bottles
LANGUAGE=zh_SG flatpak run com.usebottles.bottles
## link to zh_Hant
LANGUAGE=zh_HK flatpak run com.usebottles.bottles
LANGUAGE=zh_TW flatpak run com.usebottles.bottles
```

