### PR TITLE
Fix invalid css issue for library menu buttons

### DIFF
--- a/src/views/library.py
+++ b/src/views/library.py
@@ -16,6 +16,7 @@
 #
 
 import logging
+import re
 from datetime import datetime
 from gettext import gettext as _
 from gi.repository import Gtk, Gdk, GLib, Adw
@@ -62,8 +63,8 @@ class LibraryView(Adw.Bin):
 
     def add_css_entry(self, entry, color):
         gtk_context = self.get_style_context()
-        Gtk.StyleContext.add_class(entry.btn_menu.get_style_context(), entry.entry['name']+"_menu_button")
-        self.css = self.css+b"\n"+b"."+bytes(entry.entry["name"], 'utf-8')+b"_menu_button { color: rgba("+bytes(str(color), 'utf-8')+b","+bytes(str(color), 'utf-8')+b","+bytes(str(color), 'utf-8')+b", 255); }"
+        Gtk.StyleContext.add_class(entry.btn_menu.get_style_context(), re.sub('[~!@$%^&*()+=,./\';:"?><\[\]\{}|`#]', '', entry.entry["name"]).strip(' ')+"_menu_button")
+        self.css = self.css+b"\n"+b"."+bytes(re.sub('[~!@$%^&*()+=,./\';:"?><\[\]\{}|`#]', '', entry.entry["name"]).strip(' '), 'utf-8')+b"_menu_button { color: rgba("+bytes(str(color), 'utf-8')+b","+bytes(str(color), 'utf-8')+b","+bytes(str(color), 'utf-8')+b", 255); }"
         self.style_provider.load_from_data(self.css)
         Gtk.StyleContext.add_provider(
             entry.btn_menu.get_style_context(),


### PR DESCRIPTION
# Description
This stops bottles from adding invalid css classes to buttons which causes them to loose the color they're supposed to have, causing it to potentially have bad contrast with the thumbnail.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
    - Go to library view
    - check if menu button for library entry (in this case notepad++) has bad contrast
