### PR TITLE
backend: Fix Gamescope arguments

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -472,7 +472,7 @@ class WineCommand:
                     f.write("".join(file))
 
                 # Update command
-                command = f"{self.__get_gamescope_cmd(return_steam_cmd)} {gamescope_run}"
+                command = f"{self.__get_gamescope_cmd(return_steam_cmd)} -- {gamescope_run}"
 
                 # Set file as executable
                 st = os.stat(gamescope_run)


### PR DESCRIPTION
# Description
Fix Gamescope incorrectly being passed the apps' arguments. Fixes #2165.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Start GOG Galaxy with Gamescope activated
