### PR TITLE
Use AdwMessageDialog for custom Bottles path error

### DIFF
--- a/com.usebottles.bottles.dev.json
+++ b/com.usebottles.bottles.dev.json
@@ -414,7 +414,8 @@
         {
           "type": "git",
           "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-          "commit": "da4125248a434ba7caaec85186db6ab44deecad7"
+          "tag": "1.2.alpha",
+          "commit": "9150f4016a04064a00733b78391c8e6aad49bee8"
         }
       ],
       "modules": [

--- a/com.usebottles.bottles.dev.yml
+++ b/com.usebottles.bottles.dev.yml
@@ -277,7 +277,8 @@ modules:
     sources:
     - type: git
       url: https://gitlab.gnome.org/GNOME/libadwaita.git
-      commit: da4125248a434ba7caaec85186db6ab44deecad7
+      tag: 1.2.alpha
+      commit: 9150f4016a04064a00733b78391c8e6aad49bee8
     modules:
     - name: libsass
       buildsystem: meson

--- a/src/window.py
+++ b/src/window.py
@@ -213,16 +213,12 @@ class MainWindow(Adw.ApplicationWindow):
             self.headerbar.get_style_context().remove_class("flat")
 
             if Paths.custom_bottles_path_err:
-                dialog = Gtk.MessageDialog(
-                    transient_for=self,
-                    flags=0,
-                    message_type=Gtk.MessageType.ERROR,
-                    buttons=Gtk.ButtonsType.OK,
-                    text=_("The custom bottles path was not found. "
-                           "Please, check the path in Preferences.\n"
-                           "Fall-backing to the default path; "
-                           "no bottles from that path will be listed!")
-                )
+                dialog = Adw.MessageDialog.new(
+                                                self,
+                                                "Custom Bottles Path not Found",
+                                                "Falling back to default path. No bottles from the given path will be listed."
+                                                )
+                dialog.add_response("cancel", "Close")
                 dialog.present()
 
             if self.arg_exe and not self.arg_bottle:
@@ -376,3 +372,4 @@ class MainWindow(Adw.ApplicationWindow):
     @staticmethod
     def open_url(widget, url):
         webbrowser.open_new_tab(url)
+


### PR DESCRIPTION
- Bump libadwaita dependency in Flatpak manifest

This fixes the regression to https://github.com/bottlesdevs/Bottles/commit/ed67dd8a84e3e2b781b6d7c7e6e44203c8d0f0df after we switched to libadwaita.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Tested locally