### PR TITLE
Fix Latencyflex not disabling correctly and environment variables

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -344,7 +344,7 @@ class WineCommand:
                     gpu_envs = discrete["envs"]
                     for p in gpu_envs:
                         env.add(p, gpu_envs[p])
-                    env.add("VK_ICD_FILENAMES", discrete["icd"])
+                    env.concat("VK_ICD_FILENAMES", discrete["icd"])
 
             # VK_ICD
             if not env.has("VK_ICD_FILENAMES"):
@@ -353,7 +353,7 @@ class WineCommand:
                     System support PRIME but user disabled the discrete GPU
                     setting (previus check skipped), so using the integrated one.
                     '''
-                    env.add("VK_ICD_FILENAMES", gpu["prime"]["integrated"]["icd"])
+                    env.concat("VK_ICD_FILENAMES", gpu["prime"]["integrated"]["icd"])
                 else:
                     '''
                     System doesn't support PRIME, so using the first result
@@ -361,7 +361,7 @@ class WineCommand:
                     '''
                     if "vendors" in gpu and len(gpu["vendors"]) > 0:
                         _first = list(gpu["vendors"].keys())[0]
-                        env.add("VK_ICD_FILENAMES", gpu["vendors"][_first]["icd"])
+                        env.concat("VK_ICD_FILENAMES", gpu["vendors"][_first]["icd"])
                     else:
                         logging.warning("No GPU vendor found, keep going without setting VK_ICD_FILENAMES…")
 

--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -910,7 +910,7 @@ class PreferencesView(Adw.PreferencesPage):
     def __set_latencyflex(self, *_args):
         """Set the latency flex value"""
         self.queue.add_task()
-        if(self.combo_latencyflex.get_selected) == 0:
+        if self.combo_latencyflex.get_selected() == 0:
             RunAsync(
             task_func=self.manager.install_dll_component,
             callback=self.set_latencyflex_status,


### PR DESCRIPTION
# Description
Here is a fix for Latency flex.

First, the function to disable it was not called correctly, resulting in the fact that LatencyFlex was never disabling itself after it was enabled once.

Other fix is that the `VK_ICD_FILENAMES` was not set correctly: currently, it would only be assigned to the LatencyFlex JSON, so it would not have the JSON for the GPU, making games crash at launch. This fixes the issue by changing all the `env.add()` of the variable `VK_ICD_FILENAMES` to `env.concat()`. That way, no code is overwriting the variable, and the games load correctly.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update