### PR TITLE
feat: enable VKD3D in the Gaming environment

### DIFF
--- a/bottles/backend/models/samples.py
+++ b/bottles/backend/models/samples.py
@@ -84,7 +84,7 @@ class Samples:
             "Parameters": {
                 "dxvk": True,
                 # "nvapi": True,
-                "vkd3d": False,
+                "vkd3d": True,
                 "sync": "esync",
                 "fsr": False,
                 "discrete_gpu": True,


### PR DESCRIPTION
# Description
Enables VKD3D by default when creating a Bottle with the gaming environment, as most games releasing currently are made under DX12 and without, games won't launch properly.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- Locally
