### PR TITLE
Remember last used view in topmost `AdwViewStack`

### DIFF
--- a/bottles/frontend/windows/main_window.py
+++ b/bottles/frontend/windows/main_window.py
@@ -177,7 +177,17 @@ class MainWindow(Adw.ApplicationWindow):
             self.page_list.search_bar.set_key_capture_widget(self)
             self.btn_search.bind_property('active', self.page_list.search_bar, 'search-mode-enabled',
                                           GObject.BindingFlags.BIDIRECTIONAL)
-            self.stack_main.set_visible_child_name("page_list")
+
+            if self.stack_main.get_child_by_name(self.settings.get_string("startup-view")) is None:
+                self.stack_main.set_visible_child_name("page_list")
+
+            self.settings.bind(
+                "startup-view",
+                self.stack_main,
+                "visible-child-name",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+
             self.lock_ui(False)
             self.headerbar.get_style_context().remove_class("flat")
 

--- a/data/com.usebottles.bottles.gschema.xml
+++ b/data/com.usebottles.bottles.gschema.xml
@@ -57,7 +57,7 @@
       <description>Toggle release candidate for runners.</description>
     </key>
     <key type="s" name="startup-view">
-      <default>'page_add'</default>
+      <default>'page_library'</default>
       <summary>Startup view</summary>
       <description>Choose which view the application should be started in.</description>
     </key>


### PR DESCRIPTION
# Description
Quoting the commit message
```
It makes sense to start the application in the main view where it was
closed. For example, it is plausible that most users set up their
bottles once and then want to land directly in the library view after
launch.

This behavior is also known from other programs such as web browsers or
GNOME Calendar, and it seems that Bottles once handled it this way in
the past. Therefore the gsettings key `startup-view` has now been
(re)activated and represents the last selected view in the main window.
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- Manually, by building Bottles and testing the changes
