### PR TITLE
fix: add dest to cabextract on local files

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -431,7 +431,8 @@ class DependencyManager:
 
             if not CabExtract().run(
                     f"{path}/{step.get('file_name')}",
-                    file_path
+                    file_path,
+                    destination=dest
             ):
                 return False
 


### PR DESCRIPTION
# Description
It is not used currently, but using action `cab_extract` in dependencies on local files is not working because the destination isn't provided. This PR adds the destination argument so that it works properly.

Fixes nothing for now

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] using local repos and extracting a cab from the temp folder
