### PR TITLE
frontend: Fix various library crashes and empty library items

### DIFF
--- a/bottles/backend/managers/library.py
+++ b/bottles/backend/managers/library.py
@@ -77,7 +77,15 @@ class LibraryManager:
 
         self.__library[_uuid] = data
         self.save_library()
-    
+
+    def download_thumbnail(self, uuid: str, config: dict):
+        if self.__library.get(uuid):
+            data = self.__library.get(uuid)
+            self.__library[uuid]['thumbnail'] = SteamGridDBManager.get_game_grid(data['name'], config)
+            self.save_library()
+            return
+        logging.warning(f'Entry not found in library, can\'t download thumbnail: {_uuid}')
+
     def __already_in_library(self, data: dict):
         """
         Checks if the entry UUID is already in the library.yml file.

--- a/bottles/backend/managers/library.py
+++ b/bottles/backend/managers/library.py
@@ -79,12 +79,20 @@ class LibraryManager:
         self.save_library()
 
     def download_thumbnail(self, uuid: str, config: dict):
-        if self.__library.get(uuid):
-            data = self.__library.get(uuid)
-            self.__library[uuid]['thumbnail'] = SteamGridDBManager.get_game_grid(data['name'], config)
-            self.save_library()
-            return
-        logging.warning(f'Entry not found in library, can\'t download thumbnail: {_uuid}')
+        if not self.__library.get(uuid):
+            logging.warning(f'Entry not found in library, can\'t download thumbnail: {_uuid}')
+            return False
+
+        data = self.__library.get(uuid)
+        value = SteamGridDBManager.get_game_grid(data['name'], config)
+
+        if not value:
+            return False
+
+        self.__library[uuid]['thumbnail'] = value
+        self.save_library()
+        return True
+
 
     def __already_in_library(self, data: dict):
         """

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -44,6 +44,7 @@ from bottles.backend.managers.component import ComponentManager
 from bottles.backend.managers.installer import InstallerManager
 from bottles.backend.managers.dependency import DependencyManager
 from bottles.backend.managers.steam import SteamManager
+from bottles.backend.managers.library import LibraryManager
 from bottles.backend.managers.epicgamesstore import EpicGamesStoreManager
 from bottles.backend.managers.ubisoftconnect import UbisoftConnectManager
 from bottles.backend.repos.repo import RepoStatus
@@ -1391,6 +1392,13 @@ class Manager:
             logging.info(f"Removing applications installed with the bottle…")
             for inst in glob(f"{Paths.applications}/{config.get('Name')}--*"):
                 os.remove(inst)
+
+            logging.info(f"Removing library entries associated with this bottle…")
+            library_manager = LibraryManager()
+            entries = library_manager.get_library().copy()
+            for uuid, entry in entries.items():
+                if entry.get('bottle').get('name') == config.get('Name'):
+                    library_manager.remove_from_library(uuid)
 
             if config.get("Custom_Path"):
                 logging.info(f"Removing placeholder…")

--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -264,6 +264,7 @@ class PreferencesView(Adw.PreferencesPage):
             if bottle.get("name") == old_name:
                 logging.info(f"Updating library entry for {entry.get('name')}")
                 entries[uuid]["bottle"]["name"] = new_name
+                break
 
         library_manager.__library = entries
         library_manager.save_library()

--- a/bottles/frontend/views/library.py
+++ b/bottles/frontend/views/library.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import contextlib
 import logging
 import re
 from datetime import datetime
@@ -53,8 +54,10 @@ class LibraryView(Adw.Bin):
         self.scroll_window.set_visible(not len(entries) == 0)
 
         for u, e in entries.items():
-            entry = LibraryEntry(self, u, e)
-            self.main_flow.append(entry)
+            # We suppress exceptions so that it doesn't continue if the init fails
+            with contextlib.suppress(Exception):
+                entry = LibraryEntry(self, u, e)
+                self.main_flow.append(entry)
 
     def remove_entry(self,  entry):
         def undo_callback(*args):

--- a/bottles/frontend/widgets/library.py
+++ b/bottles/frontend/widgets/library.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import logging
 import os
 import math
 from datetime import datetime
@@ -25,9 +24,13 @@ from gi.repository import Gtk, Gdk, GLib, GdkPixbuf, Adw
 from bottles.frontend.utils.threading import RunAsync
 from bottles.backend.managers.library import LibraryManager
 from bottles.backend.managers.thumbnail import ThumbnailManager
+from bottles.backend.managers.steamgriddb import SteamGridDBManager
 from bottles.backend.runner import Runner
 from bottles.backend.wine.winedbg import WineDbg
 from bottles.backend.wine.executor import WineExecutor
+from bottles.backend.logger import Logger
+
+logging = Logger()
 
 
 @Gtk.Template(resource_path='/com/usebottles/bottles/library-entry.ui')
@@ -59,8 +62,11 @@ class LibraryEntry(Gtk.Box):
         self.entry = entry
         self.config = self.__get_config()
         
+        # This happens when a Library entry is an "orphan" (no bottles associated)
         if self.config is None:
-            return
+            library_manager = LibraryManager()
+            library_manager.remove_from_library(self.uuid)
+            raise Exception
 
         self.program = self.__get_program()
 
@@ -74,6 +80,15 @@ class LibraryEntry(Gtk.Box):
 
         if entry.get('thumbnail'):
             path = ThumbnailManager.get_path(self.config, entry['thumbnail'])
+
+            if path is None:
+                # redownloading *should* never fail as it was successfully downloaded before
+                logging.info("Redownloading grid image...")
+                library_manager = LibraryManager()
+                library_manager.download_thumbnail(self.uuid, self.config)
+                entry = library_manager.get_library().get(uuid)
+                path = ThumbnailManager.get_path(self.config, entry['thumbnail'])
+
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, 240, 360)
             self.img_cover.set_pixbuf(pixbuf)
             self.img_cover.set_visible(True)

--- a/bottles/frontend/widgets/library.py
+++ b/bottles/frontend/widgets/library.py
@@ -84,14 +84,16 @@ class LibraryEntry(Gtk.Box):
                 # redownloading *should* never fail as it was successfully downloaded before
                 logging.info("Redownloading grid image...")
                 library_manager = LibraryManager()
-                library_manager.download_thumbnail(self.uuid, self.config)
-                entry = library_manager.get_library().get(uuid)
-                path = ThumbnailManager.get_path(self.config, entry['thumbnail'])
+                result = library_manager.download_thumbnail(self.uuid, self.config)
+                if result:
+                    entry = library_manager.get_library().get(uuid)
+                    path = ThumbnailManager.get_path(self.config, entry['thumbnail'])
 
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, 240, 360)
-            self.img_cover.set_pixbuf(pixbuf)
-            self.img_cover.set_visible(True)
-            self.label_no_cover.set_visible(False)
+            if path is not None:
+                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, 240, 360)
+                self.img_cover.set_pixbuf(pixbuf)
+                self.img_cover.set_visible(True)
+                self.label_no_cover.set_visible(False)
 
         motion_ctrl = Gtk.EventControllerMotion.new()
         motion_ctrl.connect("enter", self.__on_motion_enter)

--- a/bottles/frontend/widgets/library.py
+++ b/bottles/frontend/widgets/library.py
@@ -24,7 +24,6 @@ from gi.repository import Gtk, Gdk, GLib, GdkPixbuf, Adw
 from bottles.frontend.utils.threading import RunAsync
 from bottles.backend.managers.library import LibraryManager
 from bottles.backend.managers.thumbnail import ThumbnailManager
-from bottles.backend.managers.steamgriddb import SteamGridDBManager
 from bottles.backend.runner import Runner
 from bottles.backend.wine.winedbg import WineDbg
 from bottles.backend.wine.executor import WineExecutor


### PR DESCRIPTION
# Description
- if the bottle was deleted but the library entry remains, delete it
- if images are missing, redownload them if they were present
- deleting a bottle now deletes the library entry to avoid empty grey entries
- Renaming a program renames the library entry and redownloads a cover

---

- Fixes #2416 
- Fixes #2354
- Fixes #2511
- Fixes #2490
- Fixes #2386

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally, with multiple programs that have thumbnails or not
