### PR TITLE
Disable Gamescope settings when unavailable

### DIFF
--- a/src/views/bottle_preferences.py
+++ b/src/views/bottle_preferences.py
@@ -183,6 +183,7 @@ class PreferencesView(Adw.PreferencesPage):
         '''Toggle some utilities according to its availability'''
         self.switch_gamemode.set_sensitive(gamemode_available)
         self.switch_gamescope.set_sensitive(gamescope_available)
+        self.btn_manage_gamescope.set_sensitive(gamescope_available)
         self.switch_mangohud.set_sensitive(mangohud_available)
         self.switch_obsvkc.set_sensitive(obs_vkc_available)
         _not_available = _("This feature is not available on your system.")
@@ -190,6 +191,7 @@ class PreferencesView(Adw.PreferencesPage):
             self.switch_gamemode.set_tooltip_text(_not_available)
         if not gamescope_available:
             self.switch_gamescope.set_tooltip_text(_not_available)
+            self.btn_manage_gamescope.set_tooltip_text(_not_available)
         if not mangohud_available:
             self.switch_mangohud.set_tooltip_text(_not_available)
         if not obs_vkc_available:


### PR DESCRIPTION
# Description
This MR disables configuring Gamescope when it's unavailable:
![image](https://user-images.githubusercontent.com/50847364/175756305-cddfb13b-0f8a-4fee-98fe-99ab2b8d6007.png)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Uninstalled Gamescope and check if the Gamescope settings button is diabled, then install Gamescope, restart Bottles and check if the Gamescope settings are enabled.