### PR TITLE
fix: fix appimage for unstable github builds

### DIFF
--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -12,23 +12,23 @@ jobs:
       # Dependencies
       # --------------------------------------
       - name: Install build dependencies
-        run: | 
-          apt update
-          DEBIAN_FRONTEND=noninteractive apt install -y libfuse2 gstreamer1.0-tools zstd debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget git libhandy-1-0 libhandy-1-dev appstream-util
+        run: |
+          sudo apt update
+          DEBIAN_FRONTEND=noninteractive sudo apt install -y libfuse2 gstreamer1.0-tools zstd debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget git libhandy-1-0 libhandy-1-dev appstream-util
 
       # AppImage Build
       # --------------------------------------
       - name: Install appimagetool
         run: |
-           wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/appimagetool-x86_64.AppImage
-           cd /opt && chmod +x appimagetool-x86_64.AppImage && ./appimagetool-x86_64.AppImage --appimage-extract 
-           cd /opt && mv squashfs-root appimagetool-x86_64.AppDir && ls && ln -s /opt/appimagetool-x86_64.AppDir/AppRun /usr/bin/appimagetool 
+           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/appimagetool-x86_64.AppImage
+           cd /opt && sudo chmod +x appimagetool-x86_64.AppImage && sudo ./appimagetool-x86_64.AppImage --appimage-extract 
+           cd /opt && sudo mv squashfs-root appimagetool-x86_64.AppDir && ls && sudo ln -s /opt/appimagetool-x86_64.AppDir/AppRun /usr/bin/appimagetool 
 
       - name: Install appimage-builder tool
         run: |
-          wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.0.3/appimage-builder-1.0.3-x86_64.AppImage
-          chmod +x appimage-builder-x86_64.AppImage
-          mv appimage-builder-x86_64.AppImage /usr/bin/appimage-builder
+          sudo wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.0.3/appimage-builder-1.0.3-x86_64.AppImage
+          sudo chmod +x appimage-builder-x86_64.AppImage
+          sudo mv appimage-builder-x86_64.AppImage /usr/bin/appimage-builder
 
       - name: Build AppImage
         run: appimage-builder --recipe AppImageBuilder.yml --skip-test

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -26,7 +26,7 @@ jobs:
            cd /opt && mv squashfs-root appimagetool-x86_64.AppDir && ls && ln -s /opt/appimagetool-x86_64.AppDir/AppRun /usr/bin/appimagetool 
 
       - name: Install appimage-builder tool
-        run: yes | pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git#6678a4829b1b7304dbe2ea98c7e9c88ba0526e1b
+        run: yes | pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git#a08ae8d300d9632d78865003c974175dcb90ce21
 
       - name: Build AppImage
         run: appimage-builder --recipe AppImageBuilder.yml --skip-test

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -26,7 +26,10 @@ jobs:
            cd /opt && mv squashfs-root appimagetool-x86_64.AppDir && ls && ln -s /opt/appimagetool-x86_64.AppDir/AppRun /usr/bin/appimagetool 
 
       - name: Install appimage-builder tool
-        run: yes | pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git#a08ae8d300d9632d78865003c974175dcb90ce21
+        run: |
+          wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.0.3/appimage-builder-1.0.3-x86_64.AppImage
+          chmod +x appimage-builder-x86_64.AppImage
+          mv appimage-builder-x86_64.AppImage /usr/bin/appimage-builder
 
       - name: Build AppImage
         run: appimage-builder --recipe AppImageBuilder.yml --skip-test

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install build dependencies
         run: | 
           apt update
-          DEBIAN_FRONTEND=noninteractive apt install -y gstreamer1.0-tools zstd debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget git libhandy-1-0 libhandy-1-dev appstream-util
+          DEBIAN_FRONTEND=noninteractive apt install -y libfuse2 gstreamer1.0-tools zstd debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget git libhandy-1-0 libhandy-1-dev appstream-util
 
       # AppImage Build
       # --------------------------------------

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install build dependencies
         run: | 
           apt update
-          DEBIAN_FRONTEND=noninteractive apt install -y zstd debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget git libhandy-1-0 libhandy-1-dev appstream-util
+          DEBIAN_FRONTEND=noninteractive apt install -y gstreamer1.0-tools zstd debhelper python3 python3-pip python3-setuptools python3-yaml python3-requests gettext build-essential patchelf librsvg2-dev desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace ninja-build meson winbind wget git libhandy-1-0 libhandy-1-dev appstream-util
 
       # AppImage Build
       # --------------------------------------

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -5,8 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build-packages:
-    runs-on: ubuntu-20.04
-    container: ubuntu:jammy
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build_pkgs_unstable.yml
+++ b/.github/workflows/build_pkgs_unstable.yml
@@ -31,14 +31,14 @@ jobs:
           sudo mv appimage-builder-x86_64.AppImage /usr/bin/appimage-builder
 
       - name: Build AppImage
-        run: appimage-builder --recipe AppImageBuilder.yml --skip-test
+        run: sudo appimage-builder --recipe AppImageBuilder.yml --skip-test
 
       # Rename and release packages
       # --------------------------------------
       - name: Rename packages
         run: |
-          mv Bottles-*-x86_64.AppImage Bottles-devel-x86_64.AppImage
-          mv Bottles-*-x86_64.AppImage.zsync Bottles-devel-x86_64.AppImage.zsync
+          sudo mv Bottles-*-x86_64.AppImage Bottles-devel-x86_64.AppImage
+          sudo mv Bottles-*-x86_64.AppImage.zsync Bottles-devel-x86_64.AppImage.zsync
 
       - name: Upload AppImage to Artifacts
         uses: actions/upload-artifact@v2

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -136,11 +136,12 @@ AppDir:
     - humanity-icon-theme
 
   after_runtime: |
-     rm -f $APPDIR/.bundle.yml
-     rm -rf $APPDIR/usr/share/doc
-     rm -rf $APPDIR/usr/share/man
-     mkdir -p $APPDIR/usr/local/lib/p7zip/ 
-     ln -s $APPDIR/usr/lib/p7zip/ $APPDIR/usr/local/lib/p7zip/
+    # rm -f $APPDIR/.bundle.yml
+    # rm -rf $APPDIR/usr/share/doc
+    # rm -rf $APPDIR/usr/share/man
+    # mkdir -p $APPDIR/usr/local/lib/p7zip/ 
+    # ln -s $APPDIR/usr/lib/p7zip/ $APPDIR/usr/local/lib/p7zip/
+    true
 
   files:
     include:
@@ -150,6 +151,8 @@ AppDir:
     exclude:
       - AppDir/usr/lib/x86_64-linux-gnu/gconv
       - AppDir/usr/share/man
+      - AppDir/.bundle.yml
+      - AppDir/usr/share/doc
       - AppDir/usr/share/doc/*/README.*
       - AppDir/usr/share/doc/*/changelog.*
       - AppDir/usr/share/doc/*/NEWS.*


### PR DESCRIPTION
# Description
This intends to fix appimages for unstable github workflow. In addition I'm also trying to fix the changed dependencies included with the appimage.

Fixes #1272 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
Example run: https://github.com/cat-master21/Bottles/actions/runs/2503841056
the appimage uploaded however is currently broken.