### PR TITLE
ui: Make VKD3D not enable-able without DXVK

### DIFF
--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -878,7 +878,7 @@ class PreferencesView(Adw.PreferencesPage):
         self.set_vkd3d_status(pending=True)
         self.queue.add_task()
 
-        if (self.combo_dxvk.get_selected()) == 0:
+        if (self.combo_vkd3d.get_selected()) == 0:
             self.set_vkd3d_status(pending=True)
             self.queue.add_task()
 

--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -48,6 +48,10 @@ from bottles.backend.wine.reg import Reg
 from bottles.backend.wine.regkeys import RegKeys
 from bottles.backend.utils.gpu import GPUUtils
 
+from bottles.backend.logger import Logger
+
+logging = Logger()
+
 
 # noinspection PyUnusedLocal
 @Gtk.Template(resource_path='/com/usebottles/bottles/details-preferences.ui')
@@ -837,6 +841,10 @@ class PreferencesView(Adw.PreferencesPage):
             self.set_dxvk_status(pending=True)
             self.queue.add_task()
 
+            if self.combo_vkd3d.get_selected() != 0:
+                logging.info("VKD3D is enabled, disabling")
+                self.combo_vkd3d.set_selected(0)
+
             RunAsync(
                 task_func=self.manager.install_dll_component,
                 callback=self.set_dxvk_status,
@@ -897,6 +905,10 @@ class PreferencesView(Adw.PreferencesPage):
                 scope="Parameters"
             ).data["config"]
         else:
+            if self.combo_dxvk.get_selected() == 0:
+                logging.info("DXVK is disabled, reenabling")
+                self.combo_dxvk.set_selected(1)
+
             vkd3d = self.manager.vkd3d_available[self.combo_vkd3d.get_selected() - 1]
             self.config = self.manager.update_config(
                 config=self.config,


### PR DESCRIPTION
# Description
If DXVK is disabled and VKD3D wants to be enabled, it will also enable DXVK. If DXVK wants to be disabled and VKD3D is enabled, then it will disable VKD3D.

Fixes #2427

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally
