### PR TITLE
Fixed setup of dll overrides on bottle start

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -185,7 +185,8 @@ class WineCommand:
 
         # Default DLL overrides
         if not return_steam_env:
-            dll_overrides.append("mshtml=d")
+            if all(not s.startswith("mshtml") for s in dll_overrides):
+                dll_overrides.append("mshtml=d")
             dll_overrides.append("winemenubuilder=''")
 
         # Get Runtime libraries

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -185,7 +185,7 @@ class WineCommand:
 
         # Default DLL overrides
         if not return_steam_env:
-            if all(not s.startswith("mshtml") for s in dll_overrides):
+            if all(not s.startswith("mshtml=") for s in dll_overrides):
                 dll_overrides.append("mshtml=d")
             dll_overrides.append("winemenubuilder=''")
 

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -67,7 +67,7 @@ class WineEnv:
             values = [values]
         values = sep.join(values)
 
-        if self.has(key) and self.__env[key]:
+        if self.has(key):
             values = self.__env[key] + sep + values
         self.add(key, values, True)
 

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -67,7 +67,7 @@ class WineEnv:
             values = [values]
         values = sep.join(values)
 
-        if self.has(key):
+        if self.has(key) and self.__env[key]:
             values = self.__env[key] + sep + values
         self.add(key, values, True)
 
@@ -159,6 +159,8 @@ class WineCommand:
         if config.get("Environment_Variables"):
             for var in config.get("Environment_Variables").items():
                 env.add(var[0], var[1], override=True)
+                if (var[0] == "WINEDLLOVERRIDES") and var[1]:
+                    dll_overrides.extend(var[1].split(";"))
 
         # Environment variables from argument
         if environment:


### PR DESCRIPTION
# Description
This PR makes 2 changes:
1.  If WINEDLLOVERRIDES environment variable defined in bottle's settings, it is added to final list of DLL overrides which is passed to wine.
2.  MSHTML can be enabled now through bottle's settings interface (DLL Overrides or Environment Variables), when it's needed to some apps.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
