### PR TITLE
Fix padding in launch option menu

### DIFF
--- a/src/ui/details-bottle.ui
+++ b/src/ui/details-bottle.ui
@@ -130,10 +130,13 @@
                     </object>
                 </child>
                 <child>
-                    <object class="GtkSeparator" id="extra_separator"/>
+                    <object class="GtkSeparator" id="extra_separator">
+                        <property name="margin-bottom">5</property>
+                    </object>
                 </child>
                 <child>
                     <object class="GtkBox" id="box_history">
+                        <property name="spacing">5</property>
                         <property name="orientation">vertical</property>
                     </object>
                 </child>
@@ -362,4 +365,5 @@
         </child>
     </object>
 </interface>
+
 


### PR DESCRIPTION
# Description
Currently the dropdown for launch options had bad/no padding for the recently launched applications:
![Screenshot from 2022-07-12 10-21-52](https://user-images.githubusercontent.com/60044824/178446648-07d48b7c-efb1-4692-9a13-259bb38b3f88.png)

This is how it looks with this pr:
![Screenshot from 2022-07-12 10-26-36](https://user-images.githubusercontent.com/60044824/178446846-caf46ac3-50fe-4503-b6e1-93772ff52bd6.png)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - Navigate to new menu
    - Verify UI changes
    - Verify that buttons still work