### PR TITLE
Minor Gamescope improvements

### DIFF
--- a/src/ui/details-preferences.ui
+++ b/src/ui/details-preferences.ui
@@ -523,11 +523,6 @@
                         <property name="title" translatable="yes">Gamescope</property>
                         <property name="subtitle" translatable="yes">Use the Gamescope micro-compositor.</property>
                         <child>
-                            <object class="GtkSwitch" id="switch_gamescope">
-                                <property name="valign">center</property>
-                            </object>
-                        </child>
-                        <child>
                             <object class="GtkButton" id="btn_manage_gamescope">
                                 <property name="tooltip-text" translatable="yes">Manage Gamescope settings</property>
                                 <property name="valign">center</property>
@@ -535,6 +530,11 @@
                                 <style>
                                     <class name="flat"/>
                                 </style>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkSwitch" id="switch_gamescope">
+                                <property name="valign">center</property>
                             </object>
                         </child>
                     </object>

--- a/src/ui/dialog-gamescope.ui
+++ b/src/ui/dialog-gamescope.ui
@@ -80,6 +80,7 @@
                                 <child>
                                     <object class="AdwActionRow">
                                         <property name="title" translatable="yes">Use integer scaling</property>
+                                        <property name="activatable-widget">switch_scaling</property>
                                         <child>
                                             <object class="GtkSwitch" id="switch_scaling">
                                                 <property name="valign">center</property>


### PR DESCRIPTION
# Description
This MR adds some minor improvements for Gamescope.

First, GtkSwitch and GtkButton are switched:
![image](https://user-images.githubusercontent.com/50847364/175289406-19c4890f-013b-44c2-ab60-f17ef5f64978.png)

Second, "Use integer scaling" can be toggled by simply pressing on the row.

In accordance of:
- https://github.com/bottlesdevs/Bottles/pull/1668#discussion_r904771073
- https://github.com/bottlesdevs/Bottles/pull/1668#discussion_r904763987

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Launched the app.