### PR TITLE
details: fix title buttons position

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,13 @@
     "python.analysis.extraPaths": [
         "./build/files/lib/python3.9/site-packages",
         "./build/var/run/host/lib/python3.10/site-packages"
-    ]
+    ],
+    "files.watcherExclude": {
+        "**/.dart_tool": true,
+        ".flatpak/**": true,
+        "_build/**": true
+    },
+    "mesonbuild.configureOnOpen": false,
+    "mesonbuild.buildFolder": "_build",
+    "mesonbuild.mesonPath": "/var/home/nahuelwexd/Proyectos/Bottles/.flatpak/meson.sh"
 }

--- a/src/ui/details.ui
+++ b/src/ui/details.ui
@@ -12,7 +12,6 @@
                         <property name="orientation">vertical</property>
                         <child>
                             <object class="AdwHeaderBar" id="sidebar_headerbar">
-                                <property name="show-start-title-buttons">False</property>
                                 <property name="show-end-title-buttons">False</property>
                                 <property name="title-widget">
                                     <object class="AdwWindowTitle" id="sidebar_title">
@@ -54,8 +53,7 @@
                         <property name="orientation">vertical</property>
                         <child>
                             <object class="AdwHeaderBar" id="content_headerbar">
-                                <property name="show-start-title-buttons">True</property>
-                                <property name="show-end-title-buttons">True</property>
+                                <property name="show-start-title-buttons">False</property>
                                 <property name="title-widget">
                                     <object class="AdwWindowTitle" id="content_title">
                                     </object>
@@ -120,4 +118,3 @@
         </child>
     </object>
 </interface>
-

--- a/src/views/details.py
+++ b/src/views/details.py
@@ -103,6 +103,7 @@ class DetailsView(Adw.Bin):
     def __on_leaflet_folded(self, widget, *args):
         folded = widget.get_folded()
         self.sidebar_headerbar.set_show_end_title_buttons(folded)
+        self.content_headerbar.set_show_start_title_buttons(folded)
         self.btn_back_sidebar.set_visible(folded)
 
     def __on_page_change(self, *args):


### PR DESCRIPTION
# Description
In the details screen, the title buttons were **always** displayed in the content pane. This is not a problem with GNOME's default decoration layout (`appmenu:close`), but in DEs like elementary or KDE, this brings an appearance that is perhaps not as expected:

![imagen](https://user-images.githubusercontent.com/18204745/173937833-62249a4e-3988-44a4-a71a-2a8d8dd49235.png)  
![imagen](https://user-images.githubusercontent.com/18204745/173938055-6c55a698-47eb-4e2c-a249-dcb5948b2954.png)

This PR allows any controls that need to be displayed in the sidebar panel to do so seamlessly:

![imagen](https://user-images.githubusercontent.com/18204745/173939384-b7950aac-98fd-44e1-9898-0c5b5873ed95.png)  
![imagen](https://user-images.githubusercontent.com/18204745/173939525-60661a3c-f5bd-4e2c-bc4c-ec89f1b5f3c1.png)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
