### PR TITLE
frontend/cli: run: Allow multiple arguments to pass to executable

### DIFF
--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -243,7 +243,7 @@ class ManagerUtils:
             with open(desktop_file, "w") as f:
                 f.write(f"[Desktop Entry]\n")
                 f.write(f"Name={program.get('name')}\n")
-                f.write(f"Exec={cmd_cli} run -p {shlex.quote(program.get('name'))} -b '{config.get('Name')}'\n")
+                f.write(f"Exec={cmd_cli} run -p {shlex.quote(program.get('name'))} -b '{config.get('Name')} -- %u'\n")
                 f.write(f"Type=Application\n")
                 f.write(f"Terminal=false\n")
                 f.write(f"Categories=Application;\n")

--- a/bottles/frontend/cli/cli.in
+++ b/bottles/frontend/cli/cli.in
@@ -135,8 +135,8 @@ class CLI:
         run_parser = subparsers.add_parser("run", help="Run a program")
         run_parser.add_argument("-b", "--bottle", help="Bottle name", required=True)
         run_parser.add_argument("-e", "--executable", help="Path to the executable")
-        run_parser.add_argument("-a", "--args", help="Arguments to pass to the executable")
         run_parser.add_argument("-p", "--program", help="Program to run")
+        run_parser.add_argument("args", nargs="*", action="extend", help="Arguments to pass to the executable")
 
         standalone_parser = subparsers.add_parser("standalone", help="Generate a standalone script to launch commands "
                                                                      "without passing trough Bottles")
@@ -535,7 +535,7 @@ class CLI:
         self.utils_conn = ConnectionUtils(force_offline=True)  # avoid manager checks
         _bottle = self.args.bottle
         _program = self.args.program
-        _args = "" if self.args.args is None else self.args.args
+        _args = " ".join(self.args.args)
         _executable = self.args.executable
         _cwd = None
         _script = None

--- a/bottles/frontend/cli/cli.in
+++ b/bottles/frontend/cli/cli.in
@@ -136,6 +136,8 @@ class CLI:
         run_parser.add_argument("-b", "--bottle", help="Bottle name", required=True)
         run_parser.add_argument("-e", "--executable", help="Path to the executable")
         run_parser.add_argument("-p", "--program", help="Program to run")
+        run_parser.add_argument("--args-replace", action='store_false', dest='keep_args',
+            help="Replace current program arguments, instead of append")
         run_parser.add_argument("args", nargs="*", action="extend", help="Arguments to pass to the executable")
 
         standalone_parser = subparsers.add_parser("standalone", help="Generate a standalone script to launch commands "
@@ -535,6 +537,7 @@ class CLI:
         self.utils_conn = ConnectionUtils(force_offline=True)  # avoid manager checks
         _bottle = self.args.bottle
         _program = self.args.program
+        _keep = self.args.keep_args
         _args = " ".join(self.args.args)
         _executable = self.args.executable
         _cwd = None
@@ -566,7 +569,8 @@ class CLI:
 
             program = [p for p in programs if p["name"] == _program][0]
             _executable = program.get("path", "")
-            _args = program.get("arguments", "")
+            if _keep:
+                _args = program.get("arguments", "") + " " + _args
             _cwd = program.get("folder", "")
             _script = program.get("script", None)
 


### PR DESCRIPTION
### frontend/cli: run: Allow multiple arguments to pass to executable and escape them

E.g.
```
bottles-cli run -b bottle -e x.exe arg1 arg2
bottles-cli run -b bottle -e x.exe -- --arg1=val arg2
```
Fixes https://github.com/bottlesdevs/Bottles/issues/2305

Will break expected functionality: `--args` now not expected

### frontend/cli: run: Append or replace new arguments, if program launched

if program X launched with default arguments `defargs`:
```
bottles-cli run -b bottle -p X arg1 arg2
x defargs arg1 arg2
bottles-cli run -b bottle -p X --args-replace arg1 arg2
x arg1 arg2
```

### backend: create_desktop_entry: Let .desktop file listening for additional arguments

.desktop file now listen for new arguments

Allow something like this:
```
xdg-mime default bottle--telegram--1111.1111.desktop x-scheme-handler/tg
xdg-open tg://settings # will open installed in bottles telegram settings # NB: not checked
```


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Just check it works in separate python file :(
