### PR TITLE
backend: Add `import_bundle` on dependency installation

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -613,10 +613,11 @@ class DependencyManager:
             dlls = glob(os.path.join(path, step.get("dll")))
 
             bundle = {"HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides": []}
-            
+            import ntpath
             for dll in dlls:
+                dll_name = os.path.splitext(os.path.basename(dll))[0]
                 bundle["HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides"].append({
-                    "value": dll,
+                    "value": dll_name,
                     "data": step.get("type")
                 })
 

--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -612,12 +612,15 @@ class DependencyManager:
             path = step["url"].replace("temp/", f"{Paths.temp}/")
             dlls = glob(os.path.join(path, step.get("dll")))
 
+            bundle = {"HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides": []}
+            
             for dll in dlls:
-                reg.add(
-                    key="HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides",
-                    value=dll,
-                    data=step.get("type")
-                )
+                bundle["HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides"].append({
+                    "value": dll,
+                    "data": step.get("type")
+                })
+
+            reg.import_bundle(bundle)
             return True
 
         if step.get("bundle"):


### PR DESCRIPTION
# Description
This improves the installation time a lot for certain dependencies (looking at you faudio with your 34 DLLs)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally
