### PR TITLE
frontend: make app name untranslatable, disambiguate Bottles & bottles

### DIFF
--- a/bottles/frontend/ui/window.blp
+++ b/bottles/frontend/ui/window.blp
@@ -34,7 +34,7 @@ Popover pop_menu {
 }
 
 template MainWindow : .AdwApplicationWindow {
-  title: _("Bottles");
+  title: "Bottles";
   default-width: "880";
   default-height: "640";
   icon-name: "com.usebottles.bottles";
@@ -49,7 +49,7 @@ template MainWindow : .AdwApplicationWindow {
 
         HeaderBar headerbar {
           title-widget: .AdwViewSwitcherTitle view_switcher_title {
-            title: _("Bottles");
+            title: "Bottles";
             stack: "stack_main";
           }
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -205,10 +205,12 @@ msgstr "استلُم طلب [تحديث]."
 msgid "Calculating…"
 msgstr "جارٍ الحساب …"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017 Bottles Developers"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "مُطوِّروا بوتلز"
@@ -818,6 +820,7 @@ msgstr "استخدم بيئة مقيدة / مُدارة لهذه قارورة."
 msgid "Manage the Sandbox Permissions"
 msgstr "أدِر أذونات ساحة الحماية"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "وقت تشغيل بوتلز"
@@ -985,6 +988,7 @@ msgstr "اختر"
 msgid "Create New Bottle"
 msgstr "أنشئ قارورة جديدة"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "تقرير تعطل القارورة"
@@ -1834,11 +1838,10 @@ msgstr "ابحث في قاروراتك…"
 msgid "Steam Proton"
 msgstr "بروتون لستيم"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "القوارير"
 
@@ -1963,6 +1966,7 @@ msgstr "أُنشئت القارورة"
 msgid "Previous"
 msgstr "السابق"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "مرحبا بك في بوتلز"
@@ -1971,6 +1975,7 @@ msgstr "مرحبا بك في بوتلز"
 msgid "Run Windows Software on Linux."
 msgstr "شغِّل برامج ويندوز على لينكس."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "النوافذ في بوتلز"
@@ -1998,6 +2003,7 @@ msgstr "كل شيء جاهز!"
 msgid "Please Finish the setup first"
 msgstr "فضلاً أنهِ الإعداد أولاً"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "ابدأ باستخدام بوتلز"
@@ -2229,6 +2235,7 @@ msgstr "استورد…"
 msgid "Help"
 msgstr "المساعدة"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "حول بوتلز"

--- a/po/be.po
+++ b/po/be.po
@@ -200,10 +200,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -789,6 +791,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr ""
@@ -954,6 +957,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1751,11 +1755,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr ""
 
@@ -1880,6 +1883,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1888,6 +1892,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr ""
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1914,6 +1919,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2144,6 +2150,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -239,10 +239,12 @@ msgstr "Получена е заявка за [Опресняване]."
 msgid "Calculating…"
 msgstr "Изчисляване…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017 – Разработчиците на „Bottles“"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Разработчиците на „Bottles“"
@@ -932,6 +934,7 @@ msgstr "Използвайте изолирана среда за тази бу�
 msgid "Manage the Sandbox Permissions"
 msgstr "Управление на разрешенията за пясъчника"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 msgid "Bottles Runtime"
@@ -1124,6 +1127,7 @@ msgstr "Избиране"
 msgid "Create New Bottle"
 msgstr "Създаване на нова бутилка"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Доклад за срив на „Bottles“"
@@ -2002,11 +2006,10 @@ msgstr "Търсене на Вашите бутилки…"
 msgid "Steam Proton"
 msgstr "„Steam Proton“"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "„Bottles“"
 
@@ -2133,6 +2136,7 @@ msgstr "Бутилката е създадена"
 msgid "Previous"
 msgstr "Назад"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Добре дошли в „Bottles“"
@@ -2141,6 +2145,7 @@ msgstr "Добре дошли в „Bottles“"
 msgid "Run Windows Software on Linux."
 msgstr "Използвайте софтуер за „Windows“ на „Линукс“."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "„Windows“ в бутилки"
@@ -2169,6 +2174,7 @@ msgstr "Всичко е готово!"
 msgid "Please Finish the setup first"
 msgstr "Моля, първо завършете настройката"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Започнете използването на „Bottles“"
@@ -2402,6 +2408,7 @@ msgstr "Импортиране…"
 msgid "Help"
 msgstr "Помощ"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Относно „Bottles“"

--- a/po/bn.po
+++ b/po/bn.po
@@ -204,11 +204,13 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Bottles Developers"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -833,6 +835,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "কম্পোনেন্ট ভার্সন"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1005,6 +1008,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "ডুপ্লিকেট bottle"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1822,11 +1826,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1955,6 +1958,7 @@ msgstr "Bottles"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1964,6 +1968,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "Bottles দিয়ে লিনাক্সে উইন্ডোজ সফটওয়্যার চালান!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -1991,6 +1996,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2235,6 +2241,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/bottles.pot
+++ b/po/bottles.pot
@@ -201,10 +201,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -790,6 +792,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr ""
@@ -955,6 +958,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1752,11 +1756,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr ""
 
@@ -1881,6 +1884,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1889,6 +1893,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr ""
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1915,6 +1920,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2145,6 +2151,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -205,11 +205,13 @@ msgstr "S'ha rebut la sol·licitud [Actualització]."
 msgid "Calculating…"
 msgstr "S'està calculant…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Desenvolupadors de Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -849,6 +851,7 @@ msgstr "Utilitzeu un entorn restringit/gestionat per a aquesta ampolla."
 msgid "Manage the Sandbox Permissions"
 msgstr "Administra els permisos d'espai aïllat"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Entorn d’execució del Bottles"
@@ -1028,6 +1031,7 @@ msgstr "Seleccioneu"
 msgid "Create New Bottle"
 msgstr "Crea una ampolla nova"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1932,11 +1936,10 @@ msgstr "Cerca les vostres ampolles…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2063,6 +2066,7 @@ msgstr "S’ha creat l’ampolla"
 msgid "Previous"
 msgstr "Anterior"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Us donem la benvinguda al Bottles"
@@ -2072,6 +2076,7 @@ msgstr "Us donem la benvinguda al Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Executeu programari de Windows en Linux amb el Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "El Windows al Bottles"
@@ -2101,6 +2106,7 @@ msgstr "Tot a punt!"
 msgid "Please Finish the setup first"
 msgstr "Si us plau, acabeu primer la configuració"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Començar a utilitzar Bottles"
@@ -2340,6 +2346,7 @@ msgstr "Importar"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Quant al Bottles"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -211,11 +211,13 @@ msgstr "[تازەکردنەوە] داواکاری وەرگیرا."
 msgid "Calculating…"
 msgstr "هەژمارکردن..."
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "گەشەپێدەرانی بۆتڵز - ٢٠٢٢-٢٠١٧ ©"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -862,6 +864,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "بەڕێوەبردنی وەشانەکانی DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1052,6 +1055,7 @@ msgstr "دیاریکردن"
 msgid "Create New Bottle"
 msgstr "دروستکردنی بۆتڵێکی تازە"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1935,11 +1939,10 @@ msgstr "بەدوای بۆتڵەکانتدا بگەڕێ..."
 msgid "Steam Proton"
 msgstr "پریفیکسەکانی ستیم پرۆتۆن"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "بۆتڵز"
 
@@ -2077,6 +2080,7 @@ msgstr "بتڵ دروستکرا"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "بەخێربێیت بۆ بۆتڵز"
@@ -2086,6 +2090,7 @@ msgstr "بەخێربێیت بۆ بۆتڵز"
 msgid "Run Windows Software on Linux."
 msgstr "لەگەڵ بۆتڵز، نەرمەکاڵای ویندۆز لەسەر لینوکس بەکاربهێنە!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2113,6 +2118,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2372,6 +2378,7 @@ msgstr "هاوردەکەر"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "دەربارەی بۆتڵز"

--- a/po/cs.po
+++ b/po/cs.po
@@ -203,10 +203,12 @@ msgstr "[Refresh] žádost přijata."
 msgid "Calculating…"
 msgstr "Počítání…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017 vývojáři Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Vývojáři lahví"
@@ -830,6 +832,7 @@ msgstr "Pro tuto láhev použijte omezené/řízené prostředí."
 msgid "Manage the Sandbox Permissions"
 msgstr "Správa oprávnění Sandboxu"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Použít běhové prostředí láhví"
@@ -1001,6 +1004,7 @@ msgstr "Vybrat"
 msgid "Create New Bottle"
 msgstr "Vytvořit novou láhev"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Zpráva o havárii lahví"
@@ -1863,11 +1867,10 @@ msgstr "Prohledávejte své lahve…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Láhve"
 
@@ -1995,6 +1998,7 @@ msgstr "Láhev vytvořena"
 msgid "Previous"
 msgstr "Předchozí"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Vítejte v Láhvích"
@@ -2003,6 +2007,7 @@ msgstr "Vítejte v Láhvích"
 msgid "Run Windows Software on Linux."
 msgstr "Spuštění softwaru Windows na Linuxu."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Okna v lahvích"
@@ -2031,6 +2036,7 @@ msgstr "Vše připraveno!"
 msgid "Please Finish the setup first"
 msgstr "Nejprve dokončete nastavení"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Začněte používat Láhve"
@@ -2263,6 +2269,7 @@ msgstr "Import…"
 msgid "Help"
 msgstr "Nápověda"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "O Láhvích"

--- a/po/da.po
+++ b/po/da.po
@@ -214,10 +214,12 @@ msgstr "[Genopfrisk] anmodning modtaget."
 msgid "Calculating…"
 msgstr "Duplikerer…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -854,6 +856,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Versionering"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1036,6 +1039,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "Opret ny flaske"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1893,11 +1897,10 @@ msgstr "Sidste opdatering til denne flaske."
 msgid "Steam Proton"
 msgstr "ProtonDB"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr ""
 
@@ -2032,6 +2035,7 @@ msgstr "Flasker Startet!"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Om Flasker"
@@ -2041,6 +2045,7 @@ msgstr "Om Flasker"
 msgid "Run Windows Software on Linux."
 msgstr "Kør nemt Windows programvare på Linux med 🍷 Flasker!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2068,6 +2073,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2321,6 +2327,7 @@ msgstr "Importer"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Om Flasker"

--- a/po/de.po
+++ b/po/de.po
@@ -203,11 +203,13 @@ msgstr "[Neu laden] Anforderung erhalten."
 msgid "Calculating…"
 msgstr "Berechne…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Bottles Entwickler"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -850,6 +852,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Sandbox-Berechtigungen verwalten"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Bottles-Runtime"
@@ -1030,6 +1033,7 @@ msgstr "Auswählen"
 msgid "Create New Bottle"
 msgstr "Neue Bottle erstellen"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1931,11 +1935,10 @@ msgstr "Durchsuche deine Bottles…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2064,6 +2067,7 @@ msgstr "Bottle erstellt"
 msgid "Previous"
 msgstr "Zurück"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Willkommen bei Bottles"
@@ -2073,6 +2077,7 @@ msgstr "Willkommen bei Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Mit Bottles Windows-Software unter Linux ausführen!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows in Bottles"
@@ -2103,6 +2108,7 @@ msgstr "Alles bereit!"
 msgid "Please Finish the setup first"
 msgstr "Bitte beenden Sie zuerst die Einrichtung"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Starte mit Bottles"
@@ -2342,6 +2348,7 @@ msgstr "Importieren"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Über Bottles"

--- a/po/el.po
+++ b/po/el.po
@@ -204,11 +204,13 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2021 - Προγραμματιστές του Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -842,6 +844,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Διαχείρηση εκδόσεων DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1027,6 +1030,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1855,11 +1859,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1991,6 +1994,7 @@ msgstr "Όνομα bottle"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -2000,6 +2004,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "Τρέξτε λογισμικό των Windows σε Linux με το Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2027,6 +2032,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2277,6 +2283,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -216,11 +216,13 @@ msgstr "Riceviĝis peto [Reŝargi]."
 msgid "Calculating…"
 msgstr "Elŝutante…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2021 - Kreantoj de Boteloj"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -861,6 +863,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Administri versiojn de DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1044,6 +1047,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "Krei novan botelon"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1909,11 +1913,10 @@ msgstr "Nomu vian botelon"
 msgid "Steam Proton"
 msgstr "ProtonDB"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Boteloj"
 
@@ -2050,6 +2053,7 @@ msgstr "Kreiĝis botelo"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Bonvenon al Boteloj"
@@ -2059,6 +2063,7 @@ msgstr "Bonvenon al Boteloj"
 msgid "Run Windows Software on Linux."
 msgstr "Ruli Vindozajn programonj sur Linukso per Boteloj 🍷!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2086,6 +2091,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2344,6 +2350,7 @@ msgstr "Enportilo"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Pri Boteloj"

--- a/po/es.po
+++ b/po/es.po
@@ -203,11 +203,13 @@ msgstr "Se recibió la solicitud [Actualizar]."
 msgid "Calculating…"
 msgstr "Calculando…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Desarrolladores de Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -849,6 +851,7 @@ msgstr "Utilice un entorno restringido/gestionado para esta botella."
 msgid "Manage the Sandbox Permissions"
 msgstr "Gestionar permisos del Sandbox"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Tiempo de ejecución de botellas"
@@ -1029,6 +1032,7 @@ msgstr "Seleccionar"
 msgid "Create New Bottle"
 msgstr "Crear botella nueva"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1932,11 +1936,10 @@ msgstr "Buscar sus botellas …"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Botellas"
 
@@ -2063,6 +2066,7 @@ msgstr "Botella creada"
 msgid "Previous"
 msgstr "Anterior"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Le damos la bienvenida a Bottles"
@@ -2072,6 +2076,7 @@ msgstr "Le damos la bienvenida a Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "¡Ejecute software de Windows en Linux con Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows en Bottles"
@@ -2101,6 +2106,7 @@ msgstr "¡Todo listo!"
 msgid "Please Finish the setup first"
 msgstr "Por favor, termine la configuración primero"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Empiece por crear una botella"
@@ -2340,6 +2346,7 @@ msgstr "Importar"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Acerca de Bottles"

--- a/po/et.po
+++ b/po/et.po
@@ -200,10 +200,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -789,6 +791,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr ""
@@ -954,6 +957,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1751,11 +1755,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr ""
 
@@ -1880,6 +1883,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1888,6 +1892,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr ""
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1914,6 +1919,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2144,6 +2150,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -205,11 +205,13 @@ msgstr ""
 msgid "Calculating…"
 msgstr "Bikoizten…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2021 - Bottles Garatzaileak"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -824,6 +826,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "DXVK-ren bertsioak kudeatu"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1013,6 +1016,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "Sortu egoera berria"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1858,11 +1862,10 @@ msgstr "Idatzi izen bat bottle berriarentzat"
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1994,6 +1997,7 @@ msgstr "Bottle bikoiztua"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -2003,6 +2007,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "Exekutatu Windows programak Linux-en Bottles-ekin 🍷!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2030,6 +2035,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2273,6 +2279,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -205,11 +205,13 @@ msgstr ""
 msgid "Calculating…"
 msgstr "در حال محاسبه..."
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© ۲۰۱۷-۲۰۲۲ - توسعه دهندگان Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -823,6 +825,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1001,6 +1004,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "بطری‌ها"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1832,11 +1836,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "بطری‌ها"
 
@@ -1966,6 +1969,7 @@ msgstr "بطری‌ها"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1975,6 +1979,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "اجرای نرم‌افزارهای وندوز روی لینوکس با بطری‌ها!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2002,6 +2007,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2248,6 +2254,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -238,10 +238,12 @@ msgstr "[Refresh]-pyyntö vastaanotettu."
 msgid "Calculating…"
 msgstr "Lasketaan…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017 Bottles-kehittäjät"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Bottles-kehittäjät"
@@ -902,6 +904,7 @@ msgstr "Käytä rajoitettua/hallittua ympäristö tälle pullolle."
 msgid "Manage the Sandbox Permissions"
 msgstr "Hallitse hiekkalaatikon oikeuksia"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 #, fuzzy
@@ -1086,6 +1089,7 @@ msgstr "Valitse"
 msgid "Create New Bottle"
 msgstr "Luo uusi pullo"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Pullojen kaatumisraportti"
@@ -1908,11 +1912,10 @@ msgstr "Etsi pulloja…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Pullot"
 
@@ -2038,6 +2041,7 @@ msgstr "Pullo luotu"
 msgid "Previous"
 msgstr "Edellinen"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Tervetuloa, tämä on Pullot"
@@ -2046,6 +2050,7 @@ msgstr "Tervetuloa, tämä on Pullot"
 msgid "Run Windows Software on Linux."
 msgstr "Suorita Windows-ohjelmistoja Linuxilla."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows pulloissa"
@@ -2075,6 +2080,7 @@ msgstr "Kaikki valmista!"
 msgid "Please Finish the setup first"
 msgstr "Suorita määritys ensin"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Aloita pullojen käyttö"
@@ -2307,6 +2313,7 @@ msgstr "Tuo…"
 msgid "Help"
 msgstr "Ohje"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Tietoja - Pullot"

--- a/po/fr.po
+++ b/po/fr.po
@@ -238,10 +238,12 @@ msgstr "[Refresh] requête reçue."
 msgid "Calculating…"
 msgstr "Calcul en cours…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017 — Développeurs de Bouteilles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Développeurs de Bouteilles"
@@ -936,6 +938,7 @@ msgstr "Définir un environnement restreint/géré pour cette Bouteille."
 msgid "Manage the Sandbox Permissions"
 msgstr "Gérer les autorisations du bac à sable"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 msgid "Bottles Runtime"
@@ -1131,6 +1134,7 @@ msgstr "Sélectionner"
 msgid "Create New Bottle"
 msgstr "Créer une nouvelle bouteille"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Rapport de crash de Bouteilles"
@@ -2018,11 +2022,10 @@ msgstr "Recherchez vos bouteilles…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bouteilles"
 
@@ -2152,6 +2155,7 @@ msgstr "Bouteille créée"
 msgid "Previous"
 msgstr "Précédent"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Bienvenue dans Bouteilles"
@@ -2160,6 +2164,7 @@ msgstr "Bienvenue dans Bouteilles"
 msgid "Run Windows Software on Linux."
 msgstr "Exécutez des logiciels pour Windows sous Linux."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows dans Bouteilles"
@@ -2190,6 +2195,7 @@ msgstr "Tout est prêt !"
 msgid "Please Finish the setup first"
 msgstr "Merci de terminer la configuration d’abord"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Commencer à utiliser Bouteilles"
@@ -2427,6 +2433,7 @@ msgstr "Importer…"
 msgid "Help"
 msgstr "Aide"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "À propos de Bouteilles"

--- a/po/gl.po
+++ b/po/gl.po
@@ -211,11 +211,13 @@ msgstr "Recibiuse a solicitude [Actualizar]."
 msgid "Calculating…"
 msgstr "Duplicando…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Desenvolvedores de Botellas"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -862,6 +864,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Xestionar versións de DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Tempo de execución de Bottles"
@@ -1052,6 +1055,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "Crear unha botella nova"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1915,11 +1919,10 @@ msgstr "Buscar as súas botellas…"
 msgid "Steam Proton"
 msgstr "Prefixos de Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Botellas"
 
@@ -2054,6 +2057,7 @@ msgstr "Botella creada"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Dámoslle a benvida"
@@ -2063,6 +2067,7 @@ msgstr "Dámoslle a benvida"
 msgid "Run Windows Software on Linux."
 msgstr "Execute software de Windows en Linux con Botellas!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2090,6 +2095,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2351,6 +2357,7 @@ msgstr "Importador"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Sobre Bottles"

--- a/po/he.po
+++ b/po/he.po
@@ -204,10 +204,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -793,6 +795,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr ""
@@ -958,6 +961,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1755,11 +1759,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr ""
 
@@ -1884,6 +1887,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1892,6 +1896,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr ""
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1918,6 +1923,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2148,6 +2154,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -208,10 +208,12 @@ msgstr "[Refresh] अनुरोध प्राप्त"
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -817,6 +819,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -992,6 +995,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "नई bottle"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1813,11 +1817,10 @@ msgstr "अपनी बोतल के लिए एक नाम टाइप
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1951,6 +1954,7 @@ msgstr "Bottles शुरु हो गयी!"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1960,6 +1964,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "Windows का सॉफ्टवेयर Linux मैं चलाये Bottles के साथ🍷!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -1987,6 +1992,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2225,6 +2231,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -238,10 +238,12 @@ msgstr "Primljen je zahtjev za [Aktualiziraj]."
 msgid "Calculating…"
 msgstr "Izračunavanje …"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Autorska prava © 2017. – Programeri programa Butelje (Bottles)"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Programeri programa Butelje (Bottles)"
@@ -903,6 +905,7 @@ msgstr "Koristi ograničeno/upravljano okruženje za ovu buelju."
 msgid "Manage the Sandbox Permissions"
 msgstr "Upravljaj dozvolama testnog okruženja"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 msgid "Bottles Runtime"
@@ -1099,6 +1102,7 @@ msgstr "Odaberi"
 msgid "Create New Bottle"
 msgstr "Stvori novu butelju"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -2000,11 +2004,10 @@ msgstr "Pretraži svoje butelje …"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Butelje"
 
@@ -2133,6 +2136,7 @@ msgstr "Butelja je stvorena"
 msgid "Previous"
 msgstr "Prethodno"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Dobro došao, dobro došla u Butelje"
@@ -2142,6 +2146,7 @@ msgstr "Dobro došao, dobro došla u Butelje"
 msgid "Run Windows Software on Linux."
 msgstr "Pokreći Windows softver na Linuxu pomoću programa Butelje!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows u Butelje"
@@ -2171,6 +2176,7 @@ msgstr "Sve je spremno!"
 msgid "Please Finish the setup first"
 msgstr "Najprije završi postavljanje"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Počni koristiti Butelje"
@@ -2410,6 +2416,7 @@ msgstr "Uvoz"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "O programu Butelje"

--- a/po/hu.po
+++ b/po/hu.po
@@ -204,11 +204,13 @@ msgstr "[Frissítési] kérelem érkezett."
 msgid "Calculating…"
 msgstr "Számítás…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Palackok fejlesztői"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -842,6 +844,7 @@ msgstr "Korlátozott/kezelt környezet használata ennél a palacknál."
 msgid "Manage the Sandbox Permissions"
 msgstr "Homokozó engedélyek kezelése"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Palackok futtatókörnyezet"
@@ -1023,6 +1026,7 @@ msgstr "Kiválasztás"
 msgid "Create New Bottle"
 msgstr "Új palack létrehozása"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1883,11 +1887,10 @@ msgstr "Palackok keresése…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Palackok"
 
@@ -2015,6 +2018,7 @@ msgstr "Palack létrehozva"
 msgid "Previous"
 msgstr "Előző"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Üdvözöljük a Palackokban"
@@ -2024,6 +2028,7 @@ msgstr "Üdvözöljük a Palackokban"
 msgid "Run Windows Software on Linux."
 msgstr "Futtasson Windows szoftvereket Linuxon a Palackok segítségével!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows bepalackozva"
@@ -2053,6 +2058,7 @@ msgstr "Minden kész!"
 msgid "Please Finish the setup first"
 msgstr "Kérjük, először fejezze be a beállítást"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Palackokat használatának megkezdése"
@@ -2291,6 +2297,7 @@ msgstr "Importálás"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "A Palackok névjegye"

--- a/po/id.po
+++ b/po/id.po
@@ -207,11 +207,13 @@ msgstr "Permintaan [Segarkan] diterima."
 msgid "Calculating…"
 msgstr "Menghitung…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Pengembang Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -854,6 +856,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Kelola versi DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Runtime Bottles"
@@ -1043,6 +1046,7 @@ msgstr "Pilih"
 msgid "Create New Bottle"
 msgstr "Buat Bottle baru"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1925,11 +1929,10 @@ msgstr "Cari bottles Anda .."
 msgid "Steam Proton"
 msgstr "Awalan Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2066,6 +2069,7 @@ msgstr "Bottle telah dibuat"
 msgid "Previous"
 msgstr "Sebelumnya"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Selamat datang di Bottles"
@@ -2075,6 +2079,7 @@ msgstr "Selamat datang di Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Jalankan perangkat lunak Windows di Linux dengan Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2103,6 +2108,7 @@ msgstr "Semua siap!"
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2359,6 +2365,7 @@ msgstr "Impor"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Tentang Bottles"

--- a/po/it.po
+++ b/po/it.po
@@ -203,11 +203,13 @@ msgstr "[Ricarica] richiesta ricevuta."
 msgid "Calculating…"
 msgstr "Calcolo…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Sviluppatori di Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -848,6 +850,7 @@ msgstr "Utilizzare un ambiente limitato/gestito per questa bottiglia."
 msgid "Manage the Sandbox Permissions"
 msgstr "Gestisci i permessi della sandbox"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Runtime di Bottles"
@@ -1028,6 +1031,7 @@ msgstr "Seleziona"
 msgid "Create New Bottle"
 msgstr "Crea una nuova bottiglia"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1924,11 +1928,10 @@ msgstr "Cerca bottiglie…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2056,6 +2059,7 @@ msgstr "Bottiglia creata"
 msgid "Previous"
 msgstr "Indietro"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Benvenuto in Bottles"
@@ -2065,6 +2069,7 @@ msgstr "Benvenuto in Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Esegui programmi per Windows su Linux con Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows in bottiglie"
@@ -2095,6 +2100,7 @@ msgstr "Tutto pronto!"
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Inizia a usare Bottles"
@@ -2337,6 +2343,7 @@ msgstr "Importa"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Informazioni su Bottles"

--- a/po/ja.po
+++ b/po/ja.po
@@ -204,10 +204,12 @@ msgstr "[更新] リクエストを受信しました。"
 msgid "Calculating…"
 msgstr "計算しています…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017 Bottles の開発者"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Bottles の開発者"
@@ -827,6 +829,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "サンドボックスのパーミッションを管理"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Bottlesのランタイム"
@@ -1009,6 +1012,7 @@ msgstr "選択"
 msgid "Create New Bottle"
 msgstr "新しいボトルを作成"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1857,11 +1861,10 @@ msgstr "ボトルを検索…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1988,6 +1991,7 @@ msgstr "ボトルを作成しました"
 msgid "Previous"
 msgstr "戻る"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Bottlesへようこそ"
@@ -1996,6 +2000,7 @@ msgstr "Bottlesへようこそ"
 msgid "Run Windows Software on Linux."
 msgstr "Linux上でWindowsソフトウェアを実行します。"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Bottles 内で Windows を実行します"
@@ -2022,6 +2027,7 @@ msgstr "完了しました！"
 msgid "Please Finish the setup first"
 msgstr "最初にセットアップを完了させてください"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Bottles の使用を開始"
@@ -2264,6 +2270,7 @@ msgstr "インポート"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Bottlesについて"

--- a/po/ko.po
+++ b/po/ko.po
@@ -230,11 +230,13 @@ msgstr ""
 msgid "Calculating…"
 msgstr "계산중…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Bottles 개발자"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -899,6 +901,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "DXVK 버전 관리"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 msgid "Bottles Runtime"
@@ -1100,6 +1103,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "새로운 병 만들기"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1941,11 +1945,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2077,6 +2080,7 @@ msgstr "Bottles"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Bottles에 오신 것을 환영합니다"
@@ -2086,6 +2090,7 @@ msgstr "Bottles에 오신 것을 환영합니다"
 msgid "Run Windows Software on Linux."
 msgstr "Bottles를 사용하여 Linux에서 Windows 소프트웨어를 실행하세요!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2113,6 +2118,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2358,6 +2364,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -205,10 +205,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -794,6 +796,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr ""
@@ -960,6 +963,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1757,11 +1761,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1886,6 +1889,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1895,6 +1899,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "Paleisti Windows programas"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1921,6 +1926,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2151,6 +2157,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -209,11 +209,13 @@ msgstr "Permintaan [Segarkan] diterima."
 msgid "Calculating…"
 msgstr "Mengira…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Pemaju Botol"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -866,6 +868,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Urus versi DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1056,6 +1059,7 @@ msgstr "Pilih"
 msgid "Create New Bottle"
 msgstr "Cipta botol baharu"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1933,11 +1937,10 @@ msgstr "Cari botol anda .."
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Botol"
 
@@ -2075,6 +2078,7 @@ msgstr "Botol dicipta"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Selamat datang kepada Botol"
@@ -2084,6 +2088,7 @@ msgstr "Selamat datang kepada Botol"
 msgid "Run Windows Software on Linux."
 msgstr "Jalankan perisian Windows pada Linux Dengan Botol!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2111,6 +2116,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2369,6 +2375,7 @@ msgstr "Pengimport"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Tentang Botol"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -227,11 +227,13 @@ msgstr "`Gjenoppfrisk`-forespørsel mottatt."
 msgid "Calculating…"
 msgstr "Beregner …"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2021 - Flasker-utviklerne"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -901,6 +903,7 @@ msgstr "Velg en annen springer for denne flasken."
 msgid "Manage the Sandbox Permissions"
 msgstr "Håndter DXVK-versjoner"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -1084,6 +1087,7 @@ msgstr "Velg"
 msgid "Create New Bottle"
 msgstr "Opprett ny flaske"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1960,11 +1964,10 @@ msgstr "Gi flasken et navn"
 msgid "Steam Proton"
 msgstr "ProtonDB"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Flasker"
 
@@ -2104,6 +2107,7 @@ msgstr "Flasker startet."
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Velkommen til Flasker"
@@ -2113,6 +2117,7 @@ msgstr "Velkommen til Flasker"
 msgid "Run Windows Software on Linux."
 msgstr "Kjør Windows-programvare på Linux med Flasker!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2140,6 +2145,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2399,6 +2405,7 @@ msgstr "Importerer"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Om Flasker"

--- a/po/nl.po
+++ b/po/nl.po
@@ -237,10 +237,12 @@ msgstr "[Verversen] verzoek ontvangen."
 msgid "Calculating…"
 msgstr "Berekenen…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017, Bottles-ontwikkelaars"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Bottles-ontwikkelaars"
@@ -925,6 +927,7 @@ msgstr "Gebruik een beperkte/beheerde omgeving voor deze bottle."
 msgid "Manage the Sandbox Permissions"
 msgstr "Zandbakrechten beheren"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 msgid "Bottles Runtime"
@@ -1114,6 +1117,7 @@ msgstr "Selecteren"
 msgid "Create New Bottle"
 msgstr "Nieuwe bottle maken"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Bottles-crashrapport"
@@ -1996,11 +2000,10 @@ msgstr "Uw bottles doorzoeken…"
 msgid "Steam Proton"
 msgstr "Steam-Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2127,6 +2130,7 @@ msgstr "Bottle aangemaakt"
 msgid "Previous"
 msgstr "Vorige"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Welkom bij Bottles"
@@ -2135,6 +2139,7 @@ msgstr "Welkom bij Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Voer Windows-software uit op Linux."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows in Bottles"
@@ -2163,6 +2168,7 @@ msgstr "Alles gereed!"
 msgid "Please Finish the setup first"
 msgstr "Voltooi eerst de setup"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Begin met Bottles gebruiken"
@@ -2396,6 +2402,7 @@ msgstr "Importeren…"
 msgid "Help"
 msgstr "Hulp"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Over Bottles"

--- a/po/pl.po
+++ b/po/pl.po
@@ -205,11 +205,13 @@ msgstr "[Odśwież] otrzymano żądanie."
 msgid "Calculating…"
 msgstr "Obliczanie…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Programiści Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -847,6 +849,7 @@ msgstr "Użyj ograniczonego/zarządzanego środowiska dla tej butelki."
 msgid "Manage the Sandbox Permissions"
 msgstr "Zarządzaj uprawnieniami w Sandboksie"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Runtime Bottles"
@@ -1027,6 +1030,7 @@ msgstr "Wybierz"
 msgid "Create New Bottle"
 msgstr "Utwórz nową butelkę"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1926,11 +1930,10 @@ msgstr "Szukaj swoich butelek…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2059,6 +2062,7 @@ msgstr "Butelka utworzona"
 msgid "Previous"
 msgstr "Poprzedni"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Witamy w Bottles"
@@ -2068,6 +2072,7 @@ msgstr "Witamy w Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Uruchamiaj oprogramowanie Windows na Linuksie za pomocą Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows w Bottles"
@@ -2098,6 +2103,7 @@ msgstr "Wszystko gotowe!"
 msgid "Please Finish the setup first"
 msgstr "Prosimy o ukończenie przygotowania w pierwszej kolejności"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Zacznij używać Bottles"
@@ -2336,6 +2342,7 @@ msgstr "Importuj"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "O Bottles"

--- a/po/pt.po
+++ b/po/pt.po
@@ -204,11 +204,13 @@ msgstr "Solicitação [Atualizar] recebida."
 msgid "Calculating…"
 msgstr "Calculando…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Programadores do Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -849,6 +851,7 @@ msgstr "BottleDefina um runner diferente para esta Bottle."
 msgid "Manage the Sandbox Permissions"
 msgstr "Gerir permissões do Sandbox"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Tempo de execução do Bottles"
@@ -1032,6 +1035,7 @@ msgstr "Selecionar"
 msgid "Create New Bottle"
 msgstr "Crie um novo Bottle"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1895,11 +1899,10 @@ msgstr "Procure as suas garrafas…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2027,6 +2030,7 @@ msgstr "Bottle criada"
 msgid "Previous"
 msgstr "Anterior"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Bem-vindo(a) ao Bottles"
@@ -2036,6 +2040,7 @@ msgstr "Bem-vindo(a) ao Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Execute programas do Windows no Linux com o Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows no Bottles"
@@ -2065,6 +2070,7 @@ msgstr "Tudo pronto!"
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Comece a usar o Bottles"
@@ -2306,6 +2312,7 @@ msgstr "Importar"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Sobre o Bottles"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -203,11 +203,13 @@ msgstr "Solicitação [Atualizar] recebida."
 msgid "Calculating…"
 msgstr "Calculando…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2021 - Bottles Developers"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -851,6 +853,7 @@ msgstr "BottleDefina um runner diferente para esta Bottle."
 msgid "Manage the Sandbox Permissions"
 msgstr "Gerenciar permissões do Sandbox"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Tempo de execução do Bottles"
@@ -1030,6 +1033,7 @@ msgstr "Selecionar"
 msgid "Create New Bottle"
 msgstr "Criar nova garrafa"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1912,11 +1916,10 @@ msgstr "Procure suas garrafas…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2043,6 +2046,7 @@ msgstr "Garrafa criada"
 msgid "Previous"
 msgstr "Anterior"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Bem-vindo ao Bottles"
@@ -2051,6 +2055,7 @@ msgstr "Bem-vindo ao Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Execute programas do Windows no Linux."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows no Bottles"
@@ -2080,6 +2085,7 @@ msgstr "Tudo pronto!"
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Comece a usar o Bottles"
@@ -2322,6 +2328,7 @@ msgstr "Importar…"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Sobre o Bottles"

--- a/po/ro.po
+++ b/po/ro.po
@@ -204,10 +204,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -796,6 +798,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -967,6 +970,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr "Sticle"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1766,11 +1770,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Sticle"
 
@@ -1899,6 +1902,7 @@ msgstr "Sticle"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1908,6 +1912,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "Rulează software pentru Windows cu Sticle!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1934,6 +1939,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2165,6 +2171,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -205,10 +205,12 @@ msgstr "Получен запрос [Обновить]."
 msgid "Calculating…"
 msgstr "Вычисление…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Копирайт © 2017 разработчики Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Разработчики Bottles"
@@ -833,6 +835,7 @@ msgstr "Использовать для этой бутылки ограниче
 msgid "Manage the Sandbox Permissions"
 msgstr "Управление разрешениями песочницы"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Среда выполнения Bottles"
@@ -1007,6 +1010,7 @@ msgstr "Выбрать"
 msgid "Create New Bottle"
 msgstr "Создать новую бутылку"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Отчёт об ошибке Bottles"
@@ -1873,11 +1877,10 @@ msgstr "Поиск ваших бутылок…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2002,6 +2005,7 @@ msgstr "Бутылка создана"
 msgid "Previous"
 msgstr "Назад"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Добро пожаловать в Bottles"
@@ -2010,6 +2014,7 @@ msgstr "Добро пожаловать в Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Запускайте программы Windows на Linux."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows в Bottles"
@@ -2038,6 +2043,7 @@ msgstr "Всё готово!"
 msgid "Please Finish the setup first"
 msgstr "Пожалуйста, дождитесь окончания установки"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Можно пользоваться Bottles"
@@ -2270,6 +2276,7 @@ msgstr "Импорт…"
 msgid "Help"
 msgstr "Помощь"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "О Bottles"

--- a/po/sk.po
+++ b/po/sk.po
@@ -203,10 +203,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -792,6 +794,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #, fuzzy
 msgid "Bottles Runtime"
@@ -959,6 +962,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1756,11 +1760,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Fľaše"
 
@@ -1886,6 +1889,7 @@ msgstr "Fľaše"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1894,6 +1898,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr ""
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1920,6 +1925,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2151,6 +2157,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -204,10 +204,12 @@ msgstr ""
 msgid "Calculating…"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr ""
@@ -793,6 +795,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr ""
@@ -959,6 +962,7 @@ msgstr ""
 msgid "Create New Bottle"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1757,11 +1761,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Steklenice"
 
@@ -1886,6 +1889,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1894,6 +1898,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr ""
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr ""
@@ -1920,6 +1925,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2150,6 +2156,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -208,11 +208,13 @@ msgstr "[Освежи] захтев примљен."
 msgid "Calculating…"
 msgstr "Рачунам…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Програмери \"Флаша\""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -849,6 +851,7 @@ msgstr "Користи ограничено/контролисано окруж�
 msgid "Manage the Sandbox Permissions"
 msgstr "Управљај дозволама Сендбокс окружења"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Рантајм Флаша"
@@ -1031,6 +1034,7 @@ msgstr "Одабери"
 msgid "Create New Bottle"
 msgstr "Направи нову Флашу"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1887,11 +1891,10 @@ msgstr "Претражи твоје флаше…"
 msgid "Steam Proton"
 msgstr "Стим Протон"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Флаше"
 
@@ -2019,6 +2022,7 @@ msgstr "Флаша је направљена"
 msgid "Previous"
 msgstr "Претходан"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Добродошао/ла у Флаше"
@@ -2028,6 +2032,7 @@ msgstr "Добродошао/ла у Флаше"
 msgid "Run Windows Software on Linux."
 msgstr "Покрећи Виндовс софтвер на Линуксу уз Флаше!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Виндовс у Флашама"
@@ -2057,6 +2062,7 @@ msgstr "Све спремно!"
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Почни да користиш Флаше"
@@ -2299,6 +2305,7 @@ msgstr "Увези"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "О Флашама"

--- a/po/sv.po
+++ b/po/sv.po
@@ -207,11 +207,13 @@ msgstr "[Uppdatera] begäran mottagen."
 msgid "Calculating…"
 msgstr "Beräknar…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Bottles Utvecklare"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -852,6 +854,7 @@ msgstr "Använd en begränsad/förvaltad miljö för den här flaskan."
 msgid "Manage the Sandbox Permissions"
 msgstr "Hantera behörigheter i sandlådan"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Bottles körtid"
@@ -1035,6 +1038,7 @@ msgstr "Välj"
 msgid "Create New Bottle"
 msgstr "Skapa en ny butelj"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1894,11 +1898,10 @@ msgstr "Sök bland dina flaskor…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2028,6 +2031,7 @@ msgstr "Butelj skapad"
 msgid "Previous"
 msgstr "Tidigare"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Välkommen till Bottles"
@@ -2037,6 +2041,7 @@ msgstr "Välkommen till Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Kör Windows-program på Linux med Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows i Bottles"
@@ -2066,6 +2071,7 @@ msgstr "Allt klart!"
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Börja använda Bottles"
@@ -2309,6 +2315,7 @@ msgstr "Importera"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Om Bottles"

--- a/po/ta.po
+++ b/po/ta.po
@@ -237,10 +237,12 @@ msgstr "[உதவி] கோரிக்கை பெறப்பட்டத�
 msgid "Calculating…"
 msgstr "கணக்கீடு செய்கிறது…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "பதிப்புரிமை © 2017 பாட்டில்ஸ் டெவலப்பர்கள்"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "பாட்டில்ஸ் டெவலப்பர்கள்"
@@ -920,6 +922,7 @@ msgstr "இந்த பாட்டிலுக்கு கட்டுப்�
 msgid "Manage the Sandbox Permissions"
 msgstr "சாண்ட்பாக்ஸ் அனுமதிகளை நிர்வகிக்கவும்"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 #: bottles/frontend/ui/details-preferences.blp:291
 msgid "Bottles Runtime"
@@ -1105,6 +1108,7 @@ msgstr "தேர்ந்தெடு"
 msgid "Create New Bottle"
 msgstr "புதிய பாட்டிலை உருவாக்கவும்"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "பாட்டில்கள் விபத்து அறிக்கை"
@@ -1977,11 +1981,10 @@ msgstr "உங்கள் பாட்டில்களைத் தேடு�
 msgid "Steam Proton"
 msgstr "ஸ்டீம் புரோட்டான்"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "பாட்டில்கள்"
 
@@ -2108,6 +2111,7 @@ msgstr "பாட்டில் உருவாக்கப்பட்டத�
 msgid "Previous"
 msgstr "முந்தைய"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "பாட்டில்களுக்கு வரவேற்கிறோம்"
@@ -2116,6 +2120,7 @@ msgstr "பாட்டில்களுக்கு வரவேற்கி�
 msgid "Run Windows Software on Linux."
 msgstr "லினக்ஸில் விண்டோஸ் மென்பொருளை இயக்கவும்."
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "பாட்டில்களில் விண்டோஸ்"
@@ -2144,6 +2149,7 @@ msgstr "எல்லாம் தயார்!"
 msgid "Please Finish the setup first"
 msgstr "முதலில் அமைவை முடிக்கவும்"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "பாட்டில்களைப் பயன்படுத்தத் தொடங்கவும்"
@@ -2376,6 +2382,7 @@ msgstr "இறக்குமதி…"
 msgid "Help"
 msgstr "உதவி"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "பாட்டில்கள் பற்றி"

--- a/po/th.po
+++ b/po/th.po
@@ -207,11 +207,13 @@ msgstr "[รีเฟรช] ได้รับรีเควสต์แล้
 msgid "Calculating…"
 msgstr "กำลังคำนวณ…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - ผู้พัฒนา Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -813,6 +815,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "รันไทม์ Bottles"
@@ -984,6 +987,7 @@ msgstr "เลือก"
 msgid "Create New Bottle"
 msgstr "โคลนขวด"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr ""
@@ -1800,11 +1804,10 @@ msgstr ""
 msgid "Steam Proton"
 msgstr ""
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "ขวด"
 
@@ -1932,6 +1935,7 @@ msgstr "ชื่อขวด"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr ""
@@ -1941,6 +1945,7 @@ msgstr ""
 msgid "Run Windows Software on Linux."
 msgstr "รันซอฟต์แวร์วินโดวส์บนลินุกซ์ด้วย Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "วินโดวส์ใน Bottles"
@@ -1967,6 +1972,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr ""
@@ -2205,6 +2211,7 @@ msgstr "นำเข้า"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -203,10 +203,12 @@ msgstr "[Yenile] isteği alındı."
 msgid "Calculating…"
 msgstr "Hesaplanıyor…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Bottles Geliştiricileri"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Bottles Geliştiricileri"
@@ -836,6 +838,7 @@ msgstr "Bu Şişe için farklı bir çalıştırıcı ayarla."
 msgid "Manage the Sandbox Permissions"
 msgstr "Sandbox izinlerini yönet"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Şişeler Çalışma Zamanı"
@@ -1016,6 +1019,7 @@ msgstr "Seç"
 msgid "Create New Bottle"
 msgstr "Yeni Şişe Oluştur"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1886,11 +1890,10 @@ msgstr "Şişelerinizi arayın…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Şişeler"
 
@@ -2020,6 +2023,7 @@ msgstr "Şişe oluşturuldu"
 msgid "Previous"
 msgstr "Önceki"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Şişelere Hoş Geldiniz"
@@ -2029,6 +2033,7 @@ msgstr "Şişelere Hoş Geldiniz"
 msgid "Run Windows Software on Linux."
 msgstr "Şişeler ile Windows yazılımlarını Linux'ta çalıştırın!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Şişelerde Windows"
@@ -2056,6 +2061,7 @@ msgstr "Her şey hazır!"
 msgid "Please Finish the setup first"
 msgstr "Lütfen önce kurulumu Bitirin"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Şişeler'i kullanmaya başlayın"
@@ -2300,6 +2306,7 @@ msgstr "İçe aktar"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Şişeler Hakkında"

--- a/po/uk.po
+++ b/po/uk.po
@@ -204,10 +204,12 @@ msgstr "[Оновити] запит отриманий."
 msgid "Calculating…"
 msgstr "Обчислення…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "Copyright © 2017 Розробники Bottles"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Розробники Bottles"
@@ -833,6 +835,7 @@ msgstr "Використовувати обмежене/кероване сер�
 msgid "Manage the Sandbox Permissions"
 msgstr "Керування дозволами пісочниці"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Середовище Виконання Bottles"
@@ -1005,6 +1008,7 @@ msgstr "Обрати"
 msgid "Create New Bottle"
 msgstr "Створити нову пляшку"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Звіт про аварійне завершення Bottles"
@@ -1875,11 +1879,10 @@ msgstr "Пошук ваших пляшок…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2008,6 +2011,7 @@ msgstr "Пляшку створено"
 msgid "Previous"
 msgstr "Назад"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Ласкаво просимо до Bottles"
@@ -2016,6 +2020,7 @@ msgstr "Ласкаво просимо до Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "Запускайте програми Windows на Linux із Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Windows у Bottles"
@@ -2044,6 +2049,7 @@ msgstr "Усе готово!"
 msgid "Please Finish the setup first"
 msgstr "Будь ласка, спочатку дочекайтеся завершення"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "Почніть використовувати Bottles"
@@ -2276,6 +2282,7 @@ msgstr "Імпорт…"
 msgid "Help"
 msgstr "Довідка"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Про Bottles"

--- a/po/vi.po
+++ b/po/vi.po
@@ -209,11 +209,13 @@ msgstr "[Làm mới] yêu cầu đã nhận."
 msgid "Calculating…"
 msgstr "Tính toán…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Nhà phát triển Chai"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -862,6 +864,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "Quản lý các phiên bản DXVK"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Bottles Runtime"
@@ -1049,6 +1052,7 @@ msgstr "Chọn"
 msgid "Create New Bottle"
 msgstr "Tạo một Chai mới"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1919,11 +1923,10 @@ msgstr "Chọn một tên cho bottle của bạn"
 msgid "Steam Proton"
 msgstr "ProtonDB"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -2061,6 +2064,7 @@ msgstr "Đã tạo Chai"
 msgid "Previous"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "Chào mừng bạn đến với Chai"
@@ -2070,6 +2074,7 @@ msgstr "Chào mừng bạn đến với Chai"
 msgid "Run Windows Software on Linux."
 msgstr "Chạy phần mềm Windows trên Linux với Bottles!"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2097,6 +2102,7 @@ msgstr ""
 msgid "Please Finish the setup first"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 #, fuzzy
 msgid "Start using Bottles"
@@ -2356,6 +2362,7 @@ msgstr "Trình Nhập"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "Về Chai"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -203,10 +203,12 @@ msgstr "[刷新] 请求已收到。"
 msgid "Calculating…"
 msgstr "计算中…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "版权所有 © 2017 Bottles 开发者"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 msgid "Bottles Developers"
 msgstr "Bottles 开发者"
@@ -807,6 +809,7 @@ msgstr "对此 bottle 使用受限/受管理环境。"
 msgid "Manage the Sandbox Permissions"
 msgstr "管理沙盒权限"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Bottles 运行时（Runtime）"
@@ -972,6 +975,7 @@ msgstr "选择"
 msgid "Create New Bottle"
 msgstr "新建 Bottle"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 msgid "Bottles Crash Report"
 msgstr "Bottles 崩溃报告"
@@ -1800,11 +1804,10 @@ msgstr "搜索你的 bottles…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1929,6 +1932,7 @@ msgstr "Bottle 已创建"
 msgid "Previous"
 msgstr "上一个"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "欢迎使用 Bottles"
@@ -1937,6 +1941,7 @@ msgstr "欢迎使用 Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "在 Linux 上运行 Windows 软件。"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 msgid "Windows in Bottles"
 msgstr "Bottles 中的窗口"
@@ -1963,6 +1968,7 @@ msgstr "大功告成！"
 msgid "Please Finish the setup first"
 msgstr "请先完成设置"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "开始使用 Bottles"
@@ -2193,6 +2199,7 @@ msgstr "导入…"
 msgid "Help"
 msgstr "帮助"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "关于 Bottles"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -203,11 +203,13 @@ msgstr "［重新整理］請求已收到。"
 msgid "Calculating…"
 msgstr "計算中…"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:7
 #, fuzzy
 msgid "Copyright © 2017 Bottles Developers"
 msgstr "© 2017-2022 - Bottles 開發者"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/about.blp:13
 #, fuzzy
 msgid "Bottles Developers"
@@ -828,6 +830,7 @@ msgstr ""
 msgid "Manage the Sandbox Permissions"
 msgstr "管理 DXVK 版本"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/details-preferences.blp:287
 msgid "Bottles Runtime"
 msgstr "Bottles 執行環境"
@@ -1004,6 +1007,7 @@ msgstr "選取"
 msgid "Create New Bottle"
 msgstr "鑄造新酒瓶"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/dialog-crash-report.blp:8
 #, fuzzy
 msgid "Bottles Crash Report"
@@ -1856,11 +1860,10 @@ msgstr "在您的酒瓶中搜尋…"
 msgid "Steam Proton"
 msgstr "Steam Proton"
 
-#: bottles/frontend/ui/list.blp:42 bottles/frontend/ui/window.blp:37
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
+#: bottles/frontend/ui/list.blp:42
 #: bottles/frontend/ui/window.blp:52
 #: bottles/frontend/windows/main_window.py:166
-#: data/com.usebottles.bottles.desktop.in:3
-#: data/com.usebottles.bottles.metainfo.xml.in:7
 msgid "Bottles"
 msgstr "Bottles"
 
@@ -1991,6 +1994,7 @@ msgstr "已鑄好了酒瓶"
 msgid "Previous"
 msgstr "上一步"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:59
 msgid "Welcome to Bottles"
 msgstr "歡迎來到 Bottles"
@@ -2000,6 +2004,7 @@ msgstr "歡迎來到 Bottles"
 msgid "Run Windows Software on Linux."
 msgstr "使用 Bottles🍷以在 Linux 上執行 Windows 程式！"
 
+# Translators: Bottles is a generic noun here, referring to wine prefixes and is to be translated
 #: bottles/frontend/ui/onboard.blp:65
 #, fuzzy
 msgid "Windows in Bottles"
@@ -2028,6 +2033,7 @@ msgstr "已就緒！"
 msgid "Please Finish the setup first"
 msgstr "請先完成初始設定"
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/onboard.blp:120
 msgid "Start using Bottles"
 msgstr "開始使用 Bottles"
@@ -2267,6 +2273,7 @@ msgstr "匯入"
 msgid "Help"
 msgstr ""
 
+# Translators: Bottles is a proper noun referring to the app
 #: bottles/frontend/ui/window.blp:31
 msgid "About Bottles"
 msgstr "關於 Bottles"


### PR DESCRIPTION
# Description

Should resolve #2433

Makes "Bottles" as proper noun not translatable, adds translation notes on where it is supposed to be translated

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


