### PR TITLE
Add file preloading/caching 

### DIFF
--- a/com.usebottles.bottles.dev.json
+++ b/com.usebottles.bottles.dev.json
@@ -220,6 +220,21 @@
       ]
     },
     {
+      "name": "vmtouch",
+      "buildsystem": "simple",
+      "build-commands" : [
+        "make",
+	"make install PREFIX=/app"
+      ],
+      "sources": [
+        {
+	  "type": "git",
+	  "url": "https://github.com/hoytech/vmtouch",
+	  "commit": "8f6898e3c027f445962e223ca7a7b33d40395fc6"
+	}
+      ]
+    },
+    {
       "name": "vulkan-tools",
       "buildsystem": "cmake-ninja",
       "config-opts": [

--- a/com.usebottles.bottles.dev.yml
+++ b/com.usebottles.bottles.dev.yml
@@ -194,6 +194,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/hoytech/vmtouch
+        commit: 8f6898e3c027f445962e223ca7a7b33d40395fc6
     build-commands:
       - make
       - make install PREFIX=/app

--- a/com.usebottles.bottles.dev.yml
+++ b/com.usebottles.bottles.dev.yml
@@ -189,6 +189,14 @@ modules:
 
   # Tools / Codecs
   # ----------------------------------------------------------------------------
+  - name: vmtouch
+    buildsystem: simple
+    sources:
+      - type: git
+        url: https://github.com/hoytech/vmtouch
+    build-commands:
+      - make
+      - make install PREFIX=/app
   - name: vulkan-tools
     buildsystem: cmake-ninja
     config-opts:

--- a/src/backend/globals.py
+++ b/src/backend/globals.py
@@ -96,6 +96,7 @@ gamemode_available = shutil.which("gamemoderun") or False
 gamescope_available = shutil.which("gamescope") or False
 mangohud_available = shutil.which("mangohud") or False
 obs_vkc_available = shutil.which("obs-vkcapture") or False
+vmtouch_available = shutil.which("vmtouch") or False
 
 x_display = DisplayUtils.get_x_display()
 

--- a/src/backend/models/samples.py
+++ b/src/backend/models/samples.py
@@ -63,7 +63,7 @@ class Samples:
             "versioning_exclusion_patterns": False,
             "vmtouch": False,
             "vmtouch_cache_cwd": False,
-            "vmtouch_max_file_size": 0,
+            "vmtouch_max_file_size": 500,
             "vmtouch_lock_memory": False
         },
         "Sandbox": {

--- a/src/backend/models/samples.py
+++ b/src/backend/models/samples.py
@@ -62,9 +62,7 @@ class Samples:
             "versioning_automatic": False,
             "versioning_exclusion_patterns": False,
             "vmtouch": False,
-            "vmtouch_cache_cwd": False,
-            "vmtouch_max_file_size": 500,
-            "vmtouch_lock_memory": False
+            "vmtouch_cache_cwd": False
         },
         "Sandbox": {
             # "share_paths_ro": [], # TODO: implement

--- a/src/backend/models/samples.py
+++ b/src/backend/models/samples.py
@@ -62,7 +62,7 @@ class Samples:
             "versioning_automatic": False,
             "versioning_exclusion_patterns": False,
             "vmtouch": False,
-            "vmtouch_cached_files": [],
+            "vmtouch_cache_cwd": False,
             "vmtouch_max_file_size": 0,
             "vmtouch_lock_memory": False
         },

--- a/src/backend/models/samples.py
+++ b/src/backend/models/samples.py
@@ -61,6 +61,10 @@ class Samples:
             "versioning_compression": False,
             "versioning_automatic": False,
             "versioning_exclusion_patterns": False,
+            "vmtouch": False,
+            "vmtouch_cached_files": [],
+            "vmtouch_max_file_size": 0,
+            "vmtouch_lock_memory": False
         },
         "Sandbox": {
             # "share_paths_ro": [], # TODO: implement

--- a/src/backend/runner.py
+++ b/src/backend/runner.py
@@ -20,7 +20,7 @@ from typing import NewType
 
 from bottles.utils.threading import RunAsync  # pyright: reportMissingImports=false
 from bottles.backend.logger import Logger
-from bottles.backend.globals import gamemode_available, gamescope_available, mangohud_available, obs_vkc_available
+from bottles.backend.globals import gamemode_available, gamescope_available, mangohud_available, obs_vkc_available, vmtouch_available
 from bottles.backend.managers.runtime import RuntimeManager
 from bottles.backend.models.result import Result
 from bottles.backend.utils.manager import ManagerUtils

--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -11,7 +11,7 @@ from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.utils.display import DisplayUtils
 from bottles.backend.utils.gpu import GPUUtils
 from bottles.backend.globals import Paths, gamemode_available, gamescope_available, mangohud_available, \
-    obs_vkc_available
+    obs_vkc_available, vmtouch_available
 from bottles.backend.logger import Logger
 from bottles.utils.threading import RunAsync
 
@@ -508,7 +508,7 @@ class WineCommand:
         return " ".join(gamescope_cmd)
 
     def vmtouch_preload(self):
-        vmtouch_command = "/app/bin/vmtouch"
+        vmtouch_command = vmtouch_available
         vmtouch_flags = "-t -v -l -d"
         vmtouch_file_size = " -m 1024M"
         if self.command.find("C:\\") > 0:
@@ -529,7 +529,7 @@ class WineCommand:
         )
         vmtouch_command = "/app/bin/vmtouch"
         vmtouch_flags = "-e -v"
