### PR TITLE
fix: appimage test builds

### DIFF
--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install python3-pip python-dev build-essential gettext git libgtk-4-dev -y
+          sudo apt-get install python3-pip python-dev-is-python3 build-essential gettext git libgtk-4-dev -y
           sudo pip3 install --upgrade pip
           sudo pip3 install meson
           sudo pip3 install ninja

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -30,3 +30,9 @@ jobs:
           cd Bottles
           chmod +x appimage-build.sh
           sudo ./appimage-build.sh
+      - uses: actions/upload-artifact@v3.0.0
+        with:
+          name: "Bottles-test-appimage"
+          path: /home/runner/work/Bottles/Bottles/Bottles/build/appdir/
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install python3-pip python-dev-is-python3 build-essential gettext git libgtk-4-dev -y
+          sudo apt-get install python3-pip python-dev-is-python3 build-essential gettext git libgtk-4-dev libfuse2 -y
           sudo pip3 install --upgrade pip
           sudo pip3 install meson
           sudo pip3 install ninja

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install python3-pip python-dev-is-python3 build-essential gettext git libgtk-4-dev libfuse2 -y
+          sudo apt-get install python3-pip python-dev-is-python3 build-essential gettext git libgtk-4-dev libfuse2 libgtksourceview-5-dev -y
           sudo pip3 install --upgrade pip
           sudo pip3 install meson
           sudo pip3 install ninja

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest # Ubuntu Bionic Beaver
+    runs-on: ubuntu-22.04 # Ubuntu Jammy
     steps:
       - name: Update Packages
         run: |

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-18.04 # Ubuntu Bionic Beaver
+    runs-on: ubuntu-latest # Ubuntu Bionic Beaver
     steps:
       - name: Update Packages
         run: |

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/upload-artifact@v3.0.0
         with:
           name: "Bottles-test-appimage"
-          path: /home/runner/work/Bottles/Bottles/Bottles/build/appdir/
+          path: /home/runner/work/Bottles/Bottles/Bottles/build/*.AppImage
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt install python3-pip python-dev build-essential gettext git
+          sudo apt-get install python3-pip python-dev build-essential gettext git libgtk-4-dev -y
           sudo pip3 install --upgrade pip
           sudo pip3 install meson
           sudo pip3 install ninja

--- a/.github/workflows/test_appimage_build.yml
+++ b/.github/workflows/test_appimage_build.yml
@@ -19,7 +19,7 @@ jobs:
           sudo pip3 install ninja
 
       - name: Repo cloning
-        run: git clone https://github.com/bottlesdevs/Bottles
+        run: git clone -b $GITHUB_REF_NAME https://github.com/bottlesdevs/Bottles
 
       - name: g++ version check
         run: |

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -115,6 +115,7 @@ print_execution "chmod a+x linuxdeploy-plugin-gtk.sh"
 
 title "Executing linuxdeploy-plugin-gtk on appdir"
 export DEPLOY_GTK_VERSION=4
+sed -i 's/DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" //g' ./linuxdeploy-plugin-gtk.sh
 print_execution "./linuxdeploy-plugin-gtk.sh --appdir appdir"
 
 title "Building Bottles Appimage"

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -114,8 +114,8 @@ print_execution "curl -L https://raw.githubusercontent.com/linuxdeploy/linuxdepl
 print_execution "chmod a+x linuxdeploy-plugin-gtk.sh"
 
 title "Executing linuxdeploy-plugin-gtk on appdir"
+export DEPLOY_GTK_VERSION=4
 print_execution "./linuxdeploy-plugin-gtk.sh --appdir appdir"
 
 title "Building Bottles Appimage"
-export DEPLOY_GTK_VERSION=4
 print_execution "./linuxdeploy-x86_64.AppImage --appdir appdir  --output appimage"

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -115,7 +115,7 @@ print_execution "chmod a+x linuxdeploy-plugin-gtk.sh"
 
 title "Executing linuxdeploy-plugin-gtk on appdir"
 export DEPLOY_GTK_VERSION=4
-sed -i 's/DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" //g' ./linuxdeploy-plugin-gtk.sh
+sed -i 's/ldd/true/g' ./linuxdeploy-plugin-gtk.sh #uses static, not dynamic libraries
 print_execution "./linuxdeploy-plugin-gtk.sh --appdir appdir"
 
 title "Building Bottles Appimage"

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -111,11 +111,11 @@ print_execution "chmod a+x linuxdeploy-x86_64.AppImage"
 
 title "Downloading linuxdeploy-plugin-gtk"
 print_execution "curl -L https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh --output linuxdeploy-plugin-gtk.sh"
+print_execution "sed -i 's/ldd/true/g' ./linuxdeploy-plugin-gtk.sh" #uses static, not dynamic libraries
 print_execution "chmod a+x linuxdeploy-plugin-gtk.sh"
 
 title "Executing linuxdeploy-plugin-gtk on appdir"
 export DEPLOY_GTK_VERSION=4
-sed -i 's/ldd/true/g' ./linuxdeploy-plugin-gtk.sh #uses static, not dynamic libraries
 print_execution "./linuxdeploy-plugin-gtk.sh --appdir appdir"
 
 title "Building Bottles Appimage"

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -117,4 +117,5 @@ title "Executing linuxdeploy-plugin-gtk on appdir"
 print_execution "./linuxdeploy-plugin-gtk.sh --appdir appdir"
 
 title "Building Bottles Appimage"
+export DEPLOY_GTK_VERSION=4
 print_execution "./linuxdeploy-x86_64.AppImage --appdir appdir  --output appimage"

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -112,6 +112,7 @@ print_execution "chmod a+x linuxdeploy-x86_64.AppImage"
 title "Downloading linuxdeploy-plugin-gtk"
 print_execution "curl -L https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh --output linuxdeploy-plugin-gtk.sh"
 print_execution "sed -i 's/ldd/true/g' ./linuxdeploy-plugin-gtk.sh" #uses static, not dynamic libraries
+cat ./linuxdeploy-plugin-gtk.sh
 print_execution "chmod a+x linuxdeploy-plugin-gtk.sh"
 
 title "Executing linuxdeploy-plugin-gtk on appdir"

--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -111,8 +111,6 @@ print_execution "chmod a+x linuxdeploy-x86_64.AppImage"
 
 title "Downloading linuxdeploy-plugin-gtk"
 print_execution "curl -L https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh --output linuxdeploy-plugin-gtk.sh"
-print_execution "sed -i 's/ldd/true/g' ./linuxdeploy-plugin-gtk.sh" #uses static, not dynamic libraries
-cat ./linuxdeploy-plugin-gtk.sh
 print_execution "chmod a+x linuxdeploy-plugin-gtk.sh"
 
 title "Executing linuxdeploy-plugin-gtk on appdir"


### PR DESCRIPTION
# Description
First, it Appimage builds failing on Linux Deploy on CI, it also changes the CI to use the latest Ubuntu version instead
of Bionic which does not have gtk4. It also uploads the appimage for example, say, you wanted to test something on a
different branch.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (alert users that appimages are available)

# How Has This Been Tested?
Log of a run: https://github.com/cat-master21/Bottles/runs/6891750436?check_suite_focus=true
A AppImage available at: https://github.com/cat-master21/Bottles/actions/runs/2499291902 :rocket:!!!