### PR TITLE
tweak new installer screen

### DIFF
--- a/src/dialogs/installer.py
+++ b/src/dialogs/installer.py
@@ -88,14 +88,23 @@ class InstallerDialog(Adw.Window):
     status_error = Gtk.Template.Child()
     progressbar = Gtk.Template.Child()
     group_resources = Gtk.Template.Child()
-    label_installing_name = Gtk.Template.Child()
+    install_status_page = Gtk.Template.Child()
     img_icon = Gtk.Template.Child()
+    img_icon_install = Gtk.Template.Child()
+    style_provider = Gtk.CssProvider()
 
     # endregion
 
     def __init__(self, window, config, installer, **kwargs):
         super().__init__(**kwargs)
         self.set_transient_for(window)
+        self.style_provider.load_from_data(b"progressbar { line-height: 2.0; }")
+        Gtk.StyleContext.add_provider(
+            self.progressbar.get_style_context(),
+            self.style_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
 
         self.window = window
         self.manager = window.manager
@@ -111,7 +120,7 @@ class InstallerDialog(Adw.Window):
         }
 
         self.status_init.set_title(installer[1].get("Name"))
-        self.label_installing_name.set_text(_("Installing {0}…").format(installer[1].get("Name")))
+        self.install_status_page.set_title(_("Installing {0}…").format(installer[1].get("Name")))
         self.status_installed.set_description(
             _("{0} is now available in the programs view.").format(installer[1].get("Name")))
         self.__set_icon()
@@ -125,6 +134,7 @@ class InstallerDialog(Adw.Window):
             url = self.manager.installer_manager.get_icon_url(self.installer[0])
             if url is None:
                 self.img_icon.set_visible(False)
+                self.img_icon_install.set_visible(False)
                 return
 
             with urllib.request.urlopen(url) as res:
@@ -132,8 +142,11 @@ class InstallerDialog(Adw.Window):
                 pixbuf = GdkPixbuf.Pixbuf.new_from_stream(stream, None)
                 self.img_icon.set_pixel_size(78)
                 self.img_icon.set_from_pixbuf(pixbuf)
+                self.img_icon_install.set_pixel_size(78)
+                self.img_icon_install.set_from_pixbuf(pixbuf)
         except:
             self.img_icon.set_visible(False)
+            self.img_icon_install.set_visible(False)
 
     def __check_resources(self, *args):
         self.__local_resources = self.manager.installer_manager.has_local_resources(self.installer)

--- a/src/ui/dialog-installer.ui
+++ b/src/ui/dialog-installer.ui
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <requires lib="gtk" version="4.0"/>
@@ -98,31 +99,28 @@
                                         <property name="margin-end">10</property>
                                         <property name="orientation">vertical</property>
                                         <property name="valign">center</property>
-                                        <property name="spacing">6</property>
+                                        <property name="spacing">5</property>
                                         <child>
-                                            <object class="GtkLabel" id="label_installing_name">
-                                                <style>
-                                                    <class name="title-2"/>
-                                                </style>
+                                            <object class="GtkImage" id="img_icon_install">
+                                                <property name="halign">center</property>
+                                                <property name="margin-bottom">2</property>
                                             </object>
                                         </child>
                                         <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="true">It could take a while, take a break.</property>
-                                                <style>
-                                                    <class name="dim-label"/>
-                                                </style>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkProgressBar" id="progressbar">
+                                          <object class="AdwStatusPage" id="install_status_page">
+                                            <property name="title">name</property>
+                                            <property name="description">It could take a while, take a break.</property>
+                                            <child>
+                                              <object class="GtkProgressBar" id="progressbar">
                                                 <property name="width_request">300</property>
                                                 <property name="halign">center</property>
-                                                <property name="margin-top">24</property>
+                                                <property name="margin-top">10</property>
                                                 <property name="margin-bottom">12</property>
                                                 <property name="show-text">True</property>
-                                            </object>
-                                        </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>﻿
                                     </object>
                                 </property>
                             </object>
@@ -169,3 +167,4 @@
         </child>
     </template>
 </interface>
+


### PR DESCRIPTION
# Description
Slightly tweak the UI of the second page in the new installer screen:
- Add icon of the app being installed
- space progress bar and progress bar text

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - Navigate to changed UI
    - check if UI displays correctly 
    - check if UI works correctly
    - check if installation works correctly
 