-        command = vmtouch_command+" "+vmtouch_flags+" "+self.vmtouch_files
+        command = vmtouch_available+" "+vmtouch_flags+" "+self.vmtouch_files
         subprocess.Popen(
             command,
             shell=True,
@@ -541,7 +541,7 @@ class WineCommand:
         if None in [self.runner, self.env]:
             return
 
-        if self.config["Parameters"].get("vmtouch"):
+        if vmtouch_available and self.config["Parameters"].get("vmtouch"):
             self.vmtouch_preload()
 
         if self.config["Parameters"].get("sandbox"):
@@ -577,7 +577,7 @@ class WineCommand:
         res = proc.communicate()[0]
         enc = detect_encoding(res)
 
-        if self.config["Parameters"].get("vmtouch"):
+        if vmtouch_available and self.config["Parameters"].get("sandbox"):
             self.vmtouch_free()
 
         if enc is not None:

--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -510,7 +510,7 @@ class WineCommand:
     def vmtouch_preload(self):
         vmtouch_command = "/app/bin/vmtouch"
         vmtouch_flags = "-t -v -l -d"
-        vmtouch_file_size = " -m "+str(self.config["Parameters"].get("vmtouch_max_file_size"))+"M"
+        vmtouch_file_size = " -m 1024M"
         if self.command.find("C:\\") > 0:
             self.vmtouch_files = "'"+(self.cwd+"/"+(self.command.split(" ")[-1].split('\\')[-1])).replace('\'', "")+"'"
         else:

--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -507,20 +507,34 @@ class WineCommand:
         return " ".join(gamescope_cmd)
 
     def vmtouch_preload(self):
+        vmtouch_command = "/app/bin/vmtouch"
         print("!!using vmtouch!!")
         print("command:")
         print(self.command)
         print("cwd:")
         print(self.cwd)
         print("main executable:")
+        #if self.config["Parameters"].get("vmtouch_lock_memory"):
+        #    vmtouch_flags = "-t -v -L"
+        #else:
+        vmtouch_flags = "-t -v -l"
+
+        vmtouch_file_size = " -m "+str(self.config["Parameters"].get("vmtouch_max_file_size"))+"M"
         if self.command.find("C:\\") > 0:
-            executable = (self.cwd+"/"+(self.command.split(" ")[-1].split('\\')[-1])).replace('\'', "")
+            vmtouch_files = (self.cwd+"/"+(self.command.split(" ")[-1].split('\\')[-1])).replace('\'', "")
         else:
-            executable = self.command.split(" ")[-1]
+            vmtouch_files = self.command.split(" ")[-1]
+
+        if self.config["Parameters"].get("vmtouch_cache_cwd"):
+            vmtouch_files = vmtouch_files+"' '"+self.cwd+"/"
+        print("command pre split")
+        print(self.command)
+        print("command post split")
         print(self.command.split(" ")[-1])
         print("executable")
-        print(executable)
-        self.command = "/app/bin/vmtouch -t -l -v '"+executable+"' & "+self.command
+        print(vmtouch_files)
+        self.command = vmtouch_command+" "+vmtouch_flags+" "+vmtouch_file_size+" '"+vmtouch_files+"' & "+self.command
+        print(self.command)
 
     def run(self):
         if None in [self.runner, self.env]:

--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -506,9 +506,28 @@ class WineCommand:
 
         return " ".join(gamescope_cmd)
 
+    def vmtouch_preload(self):
+        print("!!using vmtouch!!")
+        print("command:")
+        print(self.command)
+        print("cwd:")
+        print(self.cwd)
+        print("main executable:")
+        if self.command.find("C:\\") > 0:
+            executable = (self.cwd+"/"+(self.command.split(" ")[-1].split('\\')[-1])).replace('\'', "")
+        else:
+            executable = self.command.split(" ")[-1]
+        print(self.command.split(" ")[-1])
+        print("executable")
+        print(executable)
+        self.command = "/app/bin/vmtouch -t -l -v '"+executable+"' & "+self.command
+
     def run(self):
         if None in [self.runner, self.env]:
             return
+
+        if self.config["Parameters"].get("vmtouch"):
+            self.vmtouch_preload()
 
         if self.config["Parameters"].get("sandbox"):
             permissions = self.config["Sandbox"]

--- a/src/backend/wine/winecommand.py
+++ b/src/backend/wine/winecommand.py
@@ -508,7 +508,6 @@ class WineCommand:
         return " ".join(gamescope_cmd)
 
     def vmtouch_preload(self):
-        vmtouch_command = vmtouch_available
         vmtouch_flags = "-t -v -l -d"
         vmtouch_file_size = " -m 1024M"
         if self.command.find("C:\\") > 0:
@@ -518,7 +517,7 @@ class WineCommand:
 
         if self.config["Parameters"].get("vmtouch_cache_cwd"):
             self.vmtouch_files = "'"+self.vmtouch_files+"' '"+self.cwd+"/'"
-        self.command = vmtouch_command+" "+vmtouch_flags+" "+vmtouch_file_size+" "+self.vmtouch_files+" && "+self.command
+        self.command = vmtouch_available+" "+vmtouch_flags+" "+vmtouch_file_size+" "+self.vmtouch_files+" && "+self.command
 
     def vmtouch_free(self):
         subprocess.Popen(
@@ -527,7 +526,6 @@ class WineCommand:
             env=self.env,
             cwd=self.cwd,
         )
-        vmtouch_command = "/app/bin/vmtouch"
         vmtouch_flags = "-e -v"
         command = vmtouch_available+" "+vmtouch_flags+" "+self.vmtouch_files
         subprocess.Popen(

--- a/src/dialogs/meson.build
+++ b/src/dialogs/meson.build
@@ -24,6 +24,7 @@ bottles_sources = [
   'depscheck.py',
   'exclusionpatterns.py',
   'upgradeversioning.py',
+  'vmtouch.py',
 ]
 
 install_data(bottles_sources, install_dir: dialogsdir)

--- a/src/dialogs/vmtouch.py
+++ b/src/dialogs/vmtouch.py
@@ -1,0 +1,73 @@
+# vmtouch.py
+#
+# Copyright 2022 axtlos <axtlos@tar.black>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+from gi.repository import Gtk, GLib, Adw
+
+
+@Gtk.Template(resource_path='/com/usebottles/bottles/dialog-vmtouch.ui')
+class VmtouchDialog(Adw.Window):
+    __gtype_name__ = 'VmtouchDialog'
+
+    # region Widgets
+    switch_cache_cwd = Gtk.Template.Child()
+    arg_max_size = Gtk.Template.Child()
+    switch_lock_all = Gtk.Template.Child()
+    btn_save = Gtk.Template.Child()
+    btn_cancel = Gtk.Template.Child()
+
+    # endregion
+
+    def __init__(self, window, config, **kwargs):
+        super().__init__(**kwargs)
+        self.set_transient_for(window)
+
+        # common variables and references
+        self.window = window
+        self.manager = window.manager
+        self.config = config
+
+        # connect signals
+        self.btn_save.connect("clicked", self.__save)
+
+        self.__update(config)
+
+    def __update(self, config):
+        parameters = config["Parameters"]
+        self.switch_cache_cwd.set_state(parameters["vmtouch_cache_cwd"])
+        self.arg_max_size.set_text(str(parameters["vmtouch_max_file_size"]))
+        self.switch_lock_all.set_state(parameters["vmtouch_lock_memory"])
+
+    def __idle_save(self, *_args):
+        settings = {"vmtouch_cache_cwd": self.switch_cache_cwd.get_state(),
+                    "vmtouch_max_file_size": int(self.arg_max_size.get_text()),
+                    "vmtouch_lock_memory": self.switch_lock_all.get_state()}
+
+        for setting in settings.keys():
+            self.manager.update_config(
+                config=self.config,
+                key=setting,
+                value=settings[setting],
+                scope="Parameters"
+            )
+
+        self.destroy()
+
+    def __save(self, *_args):
+        GLib.idle_add(self.__idle_save)
+

--- a/src/dialogs/vmtouch.py
+++ b/src/dialogs/vmtouch.py
@@ -27,7 +27,7 @@ class VmtouchDialog(Adw.Window):
     # region Widgets
     switch_cache_cwd = Gtk.Template.Child()
     arg_max_size = Gtk.Template.Child()
-    switch_lock_all = Gtk.Template.Child()
+    #switch_lock_all = Gtk.Template.Child()
     btn_save = Gtk.Template.Child()
     btn_cancel = Gtk.Template.Child()
 
@@ -51,12 +51,12 @@ class VmtouchDialog(Adw.Window):
         parameters = config["Parameters"]
         self.switch_cache_cwd.set_state(parameters["vmtouch_cache_cwd"])
         self.arg_max_size.set_text(str(parameters["vmtouch_max_file_size"]))
-        self.switch_lock_all.set_state(parameters["vmtouch_lock_memory"])
+        #self.switch_lock_all.set_state(parameters["vmtouch_lock_memory"])
 
     def __idle_save(self, *_args):
         settings = {"vmtouch_cache_cwd": self.switch_cache_cwd.get_state(),
-                    "vmtouch_max_file_size": int(self.arg_max_size.get_text()),
-                    "vmtouch_lock_memory": self.switch_lock_all.get_state()}
+                    "vmtouch_max_file_size": int(self.arg_max_size.get_text())}
+                    #"vmtouch_lock_memory": self.switch_lock_all.get_state()}
 
         for setting in settings.keys():
             self.manager.update_config(

--- a/src/dialogs/vmtouch.py
+++ b/src/dialogs/vmtouch.py
@@ -26,8 +26,6 @@ class VmtouchDialog(Adw.Window):
 
     # region Widgets
     switch_cache_cwd = Gtk.Template.Child()
-    arg_max_size = Gtk.Template.Child()
-    #switch_lock_all = Gtk.Template.Child()
     btn_save = Gtk.Template.Child()
     btn_cancel = Gtk.Template.Child()
 
@@ -50,13 +48,9 @@ class VmtouchDialog(Adw.Window):
     def __update(self, config):
         parameters = config["Parameters"]
         self.switch_cache_cwd.set_state(parameters["vmtouch_cache_cwd"])
-        self.arg_max_size.set_text(str(parameters["vmtouch_max_file_size"]))
-        #self.switch_lock_all.set_state(parameters["vmtouch_lock_memory"])
 
     def __idle_save(self, *_args):
-        settings = {"vmtouch_cache_cwd": self.switch_cache_cwd.get_state(),
-                    "vmtouch_max_file_size": int(self.arg_max_size.get_text())}
-                    #"vmtouch_lock_memory": self.switch_lock_all.get_state()}
+        settings = {"vmtouch_cache_cwd": self.switch_cache_cwd.get_state()}
 
         for setting in settings.keys():
             self.manager.update_config(

--- a/src/ui/bottles.gresource.xml
+++ b/src/ui/bottles.gresource.xml
@@ -49,6 +49,7 @@
         <file>dialog-deps-check.ui</file>
         <file>dialog-exclusion-patterns.ui</file>
         <file>dialog-upgrade-versioning.ui</file>
+        <file>dialog-vmtouch.ui</file>
         <file>onboard.ui</file>
         <file>about.ui</file>
     </gresource>

--- a/src/ui/details-preferences.ui
+++ b/src/ui/details-preferences.ui
@@ -576,7 +576,7 @@
                   <object class="AdwActionRow">
                     <property name="activatable-widget">switch_vmtouch</property>
                     <property name="title" translatable="yes">Vmtouch</property>
-                    <property name="subtitle" translatable="yes">Preload game files into ram</property>
+                    <property name="subtitle" translatable="yes">Preload game files into RAM</property>
                     <child>
                       <object class="GtkButton" id="btn_manage_vmtouch">
                         <property name="tooltip-text" translatable="yes">Manage vmtouch settings</property>

--- a/src/ui/details-preferences.ui
+++ b/src/ui/details-preferences.ui
@@ -573,6 +573,28 @@
                     </object>
                 </child>
                 <child>
+                  <object class="AdwActionRow">
+                    <property name="activatable-widget">switch_vmtouch</property>
+                    <property name="title" translatable="yes">Vmtouch</property>
+                    <property name="subtitle" translatable="yes">Preload game files into ram</property>
+                    <child>
+                      <object class="GtkButton" id="btn_manage_vmtouch">
+                        <property name="tooltip-text" translatable="yes">Manage vmtouch settings</property>
+                        <property name="valign">center</property>
+                        <property name="icon-name">applications-system-symbolic</property>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="switch_vmtouch">
+                        <property name="valign">center</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
                     <object class="AdwActionRow" id="row_cwd">
                         <property name="activatable-widget">btn_cwd</property>
                         <property name="title" translatable="yes">Working Directory</property>

--- a/src/ui/dialog-vmtouch.ui
+++ b/src/ui/dialog-vmtouch.ui
@@ -66,18 +66,6 @@
                                       <property name="title" translatable="yes">Maximum file size to cache</property>
                                     </object>
                                 </child>
-                                <child>
-                                    <object class="AdwActionRow">
-                                        <property name="title" translatable="yes">Lock everything in memory</property>
-                                        <property name="subtitle" translatable="yes">This will lock everything related to vmtouch in memory</property>
-                                        <property name="activatable-widget">switch_lock_all</property>
-                                        <child>
-                                            <object class="GtkSwitch" id="switch_lock_all">
-                                                <property name="valign">center</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
                             </object>
                         </child>
                     </object>

--- a/src/ui/dialog-vmtouch.ui
+++ b/src/ui/dialog-vmtouch.ui
@@ -58,16 +58,6 @@
                                 </child>
                             </object>
                         </child>
-                        <child>
-                            <object class="AdwPreferencesGroup">
-                                <property name="title" translatable="yes">Miscellaneous</property>
-                                <child>
-                                    <object class="AdwEntryRow" id="arg_max_size">
-                                      <property name="title" translatable="yes">Maximum file size to cache</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
                     </object>
                 </child>
             </object>

--- a/src/ui/dialog-vmtouch.ui
+++ b/src/ui/dialog-vmtouch.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <requires lib="gtk" version="4.0"/>
+    <requires lib="libadwaita" version="1.0"/>
+    <template class="VmtouchDialog" parent="AdwWindow">
+        <property name="modal">True</property>
+        <property name="default-width">550</property>
+        <property name="title" translatable="yes">Vmtouch Settings</property>
+        <child>
+            <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <child>
+                    <object class="AdwHeaderBar">
+                    <property name="show-end-title-buttons">False</property>
+                        <child type="start">
+                            <object class="GtkButton" id="btn_cancel">
+                                <property name="label" translatable="yes">_Cancel</property>
+                                <property name="use_underline">True</property>
+                                <property name="action_name">window.close</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkShortcutController">
+                                <child>
+                                    <object class="GtkShortcut">
+                                        <property name="trigger">Escape</property>
+                                        <property name="action">action(window.close)</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child type="end">
+                            <object class="GtkButton" id="btn_save">
+                                <property name="label" translatable="yes">Save</property>
+                                <style>
+                                    <class name="suggested-action"/>
+                                </style>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwPreferencesPage">
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <property name="title" translatable="yes">Files to cache</property>
+                                <property name="description" translatable="yes">Select which files should be cached alongside the main executable.</property>
+                                <child>
+                                    <object class="AdwActionRow">
+                                        <property name="title" translatable="yes">Cache work directory</property>
+                                        <property name="activatable-widget">switch_cache_cwd</property>
+                                        <child>
+                                            <object class="GtkSwitch" id="switch_cache_cwd">
+                                                <property name="valign">center</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <property name="title" translatable="yes">Miscellaneous</property>
+                                <child>
+                                    <object class="AdwEntryRow" id="arg_max_size">
+                                      <property name="title" translatable="yes">Maximum file size to cache</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="AdwActionRow">
+                                        <property name="title" translatable="yes">Lock everything in memory</property>
+                                        <property name="subtitle" translatable="yes">This will lock everything related to vmtouch in memory</property>
+                                        <property name="activatable-widget">switch_lock_all</property>
+                                        <child>
+                                            <object class="GtkSwitch" id="switch_lock_all">
+                                                <property name="valign">center</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+            </object>
+        </child>
+    </template>
+</interface>

--- a/src/views/bottle_preferences.py
+++ b/src/views/bottle_preferences.py
@@ -39,6 +39,7 @@ from bottles.dialogs.gamescope import GamescopeDialog
 from bottles.dialogs.sandbox import SandboxDialog
 from bottles.dialogs.protonalert import ProtonAlertDialog
 from bottles.dialogs.exclusionpatterns import ExclusionPatternsDialog
+from bottles.dialogs.vmtouch import VmtouchDialog
 
 from bottles.backend.wine.catalogs import win_versions
 from bottles.backend.wine.reg import Reg
@@ -55,6 +56,7 @@ class PreferencesView(Adw.PreferencesPage):
     btn_manage_gamescope = Gtk.Template.Child()
     btn_manage_sandbox = Gtk.Template.Child()
     btn_manage_versioning_patterns = Gtk.Template.Child()
+    btn_manage_vmtouch = Gtk.Template.Child()
     btn_cwd = Gtk.Template.Child()
     btn_cwd_reset = Gtk.Template.Child()
     row_dxvk = Gtk.Template.Child()
@@ -95,6 +97,7 @@ class PreferencesView(Adw.PreferencesPage):
     switch_versioning_compression = Gtk.Template.Child()
     switch_auto_versioning = Gtk.Template.Child()
     switch_versioning_patterns = Gtk.Template.Child()
+    switch_vmtouch = Gtk.Template.Child()
     toggle_sync = Gtk.Template.Child()
     toggle_esync = Gtk.Template.Child()
     toggle_fsync = Gtk.Template.Child()
@@ -147,6 +150,7 @@ class PreferencesView(Adw.PreferencesPage):
         self.btn_manage_gamescope.connect("clicked", self.__show_gamescope_settings)
         self.btn_manage_sandbox.connect("clicked", self.__show_sandbox_settings)
         self.btn_manage_versioning_patterns.connect("clicked", self.__show_exclusionpatterns_settings)
+        self.btn_manage_vmtouch.connect("clicked", self.__show_vmtouch_settings)
         self.btn_cwd.connect("clicked", self.choose_cwd)
         self.btn_cwd_reset.connect("clicked", self.choose_cwd, True)
         self.toggle_sync.connect('toggled', self.__set_wine_sync)
@@ -175,6 +179,7 @@ class PreferencesView(Adw.PreferencesPage):
         self.switch_versioning_compression.connect('state-set', self.__toggle_versioning_compression)
         self.switch_auto_versioning.connect('state-set', self.__toggle_auto_versioning)
         self.switch_versioning_patterns.connect('state-set', self.__toggle_versioning_patterns)
+        self.switch_vmtouch.connect('state-set', self.__toggle_vmtouch)
         self.combo_fsr.connect('changed', self.__set_fsr_level)
         self.combo_virt_res.connect('changed', self.__set_virtual_desktop_res)
         self.combo_dpi.connect('changed', self.__set_custom_dpi)
@@ -374,6 +379,7 @@ class PreferencesView(Adw.PreferencesPage):
         self.switch_versioning_patterns.set_active(parameters["versioning_exclusion_patterns"])
         self.switch_runtime.set_active(parameters["use_runtime"])
         self.switch_steam_runtime.set_active(parameters["use_steam_runtime"])
+        self.switch_vmtouch.set_active(parameters["vmtouch"])
 
         self.toggle_sync.set_active(parameters["sync"] == "wine")
         self.toggle_esync.set_active(parameters["sync"] == "esync")
@@ -498,6 +504,13 @@ class PreferencesView(Adw.PreferencesPage):
     def __show_environment_variables(self, widget=False):
         """Show the environment variables dialog"""
         new_window = EnvVarsDialog(
+            window=self.window,
+            config=self.config
+        )
+        new_window.present()
+
+    def __show_vmtouch_settings(self, widget):
+        new_window = VmtouchDialog(
             window=self.window,
             config=self.config
         )
@@ -762,6 +775,15 @@ class PreferencesView(Adw.PreferencesPage):
         self.config = self.manager.update_config(
             config=self.config,
             key="versioning_exclusion_patterns",
+            value=state,
+            scope="Parameters"
+        ).data["config"]
+
+    def __toggle_vmtouch(self, widget=False, state=False):
+        """Toggle vmtouch for current bottle"""
+        self.config = self.manager.update_config(
+            config=self.config,
+            key="vmtouch",
             value=state,
             scope="Parameters"
         ).data["config"]

--- a/src/views/bottle_preferences.py
+++ b/src/views/bottle_preferences.py
@@ -25,7 +25,7 @@ from bottles.utils.threading import RunAsync  # pyright: reportMissingImports=fa
 from bottles.utils.gtk import GtkUtils
 
 from bottles.backend.runner import Runner, gamemode_available, gamescope_available, mangohud_available, \
-    obs_vkc_available
+    obs_vkc_available, vmtouch_available
 from bottles.backend.managers.runtime import RuntimeManager
 from bottles.backend.utils.manager import ManagerUtils
 
@@ -209,6 +209,7 @@ class PreferencesView(Adw.PreferencesPage):
         self.btn_manage_gamescope.set_sensitive(gamescope_available)
         self.switch_mangohud.set_sensitive(mangohud_available)
         self.switch_obsvkc.set_sensitive(obs_vkc_available)
+        self.switch_vmtouch.set_sensitive(vmtouch_available)
         _not_available = _("This feature is not available on your system.")
         if not gamemode_available:
             self.switch_gamemode.set_tooltip_text(_not_available)
@@ -219,6 +220,8 @@ class PreferencesView(Adw.PreferencesPage):
             self.switch_mangohud.set_tooltip_text(_not_available)
         if not obs_vkc_available:
             self.switch_obsvkc.set_tooltip_text(_not_available)
+        if not vmtouch_available:
+            self.switch_vmtouch.set_tooltip_text(_not_available)
 
     def __check_entry_name(self, *_args):
         self.__valid_name = GtkUtils.validate_entry(self.entry_name)


### PR DESCRIPTION
# Description
This allows bottles to preload files into cache before starting the application, causing faster loading times in games and applications.

Fixes #1329 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B

---

Currently I only have the actual precaching implemented, freeing the cache after the application quits isn't yet implemented and the ui probably needs some tweaks too.