### PR TITLE
Fix deadlock of Popen.wait

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -616,7 +616,6 @@ class WineCommand:
                     env=self.env,
                     cwd=self.cwd
                 )
-                proc.wait()
             except FileNotFoundError:
                 return
                 


### PR DESCRIPTION
# Description
Hello!
Recently I've encountered with a very weird bug when running a program in Terminal mode vs Non terminal mode.
When running with the regular mode, after a while the program would hang and I would have to force close. Surprisingly enough, running with the terminal mode (the one that runs easyterm.py), everything was going ok.

After some debugging I found that the culprit was the call to `proc.wait()` in `winecommand.py`. In the Python docs there is a note regarding the mix of `proc.wait()` and the stdout PIPE. After the process generates enough output, it will deadlock. On my tests, removing the `wait` works as expected.

The wait call was introduced in this commit https://github.com/bottlesdevs/Bottles/commit/942f18d5534572ca916513090de936d24d710467

 Given that `proc.communicate()` is already being called, it should behave the same, it already blocks until the process finishes. But I don't have enough context to know why the wait call was needed in the original commit.

![image](https://user-images.githubusercontent.com/22084723/201533369-3af0d351-f4ba-4192-83f3-bc114ec4aff4.png)


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

