### PR TITLE
Fix bottle renaming

### DIFF
--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -213,6 +213,7 @@ class PreferencesView(Adw.PreferencesPage):
         self.__valid_name = GtkUtils.validate_entry(self.entry_name)
 
     def __save_name(self, *_args):
+        self.__check_entry_name()
         if not self.__valid_name:
             self.entry_name.set_text(self.config.get("Name"))
             self.__valid_name = True


### PR DESCRIPTION
# Description
Previously, the check_entry_name method was not called when renaming a bottle, meaning valid_name wasn't set and bottles could not be renamed.  

Fixes #2304

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Altered bottle_preferences.py on my Bottles Flatpak install and verified that renaming works
