### PR TITLE
Bugfix glob file copy_dll

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -544,8 +544,8 @@ class DependencyManager:
             if "*" in step.get('file_name'):
                 files = glob(f"{path}/{step.get('file_name')}")
                 for fg in files:
-                    _name = fg
-                    _path = os.path.join(path, step.get("file_name"), _name)
+                    _name = fg.split("/")[-1]
+                    _path = os.path.join(path, _name)
                     _dest = os.path.join(dest, _name)
                     logging.info(f"Copying {_name} to {_dest}")
 


### PR DESCRIPTION
The old code tried to copy the dll's over themselves (giving a `SameFileError`) because `_path` and `_dest` would be the same.

Fixes #(issue)
https://github.com/bottlesdevs/dependencies/issues/120

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Installing dependencies `d3dcompiler_43`, `d3dcompiler_47`, `d3dx9`, and `d3dx11` now works properly.