### PR TITLE
Improve library menu button

### DIFF
--- a/com.usebottles.bottles.dev.yml
+++ b/com.usebottles.bottles.dev.yml
@@ -80,6 +80,15 @@ cleanup-commands:
 modules:
   # Python modules
   # ----------------------------------------------------------------------------
+  - name: python-pillow
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app --root=/
+    sources:
+      - type: archive
+        url: https://github.com/python-pillow/Pillow/archive/refs/tags/9.2.0.tar.gz
+        sha256: 95836f00972dbf724bf1270178683a0ac4ea23c6c3a980858fc9f2f9456e32ef
+
   - name: PyYAML
     buildsystem: simple
     build-commands:

--- a/src/ui/library-entry.ui
+++ b/src/ui/library-entry.ui
@@ -31,7 +31,7 @@
                 <property name="width-request">256</property>
                 <property name="height-request">384</property>
                 <child type="overlay">
-                    <object class="GtkMenuButton">
+                    <object class="GtkMenuButton" id="btn_menu">
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <property name="margin-top">5</property>
@@ -39,8 +39,7 @@
                         <property name="popover">pop_context</property>
                         <property name="icon-name">view-more-symbolic</property>
                         <style>
-                            <class name="osd"/>
-                            <class name="circular"/>
+                            <class name="flat"/>
                         </style>
                     </object>
                 </child>
@@ -153,3 +152,4 @@
         </style>
     </template>
 </interface>
+

--- a/src/views/library.py
+++ b/src/views/library.py
@@ -32,11 +32,13 @@ class LibraryView(Adw.Bin):
     scroll_window = Gtk.Template.Child()
     main_flow = Gtk.Template.Child()
     status_page = Gtk.Template.Child()
+    style_provider = Gtk.CssProvider()
     # endregion
 
     def __init__(self, window, **kwargs):
         super().__init__(**kwargs)
         self.window = window
+        self.css = b""
         self.update()
 
     def update(self):
@@ -57,6 +59,17 @@ class LibraryView(Adw.Bin):
         library_manager = LibraryManager()
         library_manager.remove_from_library(uuid)
         self.update()
+
+    def add_css_entry(self, entry, color):
+        gtk_context = self.get_style_context()
+        Gtk.StyleContext.add_class(entry.btn_menu.get_style_context(), entry.entry['name']+"_menu_button")
+        self.css = self.css+b"\n"+b"."+bytes(entry.entry["name"], 'utf-8')+b"_menu_button { color: rgba("+bytes(str(color), 'utf-8')+b","+bytes(str(color), 'utf-8')+b","+bytes(str(color), 'utf-8')+b", 255); }"
+        self.style_provider.load_from_data(self.css)
+        Gtk.StyleContext.add_provider(
+            entry.btn_menu.get_style_context(),
+            self.style_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
 
     def go_back(self, widget=False):
         self.window.main_leaf.navigate(Adw.NavigationDirection.BACK)

--- a/src/widgets/library.py
+++ b/src/widgets/library.py
@@ -17,6 +17,8 @@
 
 import logging
 import os
+import math
+from PIL import Image
 from datetime import datetime
 from gettext import gettext as _
 from gi.repository import Gtk, Gdk, GLib, GdkPixbuf, Adw
@@ -43,6 +45,7 @@ class LibraryEntry(Gtk.Box):
     label_no_cover = Gtk.Template.Child()
     img_cover = Gtk.Template.Child()
     img_icon = Gtk.Template.Child()
+    btn_menu = Gtk.Template.Child()
 
     # endregion
 
@@ -79,6 +82,7 @@ class LibraryEntry(Gtk.Box):
             #self.img_cover.set_paintable(texture)
             self.img_cover.set_visible(True)
             self.label_no_cover.set_visible(False)
+            self.__calculate_button_color(path=path)
 
         self.btn_run.connect("clicked", self.run_executable)
         self.btn_launch_steam.connect("clicked", self.run_steam)
@@ -146,6 +150,15 @@ class LibraryEntry(Gtk.Box):
 
     def __remove_entry(self, widget):
         self.library.remove_entry(self.uuid)
+
+    def __calculate_button_color(self, path):
+        image = Image.open(path)
+        image = image.crop((0, 0, 47, 58))
+        image.thumbnail((150, 150))
+        palette = image.convert('P', palette=Image.ADAPTIVE, colors=1).getpalette()
+        rgb = (255-palette[0], 255-palette[1], 255-palette[2])
+        button_color = math.floor(0.299*rgb[0])+math.floor(0.587*rgb[1])+math.floor(0.144*rgb[2])
+        self.library.add_css_entry(entry=self, color=button_color)
 
     def run_executable(self, widget, with_terminal=False):
         executor = WineExecutor(


### PR DESCRIPTION
# Description
The color of the menu button for library entries now adjusts after the
thumbnail image of the game, to make a better contrast

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - Add games to library
    - Check if menu button adjusts to game thumbnail
    - switch between dark/light mode to see if the menu buttons are affected
