### PR TITLE
Don't override `GST_PLUGIN_SYSTEM_PATH` if runner doesn't bundle GStreamer

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -261,7 +261,8 @@ class WineCommand:
             for lib in gst_libs:
                 if os.path.exists(os.path.join(runner_path, lib)):
                     gst_env_path.append(os.path.join(runner_path, lib))
-            env.add("GST_PLUGIN_SYSTEM_PATH", ":".join(gst_env_path), override=True)
+            if len(gst_env_path) > 0:
+                env.add("GST_PLUGIN_SYSTEM_PATH", ":".join(gst_env_path), override=True)
 
         # DXVK environment variables
         if params["dxvk"] and not return_steam_env:


### PR DESCRIPTION
# Description
Before, Bottles would set `GST_PLUGIN_SYSTEM_PATH` regardless if GStreamer was bundled in the runner. If it is not, then the environment variable would be set to an empty string, which according to [the documentation](https://gstreamer.freedesktop.org/documentation/gstreamer/running.html?gi-language=c):

> Setting this variable to an empty string will cause GStreamer not to scan any system paths at all for plug-ins.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I attempted to see "Star Wars Jedi: Fallen Order" (EA App) intro video.
Before the change, it wouldn't play when using Wine Soda. It would play on system Wine (which has GStreamer bundled), or if `BOTTLES_USE_SYSTEM_GSTREAMER` was set.
After the change, the video plays on Wine Soda without any intervention.

Tested on Linux NixOS unstable (not the Flatpak package)