### PR TITLE
Set GST_PLUGIN_SYSTEM_PATH in flatpak manifest

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -206,8 +206,6 @@ class WineCommand:
         # Get Runner libraries
         runner_path = ManagerUtils.get_runner_path(config.get("Runner"))
         if arch == "win64":
-            if "FLATPAK_ID" in os.environ:
-                env.add("GST_PLUGIN_SYSTEM_PATH", "/usr/lib/x86_64-linux-gnu/gstreamer-1.0")
             runner_libs = [
                 "lib/wine/x86_64-unix",
                 "lib32/wine/x86_64-unix",
@@ -217,8 +215,6 @@ class WineCommand:
                 "lib64/wine/i386-unix"
             ]
         else:
-            if "FLATPAK_ID" in os.environ:
-                env.add("GST_PLUGIN_SYSTEM_PATH", "/usr/lib/i386-linux-gnu/gstreamer-1.0")
             runner_libs = [
                 "lib/wine/i386-unix",
                 "lib32/wine/i386-unix",

--- a/com.usebottles.bottles.dev.json
+++ b/com.usebottles.bottles.dev.json
@@ -20,6 +20,7 @@
     "--talk-name=org.freedesktop.Notifications",
     "--env=LD_LIBRARY_PATH=/app/lib:/app/lib32",
     "--env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/",
+    "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0",
     "--require-version=1.1.2"
   ],
   "inherit-extensions": [

--- a/com.usebottles.bottles.dev.yml
+++ b/com.usebottles.bottles.dev.yml
@@ -20,6 +20,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
   - --require-version=1.1.2
 
 inherit-extensions:


### PR DESCRIPTION
It accommodates both 64-bit and 32-bit programs with caveat that
32-bit users will be seeing benign gstreamer warnings.

# Description
Set the GST_PLUGIN_SYSTEM_PATH variable in flatpak manifests in a way that accomodates both 64-bit and 32-bit programs. This reduces a bit the flatpak work-arounds that we have in the app. The lutris flatpak sets this variable this way, so you could say it is already tested plus was worked on by @TheEvilSkeleton 

Fixes #2023 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] Ran program in #2023 and can no longer reproduce the bug
- [X] Also ran 64-bit games, Cult of the Lamb and Hades and, they still worked as expected
