### PR TITLE
fix: slow replace_font

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -38,7 +38,7 @@ from bottles.backend.globals import Paths
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.wine.uninstaller import Uninstaller
 from bottles.backend.wine.winedbg import WineDbg
-from bottles.backend.wine.reg import Reg
+from bottles.backend.wine.reg import Reg, RegItem
 from bottles.backend.wine.regsvr32 import Regsvr32
 from bottles.backend.wine.regkeys import RegKeys
 from bottles.backend.wine.executor import WineExecutor
@@ -632,7 +632,7 @@ class DependencyManager:
             key=step.get("key"),
             value=step.get("value"),
             data=step.get("data"),
-            key_type=step.get("type")
+            value_type=step.get("type")
         )
         return True
 
@@ -651,18 +651,23 @@ class DependencyManager:
     def __step_replace_font(config: dict, step: dict):
         """Register a font replacement in the registry."""
         reg = Reg(config)
+        target_font = step.get("font")
         replaces = step.get("replace")
 
         if not isinstance(replaces, list):
             logging.warning("Invalid replace_font, 'replace' field should be list.")
             return False
 
-        for r in replaces:
-            reg.add(
+        regs = [
+            RegItem(
                 key="HKEY_CURRENT_USER\\Software\\Wine\\Fonts\\Replacements",
                 value=r,
-                data=step.get("font")
+                value_type="",
+                data=target_font
             )
+            for r in replaces
+        ]
+        reg.bulk_add(regs)
         return True
 
     @staticmethod

--- a/bottles/backend/utils/generic.py
+++ b/bottles/backend/utils/generic.py
@@ -15,10 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import re
-import sys
 import contextlib
+import random
+import re
+import string
 import subprocess
+import sys
 
 
 def validate_url(url: str):
@@ -118,3 +120,7 @@ def get_mime(path: str):
         if res:
             return res.decode('utf-8').split(':')[1].strip()
     return None
+
+
+def random_string(length: int):
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))

--- a/bottles/backend/wine/regkeys.py
+++ b/bottles/backend/wine/regkeys.py
@@ -251,7 +251,7 @@ class RegKeys:
             key="HKEY_CURRENT_USER\\Software\\Wine\\Direct3D",
             value="renderer",
             data=value,
-            key_type="REG_SZ"
+            value_type="REG_SZ"
         )
 
     def set_dpi(self, value: int):
@@ -262,7 +262,7 @@ class RegKeys:
             key="HKEY_CURRENT_USER\\Control Panel\\Desktop",
             value="LogPixels",
             data=value,
-            key_type="REG_DWORD"
+            value_type="REG_DWORD"
         )
 
     def set_grab_fullscreen(self, state: bool):


### PR DESCRIPTION
# Description
In previous implementation, `replace_font` calls `Reg.add()`, invoke `reg.exe add ...` for each font replacement entry, which is extremely slow for large replacement set since every `reg.exe` call will take several seconds to complete.

This PR will add a new `Reg.bulk_add()` for bulk registry importing support.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Optimize

# How Has This Been Tested?
- [x] `cjkfonts` installation won't take decades now
