### PR TITLE
Improve terminal emulator priorities

### DIFF
--- a/src/backend/utils/terminal.py
+++ b/src/backend/utils/terminal.py
@@ -36,18 +36,22 @@ class TerminalUtils:
     }
 
     terminals = [
+        # Part of Flatpak package
         ['easyterm.py', '-d -p "%s" -c %s'],
+        # Third party
         ['foot', '%s'],
         ['kitty', '%s'],
-        ['xfce4-terminal', '-e %s'],
-        ['xterm', '-e %s'],
-        ['konsole', '--noclose -e %s'],
-        ['kgx', '-e %s'],
-        ['gnome-terminal', '-- %s'],
-        ['mate-terminal', '--command %s'],
         ['tilix', '-- %s'],
+        # Desktop environments
+        ['xfce4-terminal', '-e %s'],
+        ['konsole', '--noclose -e %s'],
+        ['gnome-terminal', '-- %s'],
+        ['kgx', '-e %s'],
+        ['mate-terminal', '--command %s'],
         ['qterminal', '--execute %s'],
         ['lxterminal', '-e %s'],
+        # Fallback
+        ['xterm', '-e %s'],
     ]
 
     def __init__(self):


### PR DESCRIPTION
# Description
Until [XDG Terminal Intent](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/46) specification is widely supported, we can only guess what terminal emulator the user prefers.
Let’s look for third-party programs first, since those had to be installed explicitly by the user, and xterm last, as it tends to be present as a fallback.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
