### PR TITLE
fix: critical error when not using a Nvidia GPU

### DIFF
--- a/bottles/backend/utils/nvidia.py
+++ b/bottles/backend/utils/nvidia.py
@@ -6,6 +6,7 @@ from ctypes import CDLL, POINTER, Structure, addressof, c_char_p, c_int, c_void_
 import subprocess
 
 from bottles.backend.logger import Logger
+from bottles.backend.utils.gpu import GPUUtils, GPUVendors
 
 logging = Logger()
 
@@ -89,15 +90,7 @@ def get_nvidia_dll_path():
     See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/issues/71 for
     background on the chosen method of DLL discovery.
     """
-    _proc = subprocess.Popen(
-        f"lspci | grep -iP 'nvidia'",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        shell=True
-    )
-    stdout, stderr = _proc.communicate()
-    if len(stdout) == 0:
-        return None
+    if not GPUUtils.is_gpu(GPUVendors.NVIDIA): return None
 
     libglx_path = get_nvidia_glx_path()
     if not libglx_path:

--- a/bottles/backend/utils/nvidia.py
+++ b/bottles/backend/utils/nvidia.py
@@ -6,7 +6,6 @@ from ctypes import CDLL, POINTER, Structure, addressof, c_char_p, c_int, c_void_
 import subprocess
 
 from bottles.backend.logger import Logger
-from bottles.backend.utils.gpu import GPUUtils, GPUVendors
 
 logging = Logger()
 
@@ -90,6 +89,7 @@ def get_nvidia_dll_path():
     See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/issues/71 for
     background on the chosen method of DLL discovery.
     """
+    from bottles.backend.utils.gpu import GPUUtils, GPUVendors
     if not GPUUtils.is_gpu(GPUVendors.NVIDIA): return None
 
     libglx_path = get_nvidia_glx_path()

--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -46,7 +46,7 @@ from bottles.frontend.windows.vmtouch import VmtouchDialog
 from bottles.backend.wine.catalogs import win_versions
 from bottles.backend.wine.reg import Reg
 from bottles.backend.wine.regkeys import RegKeys
-from bottles.backend.utils.gpu import GPUUtils
+from bottles.backend.utils.gpu import GPUUtils, GPUVendors
 
 from bottles.backend.logger import Logger
 
@@ -173,7 +173,7 @@ class PreferencesView(Adw.PreferencesPage):
         # endregion
 
         """Set DXVK_NVAPI related rows to visible when an NVIDIA GPU is detected (invisible by default)"""
-        is_nvidia_gpu = GPUUtils.is_gpu("nvidia")
+        is_nvidia_gpu = GPUUtils.is_gpu(GPUVendors.NVIDIA)
         self.row_nvapi.set_visible(is_nvidia_gpu)
         self.combo_nvapi.set_visible(is_nvidia_gpu)
 


### PR DESCRIPTION
# Description
This fixes the critical (but benign) error when starting Bottles without a Nvidia 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally with a Nvidia GPU
