### PR TITLE
Add Kron4ek menu options for runners

### DIFF
--- a/bottles/frontend/views/new.py
+++ b/bottles/frontend/views/new.py
@@ -82,7 +82,7 @@ class NewView(Adw.Window):
         for runner in self.manager.runners_available:
             self.combo_runner.append(runner, runner)
 
-        rs, rc, rv, rl, ry = [], [], [], [], []
+        rs, rc, rv, rl, rk, ry = [], [], [], [], [], []
 
         for i in self.manager.runners_available:
             if i.startswith('soda'):
@@ -93,6 +93,8 @@ class NewView(Adw.Window):
                 rv.append(i)
             elif i.startswith('lutris'):
                 rl.append(i)
+            elif i.startswith('kron4ek'):
+                rk.append(i)
             elif i.startswith('sys-'):
                 ry.append(i)
 
@@ -104,6 +106,8 @@ class NewView(Adw.Window):
             self.runner = rv[0]
         elif len(rl) > 0:  # use the latest from lutris
             self.runner = rl[0]
+        elif len(rk) > 0:  # use the latest from kron4ek
+            self.runner = rk[0]
         elif len(ry) > 0:  # use the latest from system
             self.runner = ry[0]
         else:  # use any other runner available

--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -201,9 +201,10 @@ class PreferencesWindow(Adw.PreferencesWindow):
         exp_vaniglia = ComponentExpander("Vaniglia", _("Based on Wine upstream, includes staging patches."))
         exp_proton = ComponentExpander("GE Proton", _("Based on Valve's Wine, includes staging, Proton and "
                                                       "Steam-specific patches. Requires the Steam Runtime turned on."))
+        exp_kron4ek = ComponentExpander("Kron4ek", _ ("Based on Wine upstream, staging, TkG, and Proton."))
         exp_other = ComponentExpander(_("Other"))
 
-        count = {"soda": 0, "caffe": 0, "wine-ge": 0, "lutris": 0, "vaniglia": 0, "proton": 0, "other": 0}
+        count = {"soda": 0, "caffe": 0, "wine-ge": 0, "lutris": 0, "vaniglia": 0, "kron4ek": 0, "proton": 0, "other": 0}
 
         for runner in self.manager.supported_wine_runners.items():
             _runner_name = runner[0].lower()
@@ -227,6 +228,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
             elif _runner_name.startswith("vaniglia"):
                 exp_vaniglia.add_row(_entry)
                 count["vaniglia"] += 1
+            elif _runner_name.startswith("kron4ek"):
+                exp_kron4ek.add_row(_entry)
+                count["kron4ek"] += 1
             else:
                 exp_other.add_row(_entry)
                 count["other"] += 1
@@ -255,6 +259,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
         if count["vaniglia"] > 0:
             self.list_runners.add(exp_vaniglia)
             self.__registry.append(exp_vaniglia)
+        if count["kron4ek"] > 0:
+            self.list_runners.add(exp_kron4ek)
+            self.__registry.append(exp_kron4ek)
         if count["proton"] > 0:
             self.list_runners.add(exp_proton)
             self.__registry.append(exp_proton)


### PR DESCRIPTION
# Description
This is to enable https://github.com/bottlesdevs/components/pull/167

It adds a menu option for the [Kron4ek Wine runners](https://github.com/Kron4ek/Wine-Builds).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.

1. Build Flatpak with provided JSON (had to remove the <url> tags out of the appdata file for it to fully build)
2. Clone https://github.com/keenanweaver/components/tree/kron4ek somewhere
3. Launch with LOCAL_COMPONENTS=/path/to/clonedir flatpak run
4. Download runners, apply to bottles, etc.
