### PR TITLE
i18n: Fix Chinese translation not available (#1692)

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -13,7 +13,6 @@ tr
 sv
 ru
 eo
-zh_Hans
 fi
 ja
 hr
@@ -21,7 +20,6 @@ cs
 uk
 hu
 pl
-zh_Hant
 ko
 vi
 eu
@@ -40,3 +38,12 @@ sl
 ca
 lt
 sr
+
+# Please DON'T remove zh_CN/zh_HK/zh_SG/zh_TW from this file, actual Chinese users need them.
+# For more details, see <https://github.com/bottlesdevs/Bottles/issues/1692>.
+zh_Hans
+zh_Hant
+zh_CN
+zh_HK
+zh_SG
+zh_TW


### PR DESCRIPTION
# Description

Add `zh_CN`/`zh_HK`/`zh_SG`/`zh_TW` back to `LINGUAS`, so that the Chinese translation can be used by actual users.

Fixes #1692

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.

See https://github.com/bottlesdevs/Bottles/issues/1692 and https://github.com/bottlesdevs/Bottles/pull/1515.
