### PR TITLE
Stop user from skipping onboard dialog

### DIFF
--- a/src/dialogs/onboard.py
+++ b/src/dialogs/onboard.py
@@ -39,6 +39,7 @@ class OnboardDialog(Adw.Window):
     page_download = Gtk.Template.Child()
     page_finish = Gtk.Template.Child()
     img_welcome = Gtk.Template.Child()
+    label_skip = Gtk.Template.Child()
     # endregion
 
     carousel_pages = [
@@ -68,6 +69,8 @@ class OnboardDialog(Adw.Window):
         self.btn_next.connect("clicked", self.__next_page)
         self.btn_install.connect("clicked", self.__install_runner)
         self.__settings.connect("notify::gtk-application-prefer-dark-theme", self.__theme_changed)
+
+        self.btn_close.set_sensitive(False)
 
         if self.__settings.get_property("gtk-application-prefer-dark-theme"):
             self.img_welcome.set_from_resource(self.images[1])
@@ -108,6 +111,8 @@ class OnboardDialog(Adw.Window):
 
     def __install_runner(self, widget):
         def set_completed(result, error=False):
+            self.label_skip.set_visible(False)
+            self.btn_close.set_sensitive(True)
             self.__next_page()
 
         self.__installing = True

--- a/src/ui/onboard.ui
+++ b/src/ui/onboard.ui
@@ -115,14 +115,26 @@
                                         <property name="hexpand">True</property>
                                         <property name="valign">center</property>
                                         <property name="child">
-                                            <object class="GtkButton" id="btn_close">
-                                                <property name="label" translatable="yes">Start using Bottles</property>
-                                                <property name="use-underline">True</property>
-                                                <property name="halign">center</property>
-                                                <style>
-                                                    <class name="suggested-action"/>
-                                                    <class name="pill"/>
-                                                </style>
+                                            <object class="GtkBox">
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="label_skip">
+                                                        <property name="label" translatable="yes">Please Finish the setup first</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="margin-bottom">5</property>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkButton" id="btn_close">
+                                                        <property name="label" translatable="yes">Start using Bottles</property>
+                                                        <property name="use-underline">True</property>
+                                                        <property name="halign">center</property>
+                                                        <style>
+                                                            <class name="suggested-action"/>
+                                                            <class name="pill"/>
+                                                        </style>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </property>
                                     </object>


### PR DESCRIPTION
# Description
This stops the user from skipping the onboarding.

Fixes #1803 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - remove bottles data directory
    - open bottles
    - try to skip onboard, doesn't work
    - complete onboarding as intended, works without any issues
