### PR TITLE
backend: Don't use d3d10 & d3d10_1 dll's from dxvk

### DIFF
--- a/bottles/backend/dlls/dxvk.py
+++ b/bottles/backend/dlls/dxvk.py
@@ -23,16 +23,12 @@ class DXVKComponent(DLLComponent):
     dlls = {
         "x32": [
             "d3d9.dll",
-            "d3d10.dll",
-            "d3d10_1.dll",
             "d3d10core.dll",
             "d3d11.dll",
             "dxgi.dll"
         ],
         "x64": [
             "d3d9.dll",
-            "d3d10.dll",
-            "d3d10_1.dll",
             "d3d10core.dll",
             "d3d11.dll",
             "dxgi.dll"


### PR DESCRIPTION
# Description
Removes the use of `d3d10.dll` & `d3d10_1.dll` that are shipped along with dxvk. They are helper libraries while the main Direct3D 10 implementation is in `d3d10core.dll`.
They were never fully implemented and aren't installed by default in the official dxvk setup script or in Steam Proton. The devs recommend using wine's own as they work better and are more complete. (The Windows versions also work)

Fixes usage of dxvk 2.0.0 when it releases since these dll's will have been removed. Also allows using current dxvk master if you want to. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) :shrug: I guess
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I wanted to test with dxvk master and so put it in bottles dxvk directory. But i found it wouldn't work and bottles errored on startup. Had to modify `dxvk.py` and remove these dll's from the managed list.
