### PR TITLE
Remove mention of AUR and unofficial packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ translate Bottles in your language or how to help improve existing ones.
 
 ## ↗️ Install
 Bottles is officially provided as [Flatpak](https://flathub.org/apps/details/com.usebottles.bottles).
-There are also other packages maintained by our community, like Fedora, 
-[AUR (bottles-git)](https://aur.archlinux.org/packages/bottles-git/), [CachyOS AUR](https://github.com/CachyOS/linux-cachyos#we-are-providing-a-repo-which-includes-all-kernels-in-generic-v3-and-generic-and-more-optimized-packages), and MX Linux.
 
 Read [here](https://docs.usebottles.com/getting-started/installation) how to
 install Bottles on your distribution.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@
   <a href="https://github.com/bottlesdevs/Bottles/actions">
     <img src="https://github.com/bottlesdevs/Bottles/workflows/Build%20release%20packages/badge.svg">
   </a>
-  <a href="https://aur.archlinux.org/packages/bottles/">
-    <img alt="AUR version" src="https://img.shields.io/aur/version/bottles">
-  </a>
   <br>
   <a href="https://stopthemingmy.app" title="Please do not theme this app">
     <img src="https://stopthemingmy.app/badge.svg">
@@ -77,7 +74,7 @@ translate Bottles in your language or how to help improve existing ones.
 - Layers (dependencies and programs on different layers) [#510](https://github.com/bottlesdevs/Bottles/issues/510)
 
 ## ↗️ Install
-Bottles is officially provided as [Flatpak](https://flathub.org/apps/details/com.usebottles.bottles) and [AUR package](https://aur.archlinux.org/packages/bottles/). 
+Bottles is officially provided as [Flatpak](https://flathub.org/apps/details/com.usebottles.bottles).
 There are also other packages maintained by our community, like Fedora, 
 [AUR (bottles-git)](https://aur.archlinux.org/packages/bottles-git/), [CachyOS AUR](https://github.com/CachyOS/linux-cachyos#we-are-providing-a-repo-which-includes-all-kernels-in-generic-v3-and-generic-and-more-optimized-packages), and MX Linux.
 


### PR DESCRIPTION
# Description
Since we let go of the AUR package, let's stop mentioning it as an official package.

Proposal: I think we should stop mentioning unofficial packages altogether. Flatpak is officially maintained and always in the latest version. Users typically get a subpar experience with distro packages because they have to deal with outdated libs, overlooked dependencies, etc. and may stop using the app and come up with the wrong conclusion.

All in favor? @mirkobrombin @jannuary @axtloss

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update