### PR TITLE
fix: broken back button if DXVK and VKD3D are disabled

### DIFF
--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -826,7 +826,6 @@ class PreferencesView(Adw.PreferencesPage):
         self.manager.install_dll_component(config=kwargs["config"], component=kwargs["component"], remove=True)
         # Install new version
         self.manager.install_dll_component(config=kwargs["config"], component=kwargs["component"])
-        self.queue.end_task()
 
     def __set_dxvk(self, *_args):
         """Set the DXVK version to use for the bottle"""
@@ -835,7 +834,6 @@ class PreferencesView(Adw.PreferencesPage):
 
         if (self.combo_dxvk.get_selected()) == 0:
             self.set_dxvk_status(pending=True)
-            self.queue.add_task()
 
             RunAsync(
                 task_func=self.manager.install_dll_component,
@@ -880,7 +878,6 @@ class PreferencesView(Adw.PreferencesPage):
 
         if (self.combo_dxvk.get_selected()) == 0:
             self.set_vkd3d_status(pending=True)
-            self.queue.add_task()
 
             RunAsync(
                 task_func=self.manager.install_dll_component,


### PR DESCRIPTION
# Description
Too many queue.add_task and queue.end_task

Fixes #2522

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally
