### PR TITLE
fix: update library entries when renaming a bottle

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -700,6 +700,9 @@ class Manager:
         """
         bottles = os.listdir(Paths.bottles)
 
+        # Empty local bottles
+        self.local_bottles = {}
+
         def process_bottle(bottle):
             _name = bottle
             _bottle = os.path.join(Paths.bottles, bottle)


### PR DESCRIPTION
# Description
Renaming a bottle breaks library entries as the library.yml wasn't updated. Now, the changes correctly updates the library config file, and also properly update the bottles list in manager.py.

Fixes #2490 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally
