### PR TITLE
Don't allow user to create empty bottle names

### DIFF
--- a/src/ui/new.ui
+++ b/src/ui/new.ui
@@ -36,6 +36,7 @@
                         <child type="end">
                             <object class="GtkButton" id="btn_create">
                                 <property name="label" translatable="yes">Create</property>
+                                <property name="sensitive">False</property>
                                 <style>
                                     <class name="suggested-action"/>
                                 </style>

--- a/src/utils/gtk.py
+++ b/src/utils/gtk.py
@@ -22,7 +22,7 @@ class GtkUtils:
     @staticmethod
     def validate_entry(entry) -> bool:
         text = entry.get_text()
-        if re.search("[@!#$%^&*()<>?/|}{~:.;,'\"]", text):
+        if re.search("[@!#$%^&*()<>?/|}{~:.;,'\"]", text) or len(text) == 0 or text.isspace():
             entry.add_css_class("error")
             return False
         else:


### PR DESCRIPTION
# Description
The user currently is able to create bottles with empty names or names only consisting of spaces, this shouldn't be possible

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - Try to create bottle with empty name, fails
    - Try to only fill bottle name with tabs or spaces, fails 