### PR TITLE
Addresses bug from patoolib

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -501,10 +501,14 @@ class DependencyManager:
 
             os.makedirs(archive_path)
             try:
-                patoolib.extract_archive(
-                    os.path.join(Paths.temp, file),
-                    outdir=archive_path
-                )
+                ext_path = patoolib.extract_archive(os.path.join(Paths.temp, file), outdir=archive_path)
+                ext_file = ext_path + '/' + os.path.basename(ext_path)
+                if os.path.exists(archive_path):
+                    if os.path.isfile(ext_file):
+                        patoolib.extract_archive(
+                        ext_file,
+                        outdir=ext_path + '/'
+                        )
             except:
                 return False
             return True
@@ -552,6 +556,9 @@ class DependencyManager:
         try:
             if "*" in step.get('file_name'):
                 files = glob(f"{path}/{step.get('file_name')}")
+                if not files:
+                    logging.info(f"File/s not found in {path}")
+                    return False
                 for fg in files:
                     _name = fg.split("/")[-1]
                     _path = os.path.join(path, _name)

--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -557,7 +557,7 @@ class DependencyManager:
             if "*" in step.get('file_name'):
                 files = glob(f"{path}/{step.get('file_name')}")
                 if not files:
-                    logging.info(f"File/s not found in {path}")
+                    logging.info(f"File(s) not found in {path}")
                     return False
                 for fg in files:
                     _name = fg.split("/")[-1]


### PR DESCRIPTION
# Description
Fixes a bug in "patoolib" that does not extract .tar.xz files correctly if you have xz or 7z installed in your system.
Also added a check to return False when a source DLL is being copied to the wine prefix and the source file does not exist. 

Fixes https://github.com/bottlesdevs/Bottles/issues/2491

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
To reproduce, install xz or 7z in your distro.

