### PR TITLE
term-ui: dynamic length of progress bar according to terminal size

### DIFF
--- a/bottles/backend/downloader.py
+++ b/bottles/backend/downloader.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os
 import time
 import requests
 from gi.repository import GLib
@@ -94,10 +95,14 @@ class Downloader:
         speed_str = FileUtils.get_human_size(count * block_size / (time.time() - self.start_time))
         name = self.file.split("/")[-1]
         c_close, c_complete, c_incomplete = "\033[0m", "\033[92m", "\033[90m"
+        divider = 2
+        full_text_size = len(f"\r{c_complete}{name} ({100}%) {'━' * int(100 / divider)} ({done_str}/{total_str} - 100MB/S)")
+        while os.get_terminal_size().columns < full_text_size:
+            divider = divider + 1
+            full_text_size = len(f"\r{c_complete}{name} ({100}%) {'━' * int(100 / divider)} ({total_str}/{total_str} - 100MB/S)")
         try:
             print(
-                f"\r{c_incomplete if percent < 100 else c_complete}{name} ({percent}%) \
-    {'━' * int(percent / 2)} ({done_str}/{total_str} - {speed_str})",
+                f"\r{c_incomplete if percent < 100 else c_complete}{name} ({percent}%) {'━' * int(percent / divider)} ({done_str}/{total_str} - {speed_str})",
                 end=""
             )
             if percent == 100:

--- a/bottles/backend/downloader.py
+++ b/bottles/backend/downloader.py
@@ -96,10 +96,11 @@ class Downloader:
         name = self.file.split("/")[-1]
         c_close, c_complete, c_incomplete = "\033[0m", "\033[92m", "\033[90m"
         divider = 2
-        full_text_size = len(f"\r{c_complete}{name} ({100}%) {'━' * int(100 / divider)} ({done_str}/{total_str} - 100MB/S)")
+        full_text_size = len(f"\r{c_complete}{name} (100%) {'━' * int(100 / divider)} ({total_str}/{total_str} - 100MB)")
         while os.get_terminal_size().columns < full_text_size:
             divider = divider + 1
-            full_text_size = len(f"\r{c_complete}{name} ({100}%) {'━' * int(100 / divider)} ({total_str}/{total_str} - 100MB/S)")
+            full_text_size = len(f"\r{c_complete}{name} (100%) {'━' * int(100 / divider)} ({total_str}/{total_str} - 100MB)")
+            if divider > 10: break
         try:
             print(
                 f"\r{c_incomplete if percent < 100 else c_complete}{name} ({percent}%) {'━' * int(percent / divider)} ({done_str}/{total_str} - {speed_str})",


### PR DESCRIPTION
# Description
This change is just QoL, it was annoying when the terminal was to small and we download a component, it will spam the download bar. Now it changes the size dynamically, making it harder (but not impossible) to have spamming in the term.

![Screenshot_20230109_131627](https://user-images.githubusercontent.com/5410562/211306486-8b2a10ef-1c60-4cb6-a022-01df09a0dbb5.png)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally