### PR TITLE
Fix gamescope with MangoHud

### DIFF
--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -228,7 +228,7 @@ class WineCommand:
             env.concat("VK_ICD_FILENAMES", _lf_icd)
 
         # Mangohud environment variables
-        if params["mangohud"] and not self.minimal:
+        if params["mangohud"] and not self.minimal and not (gamescope_available and params.get("gamescope")):
             env.add("MANGOHUD", "1")
 
         # vkBasalt environment variables
@@ -405,14 +405,14 @@ class WineCommand:
                 else:
                     command = f"gamemode {command}"
 
-            if gamescope_available and params.get("gamescope"):
-                command = f"{self.__get_gamescope_cmd(return_steam_cmd)}  -- {command}"
-
             if mangohud_available and params.get("mangohud"):
                 if not return_steam_cmd:
                     command = f"{mangohud_available} {command}"
                 else:
                     command = f"mangohud {command}"
+
+            if gamescope_available and params.get("gamescope"):
+                command = f"{self.__get_gamescope_cmd(return_steam_cmd)}  -- {command}"
 
             if obs_vkc_available and params.get("obsvkc"):
                 command = f"{obs_vkc_available} {command}"


### PR DESCRIPTION
# Description

gamescope crashes with some Vulkan layers like MangoHud. With this change, MangoHud isn't applied to gamescope, but called within gamescope and applied only to the program executing inside it.

This gives us at least working MangoHud within gamescope until #1437 can be done

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Start bottle with both gamescope and MangoHud enabled. Should not crash.
- [x] Start bottle with only MangoHud to verify no regression in what already worked.
