### PR TITLE
Safely access `program` "dict" keys

### DIFF
--- a/bottles/backend/wine/executor.py
+++ b/bottles/backend/wine/executor.py
@@ -118,8 +118,8 @@ class WineExecutor:
         return cls(
             config=config,
             exec_path=program["path"],
-            args=program["arguments"],
-            cwd=program["folder"],
+            args=program.get("arguments", ""),
+            cwd=program.get("folder", None),
             post_script=program.get("script", None),
             terminal=terminal,
             override_dxvk=dxvk,


### PR DESCRIPTION
# Description
I've encountered with a bug when adding a Program via the plus icon. If the program is run right after being created, an error is thrown because the dictionary doesn't contain the `arguments` key.
I'm not sure if this is expected or if the dict should contain the key with an empty string.
Restarting Bottles and running the program seems to provide these defaults so it works ok after a restart.

What I did in the PR is to safely access the dictionary values and provide a default when they don't exist, which fixes the issue. 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

