### PR TITLE
Revert "make switch_theme visible"

### DIFF
--- a/bottles/frontend/ui/preferences.ui
+++ b/bottles/frontend/ui/preferences.ui
@@ -18,7 +18,7 @@
                             <object class="AdwActionRow" id="row_theme">
                                 <property name="title" translatable="yes">Dark Mode</property>
                                 <property name="subtitle" translatable="yes">Whether Bottles should use the dark color scheme.</property>
-                                <property name="visible">True</property>
+                                <property name="visible">False</property>
                                 <property name="activatable-widget">switch_theme</property>
                                 <child>
                                     <object class="GtkSwitch" id="switch_theme">


### PR DESCRIPTION
The dark mode switch should be invisible by default as to not appear on systems with color scheme preference.
