### PR TITLE
build: Depend on Meson 0.59

### DIFF
--- a/bottles/meson.build
+++ b/bottles/meson.build
@@ -4,7 +4,7 @@ moduledir = join_paths(pkgdatadir, 'bottles')
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)

--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,14 @@
 project(
 	'bottles',
 	version: '2022.8.28-brescia-2',
-	meson_version: '>= 0.50.0',
+	meson_version: '>= 0.59.0',
 	default_options: [
 		'warning_level=2',
 	],
   	license: 'GPL-3.0-or-later'
 )
 
+gnome = import('gnome')
 i18n = import('i18n')
 localedir = get_option('localedir')
 
@@ -15,4 +16,8 @@ subdir('po')
 subdir('bottles')
 subdir('data')
 
-meson.add_install_script('build-aux/meson/postinstall.py')
+gnome.post_install(
+	glib_compile_schemas: true,
+	gtk_update_icon_cache: true,
+	update_desktop_database: true,
+)


### PR DESCRIPTION
# Description
Bump meson version to 0.59, the latest installed in gnome runtime 42. It obsoletes the post_install.py script by using a function from the gnome module in meson. Inspired by https://gitlab.gnome.org/GNOME/gnome-sound-recorder/-/merge_requests/192

Should the post_install.py script be removed?


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] Ran the project in gnome-builder and it worked as expected

