### PR TITLE
Fix installer completion

### DIFF
--- a/bottles/frontend/windows/installer.py
+++ b/bottles/frontend/windows/installer.py
@@ -185,8 +185,8 @@ class InstallerDialog(Adw.Window):
     def __installed(self):
         self.set_deletable(False)
         self.stack.set_visible_child_name("page_installed")
-        self.window.page_details.update_programs()
-        self.window.page_details.set_visible_child_name("programs")
+        self.window.page_details.view_bottle.update_programs()
+        self.window.page_details.go_back_sidebar()
 
     def __error(self, error):
         self.set_deletable(True)


### PR DESCRIPTION
# Description
* Fixes error: `AttributeError: 'DetailsView' object has no attribute 'update_programs'.`
* Fixes navigation back to bottle view on installer completion

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Ran installer for GOG Galaxy. Check no errors on completion and correct navigation back.
