### PR TITLE
Fix segfault when pressing esc on about window

### DIFF
--- a/src/dialogs/generic.py
+++ b/src/dialogs/generic.py
@@ -200,8 +200,3 @@ class AboutDialog(Adw.AboutWindow):
     def __init__(self, window, **kwargs):
         super().__init__(**kwargs)
         self.set_transient_for(window)
-        self.set_modal(True)
-
-    def do_response(self, response_id):
-        if response_id == Gtk.ResponseType.DELETE_EVENT:
-            self.destroy()

--- a/src/ui/about.ui
+++ b/src/ui/about.ui
@@ -2,6 +2,7 @@
 <interface>
 <requires lib="gtk" version="4.0"/>
   <template class="AboutDialog" parent="AdwAboutWindow">
+    <property name="hide-on-close">True</property>
     <property name="application-name">Bottles</property>
     <property name="modal">True</property>
     <property name="version">2022.6.28-brescia</property>


### PR DESCRIPTION
# Description
When pressing esc on the new About window to close it bottles instead segfaulted, this commit fixes it

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - open about dialog
    - press `esc`
    - window closes without any segfault
    - repeat multiple times to make sure it works consistently
