### PR TITLE
fix: wrong call to update_programs()

### DIFF
--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -193,7 +193,9 @@ class BottleView(Adw.PreferencesPage):
                 args=args,
                 terminal=self.config.get("run_in_terminal"),
             )
-            RunAsync(executor.run, self.update_programs)
+            def callback(a,b):
+                self.update_programs()
+            RunAsync(executor.run, callback)
 
         else:
             self.window.show_toast(_("File \"{0}\" is not a .exe or .msi file").format(file.get_basename().split("/")[-1]))
@@ -407,7 +409,10 @@ class BottleView(Adw.PreferencesPage):
                 args=args,
                 terminal=self.config.get("run_in_terminal"),
             )
-            RunAsync(executor.run, self.update_programs)
+
+            def callback(a,b):
+                self.update_programs()
+            RunAsync(executor.run, callback)
 
     def __backup(self, widget, backup_type):
         """

--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -280,7 +280,7 @@ class BottleView(Adw.PreferencesPage):
             callback=set_path
         )
 
-    def update_programs(self, config=None, force_add: dict = None):
+    def update_programs(self, config: dict = None, force_add: dict = None):
         """
         This function update the programs lists.
         """


### PR DESCRIPTION
# Description
The problem was that update_programs() wait for arguments, and if used in a callback to RunAsync, it will receive the wrong arguments. 

Fixes properly #2377

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
Locally
