### PR TITLE
Remove reference to removed packages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ install Bottles on your distribution.
 We are happy to see packaged Bottles but we ask you to respect some small rules:
 - The package must be `bottles`, in other distributions it is possible to use suffixes (e.g. `bottles-git` on Arch Linux for the git based package) while on others the RDNN format is required (e.g. `com.usebottles.bottles` on elementary OS and Flathub repository). All other nomenclatures are discouraged.
 - Do not package external files and do not make changes to the code, no hard script. Obviously with the exception of files essential for packaging.
-Once the package is published, you can open a [Pull Request](https://github.com/bottlesdevs/Bottles/pulls) to add it to the packages table above! Thanks :heart:!
 - Package version should follow the CalVer model (year.month.day) and the release cycle of the project. Bottles has 2 released per month: one on 14th and one on 28th. When an hotfix came, this will be appended to the release (e.g. 2022.2.14-1). Bottles as a codename too which is not mandatory and currently only used by the Flatpak.
 
 ## Shortcuts


### PR DESCRIPTION
# Description
Removes reference to a table of third party packages not in the readme anymore

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
