### PR TITLE
Update cli.in

### DIFF
--- a/bottles/frontend/cli/cli.in
+++ b/bottles/frontend/cli/cli.in
@@ -365,6 +365,7 @@ class CLI:
         _program = {
             "arguments": _launch_options if _launch_options else "",
             "executable": _executable,
+            "name": _name,
             "folder": _folder,
             "icon": "",
             "id": _uuid,


### PR DESCRIPTION
# Description
Added the "name" parameter to the program created from bottles-cli in 'add'. This is motivated by setup scripts performing automatic bottle/program creation without use of the GUI.

Fixes https://github.com/bottlesdevs/Bottles/issues/2186

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Steps: 
- Install bottles
- Add a single bottle
- Use bottles-cli to add 2 programs to this bottle, such as:
```flatpak run --command=bottles-cli com.usebottles.bottles.dev add -b gw2_acct1 -p "/home/zhensley/Downloads/Gw2Setup-64.exe" -n Gw2-64 -l "__GL_THREADED_OPTIMIZATIONS=1 DXVK_ASYNC=1 %command% -shareArchive -autologin"
flatpak run --command=bottles-cli com.usebottles.bottles.dev add -b gw2_acct1 -p "/home/zhensley/Downloads/Gw2Setup-64.exe" -n Gw2-64_update -l "__GL_THREADED_OPTIMIZATIONS=1 DXVK_ASYNC=1 %command%"
```
- Verify program names via bottles-cli command: `flatpak run --command=bottles-cli com.usebottles.bottles.dev programs -b gw2_acct1`
- Verify program names in bottles/program listing in the GUI

Expected results: '-n' arguments are reflected as the name of the programs in the bottle
Results before the patch: '-n' arguments are ignored, programs are named after the executable name only
Results after the patch: '-n' arguments are listed as the names of the programs, matching the expected results
