### PR TITLE
Add `window.close` action for dialogs

### DIFF
--- a/src/ui/dialog-drives.ui
+++ b/src/ui/dialog-drives.ui
@@ -15,6 +15,16 @@
                     </object>
                 </child>
                 <child>
+                    <object class="GtkShortcutController">
+                        <child>
+                            <object class="GtkShortcut">
+                                <property name="trigger">Escape</property>
+                                <property name="action">action(window.close)</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
                     <object class="AdwPreferencesPage">
                         <child>
                             <object class="AdwPreferencesGroup">

--- a/src/ui/dialog-env-vars.ui
+++ b/src/ui/dialog-env-vars.ui
@@ -19,6 +19,16 @@
                     </object>
                 </child>
                 <child>
+                    <object class="GtkShortcutController">
+                        <child>
+                            <object class="GtkShortcut">
+                                <property name="trigger">Escape</property>
+                                <property name="action">action(window.close)</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
                     <object class="AdwPreferencesPage">
                         <child>
                             <object class="AdwPreferencesGroup">


### PR DESCRIPTION
Upon pressing Escape, dialogs should close.

Related to https://github.com/bottlesdevs/Bottles/issues/1598.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Tested locally