### PR TITLE
add: locale misconfigured warning

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -48,6 +48,7 @@ from bottles.backend.managers.epicgamesstore import EpicGamesStoreManager
 from bottles.backend.managers.ubisoftconnect import UbisoftConnectManager
 from bottles.backend.utils.file import FileUtils
 from bottles.backend.utils.lnk import LnkUtils
+from bottles.backend.utils.locale import available_locales, sys_locale
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.utils.generic import sort_by_version
 from bottles.backend.utils.decorators import cache
@@ -840,6 +841,15 @@ class Manager:
             '''
             wineboot.kill()
             wineserver.wait()
+
+        if key == "Language":
+            # XIM won't work with misconfigured locale, give user some hint.
+            installed_locales = available_locales()
+            host_locale = sys_locale()
+            if value != 'sys' and value not in installed_locales:
+                logging.warning(f"Target locale '{value}' is not existed in your system, which may cause problem.")
+            if value == 'sys' and host_locale[0] in ["C", "POSIX"]:
+                logging.warning(f"Your current locale is '{host_locale}', which may cause problem")
 
         if scope != "":
             if remove:

--- a/bottles/backend/utils/locale.py
+++ b/bottles/backend/utils/locale.py
@@ -1,0 +1,16 @@
+import locale
+import subprocess
+
+
+def available_locales() -> list:
+    """
+    List available locale names on host system
+    """
+    out = subprocess.run(['locale', '-a'], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    rv = out.rstrip('\n').splitlines()
+    return rv
+
+
+# noinspection PyTypeChecker
+def sys_locale() -> tuple:
+    return locale.getlocale()

--- a/bottles/backend/utils/meson.build
+++ b/bottles/backend/utils/meson.build
@@ -18,7 +18,8 @@ bottles_sources = [
   'vdf.py',
   'imagemagick.py',
   'proc.py',
-  'yaml.py'
+  'yaml.py',
+  'locale.py'
 ]
 
 install_data(bottles_sources, install_dir: utilsdir)


### PR DESCRIPTION
# Description
Input Method (IM) is a mechanism to input specific characters which are not provided on input devices like a keyboard to the various desktop applications. IM is required for some languages such as Chinese, Indic, Japanese, Korean, and Thai because these languages contain a much larger set of characters than what is available on the input devices. IM converts combinations of keystrokes from input devices to language-specific characters, and sends the information back to the focused application.

XIM, the input method protocol which WineHQ is using, requires a properly locale configuring to work.

This PR adds a warning log in `Manager.update_config()`, to notice user about misconfigured locale.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] User Experience

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Not tested
