### PR TITLE
fix: onboard dialog shows "All ready" when not ready

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -132,7 +132,7 @@ class Manager:
         times["SteamManager"] = time.time()
 
         if not is_cli:
-            times.update(self.checks(install_latest=False, first_run=True))
+            times.update(self.checks(install_latest=False, first_run=True).data)
         else:
             logging.set_silent()
 
@@ -149,50 +149,51 @@ class Manager:
                 last = t
             logging.info(times_str)
 
-    def checks(self, install_latest=False, first_run=False):
+    def checks(self, install_latest=False, first_run=False) -> Result:
         logging.info("Performing Bottles checks…")
-        times = {}
+
+        rv = Result(status=True, data={})
 
         self.check_app_dirs()
-        times["check_app_dirs"] = time.time()
+        rv.data["check_app_dirs"] = time.time()
 
-        self.check_dxvk(install_latest)
-        times["check_dxvk"] = time.time()
+        self.check_dxvk(install_latest) or rv.set_status(False)
+        rv.data["check_dxvk"] = time.time()
 
-        self.check_vkd3d(install_latest)
-        times["check_vkd3d"] = time.time()
+        self.check_vkd3d(install_latest) or rv.set_status(False)
+        rv.data["check_vkd3d"] = time.time()
 
-        self.check_nvapi(install_latest)
-        times["check_nvapi"] = time.time()
+        self.check_nvapi(install_latest) or rv.set_status(False)
+        rv.data["check_nvapi"] = time.time()
 
-        self.check_latencyflex(install_latest)
-        times["check_latencyflex"] = time.time()
+        self.check_latencyflex(install_latest) or rv.set_status(False)
+        rv.data["check_latencyflex"] = time.time()
 
-        self.check_runtimes(install_latest)
-        times["check_runtimes"] = time.time()
+        self.check_runtimes(install_latest) or rv.set_status(False)
+        rv.data["check_runtimes"] = time.time()
 
-        self.check_winebridge(install_latest)
-        times["check_winebridge"] = time.time()
+        self.check_winebridge(install_latest) or rv.set_status(False)
+        rv.data["check_winebridge"] = time.time()
 
-        self.check_runners(install_latest)
-        times["check_runners"] = time.time()
+        self.check_runners(install_latest) or rv.set_status(False)
+        rv.data["check_runners"] = time.time()
 
         if first_run:
             self.organize_components()
-            times["organize_components"] = time.time()
+            rv.data["organize_components"] = time.time()
             self.__clear_temp()
-            times["clear_temp"] = time.time()
+            rv.data["clear_temp"] = time.time()
 
         self.organize_dependencies()
-        times["organize_dependencies"] = time.time()
+        rv.data["organize_dependencies"] = time.time()
 
         self.organize_installers()
-        times["organize_installers"] = time.time()
+        rv.data["organize_installers"] = time.time()
 
         self.check_bottles()
-        times["check_bottles"] = time.time()
+        rv.data["check_bottles"] = time.time()
 
-        return times
+        return rv
 
     def __clear_temp(self, force: bool = False):
         """Clears the temp directory if user setting allows it. Use the force
@@ -421,6 +422,8 @@ class Manager:
                 if version:
                     version = f"runtime-{version}"
                     self.runtimes_available = [version]
+                    return True
+        return False
 
     def check_winebridge(self, install_latest: bool = True, update: bool = False) -> bool:
         self.winebridge_available = []
@@ -444,26 +447,32 @@ class Manager:
                 version = f.read().strip()
                 if version:
                     self.winebridge_available = [f"winebridge-{version}"]
+                    return True
+        return False
 
-    def check_dxvk(self, install_latest: bool = True):
+    def check_dxvk(self, install_latest: bool = True) -> bool:
         res = self.__check_component("dxvk", install_latest)
         if res:
             self.dxvk_available = res
+        return res is not False
 
-    def check_vkd3d(self, install_latest: bool = True):
+    def check_vkd3d(self, install_latest: bool = True) -> bool:
         res = self.__check_component("vkd3d", install_latest)
         if res:
             self.vkd3d_available = res
+        return res is not False
 
-    def check_nvapi(self, install_latest: bool = True):
+    def check_nvapi(self, install_latest: bool = True) -> bool:
         res = self.__check_component("nvapi", install_latest)
         if res:
             self.nvapi_available = res
+        return res is not False
 
-    def check_latencyflex(self, install_latest: bool = True):
+    def check_latencyflex(self, install_latest: bool = True) -> bool:
         res = self.__check_component("latencyflex", install_latest)
         if res:
             self.latencyflex_available = res
+        return res is not False
 
     def __check_component(self, component_type: str, install_latest: bool = True) -> Union[bool, list]:
         components = {

--- a/bottles/backend/models/result.py
+++ b/bottles/backend/models/result.py
@@ -39,3 +39,6 @@ class Result:
         self.status = status
         self.data = data
         self.message = message
+
+    def set_status(self, v: bool):
+        self.status = v

--- a/bottles/frontend/windows/onboard.py
+++ b/bottles/frontend/windows/onboard.py
@@ -19,6 +19,7 @@ import time
 
 from gi.repository import Gtk, Adw
 
+from bottles.backend.models.result import Result
 from bottles.frontend.utils.threading import RunAsync
 
 
@@ -111,10 +112,15 @@ class OnboardDialog(Adw.Window):
         quit()
 
     def __install_runner(self, widget):
-        def set_completed(result, error=False):
-            self.label_skip.set_visible(False)
-            self.btn_close.set_sensitive(True)
-            self.__next_page()
+        def set_completed(result: Result, error=False):
+            if result.status:
+                self.label_skip.set_visible(False)
+                self.btn_close.set_sensitive(True)
+                self.__next_page()
+            else:
+                self.__installing = False
+                self.btn_install.set_visible(True)
+                self.progressbar.set_visible(False)
 
         self.__installing = True
         self.btn_back.set_visible(False)


### PR DESCRIPTION
# Description
There is a index out of range bug at:
https://github.com/bottlesdevs/Bottles/blob/5933056003cb5d80c4e1c85ed9d874f7260cd4ed/bottles/backend/managers/manager.py#L882-L912
when user have a bad network, `self.dxvk_available`, `self.vkd3d_available`, `self.nvapi_available` will be empty.

But I suddenly realize the reason for this bug is making proper initialization a prerequisite, and there may be more bugs like this, so I choose to fix this issue by ensuring the onboard initialization will complete properly, instead of skip component download and show onboard dialog to user on every startup. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] locally
