### PR TITLE
Implement about window properly

### DIFF
--- a/src/dialogs/generic.py
+++ b/src/dialogs/generic.py
@@ -193,10 +193,10 @@ class WebDialog(Adw.Window):
         clipboard.set_content(Gdk.ContentProvider.new_for_value(self.message))
 
 
-@Gtk.Template(resource_path='/com/usebottles/bottles/about.ui')
-class AboutDialog(Adw.AboutWindow):
-    __gtype_name__ = 'AboutDialog'
+#@Gtk.Template(resource_path='/com/usebottles/bottles/about.ui')
+#class AboutDialog(Adw.AboutWindow):
+#    __gtype_name__ = 'AboutDialog'
 
-    def __init__(self, window, **kwargs):
-        super().__init__(**kwargs)
-        self.set_transient_for(window)
+#    def __init__(self, window, **kwargs):
+#        super().__init__(**kwargs)
+#        self.set_transient_for(window)

--- a/src/dialogs/generic.py
+++ b/src/dialogs/generic.py
@@ -192,11 +192,3 @@ class WebDialog(Adw.Window):
         clipboard = Gdk.Display.get_clipboard(Gdk.Display.get_default())
         clipboard.set_content(Gdk.ContentProvider.new_for_value(self.message))
 
-
-#@Gtk.Template(resource_path='/com/usebottles/bottles/about.ui')
-#class AboutDialog(Adw.AboutWindow):
-#    __gtype_name__ = 'AboutDialog'
-
-#    def __init__(self, window, **kwargs):
-#        super().__init__(**kwargs)
-#        self.set_transient_for(window)

--- a/src/ui/about.ui
+++ b/src/ui/about.ui
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
 <requires lib="gtk" version="4.0"/>
-  <template class="AboutDialog" parent="AdwAboutWindow">
-    <property name="hide-on-close">True</property>
+  <object class="AdwAboutWindow" id="about_window">
     <property name="application-name">Bottles</property>
     <property name="modal">True</property>
     <property name="version">2022.6.28-brescia</property>
@@ -103,5 +102,5 @@ Hebi-no-Sekigae https://github.com/Hebi-no-Sekigae</property>
 Noëlle https://github.com/jannuary
 Alvar Lagerlöf https://github.com/alvarlagerlof
 Ezekiel Smith https://github.com/ZekeSmith</property>
-  </template>
+  </object>
 </interface>

--- a/src/window.py
+++ b/src/window.py
@@ -41,7 +41,7 @@ from bottles.views.importer import ImporterView
 from bottles.views.loading import LoadingView
 
 from bottles.dialogs.crash import CrashReportDialog
-from bottles.dialogs.generic import AboutDialog, SourceDialog
+from bottles.dialogs.generic import SourceDialog
 from bottles.dialogs.onboard import OnboardDialog
 from bottles.dialogs.journal import JournalDialog
 from bottles.dialogs.depscheck import DependenciesCheckDialog
@@ -367,7 +367,11 @@ class MainWindow(Adw.ApplicationWindow):
         quit()
 
     def show_about_dialog(self, *args):
-        AboutDialog(self).present()
+        builder = Gtk.Builder.new_from_resource("/com/usebottles/bottles/about.ui")
+        about_window = builder.get_object("about_window")
+        about_window.set_transient_for(self)
+        about_window.present()
+
 
     @staticmethod
     def open_url(widget, url):


### PR DESCRIPTION
# Description
Don't depend on template for about window anymore, since AdwAboutWindow
is a final class and doesn't support using it as a template.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - navigade to about window
    - go through each section, make sure everything displays properly
    - test if pressing `esc` crashes bottles