### PR TITLE
Use portal for setting the Bottles Directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,10 @@
         "./build/var/run/host/lib/python3.10/site-packages"
     ],
     "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/node_modules/*/**": true,
+        "**/.hg/store/**": true,
         "**/.dart_tool": true,
         ".flatpak/**": true,
         "_build/**": true

--- a/bottles/frontend/ui/preferences.blp
+++ b/bottles/frontend/ui/preferences.blp
@@ -126,32 +126,32 @@ template PreferencesWindow : .AdwPreferencesWindow {
 
     .AdwPreferencesGroup {
       title: _("Advanced");
-
       .AdwActionRow action_bottles_path {
-        title: _("Custom Bottles Path (Requires Restart)");
-        subtitle: _("Choose where to store the new bottles (this will not move the existing ones).");
-        activatable-widget: "btn_bottles_path";
-
-        Button btn_bottles_path_reset {
-          tooltip-text: _("Reset to default");
-          valign: center;
-          visible: false;
-          icon-name: "edit-undo-symbolic";
-
-          styles [
-            "flat",
-          ]
-        }
-
-        Button btn_bottles_path {
-          tooltip-text: _("Choose a directory");
-          halign: center;
-          valign: center;
-          icon-name: "document-open-symbolic";
-
-          styles [
-            "flat",
-          ]
+        title: _("Bottles Directory");
+        subtitle: _("Directory that contains the data of your Bottles.");
+        activatable: True;
+        .GtkBox {
+          spacing: 6;
+          Button btn_bottles_path_reset {
+            tooltip-text: _("Reset to default");
+            valign: center;
+            visible: false;
+            icon-name: "edit-undo-symbolic";
+            styles ["flat"]
+          }
+          .GtkImage {
+            icon-name: folder-symbolic;
+            styles ["dim-label"]
+          }
+          .GtkLabel label_bottles_path {
+            ellipsize: end;
+            label: _("(Default)");
+            styles ["dim-label"]
+          }
+          .GtkImage {
+            icon-name: go-next-symbolic;
+            styles ["dim-label"]
+          }
         }
       }
     }

--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -25,7 +25,6 @@ from bottles.frontend.windows.filechooser import FileChooser
 
 from bottles.backend.managers.data import DataManager
 
-
 @Gtk.Template(resource_path='/com/usebottles/bottles/preferences.ui')
 class PreferencesWindow(Adw.PreferencesWindow):
     __gtype_name__ = 'PreferencesWindow'
@@ -54,8 +53,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
     action_prerelease = Gtk.Template.Child()
     action_bottles_path = Gtk.Template.Child()
     action_steam_proton = Gtk.Template.Child()
-    btn_bottles_path = Gtk.Template.Child()
     btn_bottles_path_reset = Gtk.Template.Child()
+    label_bottles_path = Gtk.Template.Child()
     btn_steam_proton_doc = Gtk.Template.Child()
     pref_core = Gtk.Template.Child()
 
@@ -78,7 +77,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
         bottles_path = self.data.get("custom_bottles_path")
         if bottles_path:
-            self.action_bottles_path.set_subtitle(bottles_path)
+            self.label_bottles_path.set_label(os.path.basename(bottles_path))
             self.btn_bottles_path_reset.set_visible(True)
 
         # bind widgets
@@ -107,7 +106,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.settings.connect('changed::dark-theme', self.__toggle_night)
         self.settings.connect('changed::release-candidate', self.__toggle_rc)
         self.settings.connect('changed::update-date', self.__toggle_update_date)
-        self.btn_bottles_path.connect('clicked', self.__choose_bottles_path)
+        self.action_bottles_path.connect('activated', self.__choose_bottles_path)
         self.btn_bottles_path_reset.connect('clicked', self.__reset_bottles_path)
         self.btn_steam_proton_doc.connect('clicked', self.__open_steam_proton_doc)
 
@@ -139,30 +138,43 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def __choose_bottles_path(self, widget):
         def set_path(_dialog, response, _file_dialog):
-            self.btn_bottles_path_reset.set_visible(True)
-            if response == Gtk.ResponseType.OK:
+            if response == Gtk.ResponseType.ACCEPT:
                 _file = _file_dialog.get_file()
                 self.data.set("custom_bottles_path", _file.get_path())
-                self.action_bottles_path.set_subtitle(_file.get_path())
+                self.label_bottles_path.set_label(os.path.basename(_file.get_path()))
+                self.btn_bottles_path_reset.set_visible(True)
+                dialog = Adw.MessageDialog.new(
+                    self.window,
+                    _("Directory Will be Updated on Next Launch"),
+                    _("Bottles has to be relaunched to change the data directory.")
+                )
+                dialog.add_response("ok", _("OK"))
+                dialog.present()
             else:
-                self.action_bottles_path.set_subtitle(
-                    _("Choose where to store the new bottles (this will not move the existing ones)."))
+                if self.data.get("custom_bottles_path") is not None:
+                    self.label_bottles_path.set_label(os.path.basename(self.data.get("custom_bottles_path")))
             _file_dialog.destroy()
 
         FileChooser(
             parent=self.window,
-            title=_("Choose new bottles path"),
+            title=_("Choose new Bottles path"),
             action=Gtk.FileChooserAction.SELECT_FOLDER,
             buttons=(_("Cancel"), _("Select")),
-            native=False,
-            callback=set_path
+            callback=set_path,
+            native=True
         )
 
     def __reset_bottles_path(self, widget):
         self.data.remove("custom_bottles_path")
         self.btn_bottles_path_reset.set_visible(False)
-        self.action_bottles_path.set_subtitle(
-            _("Choose where to store the new bottles (this will not move the existing ones)."))
+        self.label_bottles_path.set_label(_("(Default)"))
+        dialog = Adw.MessageDialog.new(
+            self.window,
+            _("Directory Will be Updated on Next Launch"),
+            _("Bottles has to be relaunched to change the data directory.")
+        )
+        dialog.add_response("ok", _("OK"))
+        dialog.present()
 
     def populate_runtimes_list(self):
         for runtime in self.manager.supported_runtimes.items():


### PR DESCRIPTION
This commit adds support for using portals to set the Bottles Directory

# Description
Please include a summary of the change and which issue is fixed (if available). 
Please also include relevant motivation and context.

This PR should let the Bottles Directory option in the preferences use portals in Flatpak (so you can actually use custom paths in the flatpak version).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- Compile the Bottles Flatpak and install it
- Go into preferences and select a folder. A portal should show up
- select a folder and click on it
- your path should be /run/user/1000/doc/xdg/portal/stuff/foldername. this means xdg-document-portal is working and is giving the flatpak persistent access to the folder.
- try rebooting
it seemed to still have access after rebooting my system
