### PR TITLE
fix: Add runner libs to fix embedded GStreamer not finding them

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -230,6 +230,8 @@ class WineCommand:
         runner_path = ManagerUtils.get_runner_path(config.get("Runner"))
         if arch == "win64":
             runner_libs = [
+                "lib",
+                "lib64",
                 "lib/wine/x86_64-unix",
                 "lib32/wine/x86_64-unix",
                 "lib64/wine/x86_64-unix",
@@ -244,6 +246,7 @@ class WineCommand:
             ]
         else:
             runner_libs = [
+                "lib",
                 "lib/wine/i386-unix",
                 "lib32/wine/i386-unix",
                 "lib64/wine/i386-unix"

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -20,6 +20,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
   - --require-version=1.1.2
 
 inherit-extensions:


### PR DESCRIPTION
# Description
When using a runner that provides GST plugins, depending on the distro those errors can happen:
```
(wine:2356): GStreamer-WARNING **: 00:08:05.072: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgsthls.so': libnettle.so.6: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.140: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstbz2.so': libbz2.so.1.0: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.151: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstrsdav1d.so': libdav1d.so.5: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.161: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstwebp.so': libwebp.so.6: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.171: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstvpx.so': libvpx.so.5: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.199: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstmatroska.so': libbz2.so.1.0: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.327: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstdtls.so': libcrypto.so.1.1: cannot open shared object file: No such file or directory

(wine:2356): GStreamer-WARNING **: 00:08:05.332: Failed to load plugin '/home/USER/.var/app/com.usebottles.bottles/data/bottles/runners/wine-ge-proton7-35/lib64/gstreamer-1.0/libgstlibav.so': libavfilter.so.7: cannot open shared object file: No such file or directory
```

This is because the plugins that are shipped are built against a specific version of the library, and if the distro ships more up to date versions (for example Arch), it can't load them. Fortunately, some of those libraries are also shipped in the runner, in the `lib` and `lib64` directory.

This PR simply adds this path to `LD_LIBRARY_PATH` so that GStreamer can find the good versions provided by the runner.

Some libraries are still not shipped, but there isn't much we can do for this.

If there is still some problems with GStreamer, the variable `BOTTLES_USE_SYSTEM_GSTREAMER` can be used to use the system GStreamer plugins, that will be built against the good version of the libraries (hopefully).

Also adds back the GST_PLUGIN_SYSTEM_PATH in the Flatpak, to mirror the Flathub version.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally, Flatpak and non-Flatpak
