### PR TITLE
fix: ComponentManager.install() deadlock

### DIFF
--- a/bottles/backend/managers/component.py
+++ b/bottles/backend/managers/component.py
@@ -354,13 +354,13 @@ class ComponentManager:
             func=func
         )
 
-        if not res and func:
+        if not res:
             '''
             If the download fails, execute the given func passing
             failed=True as a parameter.
             '''
             self.__remove_from_queue(_uuid)
-            return func(failed=True)
+            return Result(func(failed=True) if func else False)
 
         archive = manifest["File"][0]["file_name"]
 

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -370,7 +370,7 @@ class Manager:
         tmp_runners = [x for x in self.runners_available if not x.startswith('sys-')]
 
         if len(tmp_runners) == 0 and install_latest:
-            logging.warning("No managed runners found.")
+            logging.warning("No runners found.")
 
             if self.utils_conn.check_connection():
                 # if connected, install the latest runner from repository

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -370,7 +370,7 @@ class Manager:
         tmp_runners = [x for x in self.runners_available if not x.startswith('sys-')]
 
         if len(tmp_runners) == 0 and install_latest:
-            logging.warning("No runners found.")
+            logging.warning("No managed runners found.")
 
             if self.utils_conn.check_connection():
                 # if connected, install the latest runner from repository


### PR DESCRIPTION
# Description
My internet sucks, manifest fetching and file download randomly failed.
when `ComponentManager.install()` failed with downloading, it won't pop the failed installation from `self.__queue`, next call to `ComponentManager.install()` will keep waiting for empty queue forever.
then Onboard Dialog will stuck at "Almost Done" forever.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Tested locally
