### PR TITLE
Fix bottle name space error

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -889,6 +889,16 @@ class Manager:
         wineserver = WineServer(_config)
         bottle_path = ManagerUtils.get_bottle_path(config)
 
+        # Fix pathing error, where space is converted to _ in file name, but not in the path that bottle uses
+        # Replace spaces in file path with _ to solve this issue:
+        bottle_path_tmp = ""
+        for character in bottle_path:
+            if character != " ":
+                bottle_path_tmp = bottle_path_tmp + character
+            else:
+                bottle_path_tmp = bottle_path_tmp + "_"
+        bottle_path = bottle_path_tmp 
+
         if key == "sync":
             '''
             Workaround <https://github.com/bottlesdevs/Bottles/issues/916>


### PR DESCRIPTION
# Description
Fixes start-up error caused by space in bottle name

Fixes #(issue)
Bottle name is "ov2 backup ", and it caused this error on next startup:

Error while running async job: <function MainWindow.__on_start.<locals>.get_manager at 0x.....>
	Exception: [Errno 2] No such file or directory: '/...../.local/share/bottles/bottles/ov2 backup /bottle.yml'

## Type of change
- Bug fix (non-breaking change which fixes an issue)
