### PR TITLE
Updates the Components section of the Bottle Preferences

### DIFF
--- a/bottles/frontend/ui/details-preferences.blp
+++ b/bottles/frontend/ui/details-preferences.blp
@@ -230,7 +230,7 @@ template DetailsPreferences : .AdwPreferencesPage {
 
     [header-suffix]
     Button btn_manage_components {
-      tooltip-text: _("Manage Components Versions");
+      tooltip-text: _("Manage Component Versions");
       valign: center;
       icon-name: "applications-system-symbolic";
 
@@ -240,7 +240,7 @@ template DetailsPreferences : .AdwPreferencesPage {
     }
 
     .AdwExpanderRow exp_components {
-      title: _("Components");
+      title: _("Runner Components");
 
       .AdwActionRow row_runner {
         activatable-widget: "combo_runner";

--- a/bottles/frontend/ui/details-preferences.blp
+++ b/bottles/frontend/ui/details-preferences.blp
@@ -241,6 +241,7 @@ template DetailsPreferences : .AdwPreferencesPage {
 
     .AdwExpanderRow exp_components {
       title: _("Runner Components");
+      subtitle: _("Manage components, such as the Wine runner used.")
 
       .AdwActionRow row_runner {
         activatable-widget: "combo_runner";

--- a/bottles/frontend/ui/details-preferences.blp
+++ b/bottles/frontend/ui/details-preferences.blp
@@ -241,7 +241,7 @@ template DetailsPreferences : .AdwPreferencesPage {
 
     .AdwExpanderRow exp_components {
       title: _("Runner Components");
-      subtitle: _("Manage components, such as the Wine runner used.")
+      subtitle: _("Manage components, such as the Wine runner used.");
 
       .AdwActionRow row_runner {
         activatable-widget: "combo_runner";


### PR DESCRIPTION
I was looking for a way to change the runner easily a while ago, and missed this option. This would make it more visible, and with a note, so that the user doesn't accidentally miss it.