### PR TITLE
fix/urgent: downloads not working if no terminal attached

### DIFF
--- a/bottles/backend/downloader.py
+++ b/bottles/backend/downloader.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
+import shutil
 import time
 import requests
 from gi.repository import GLib
@@ -97,7 +97,7 @@ class Downloader:
         c_close, c_complete, c_incomplete = "\033[0m", "\033[92m", "\033[90m"
         divider = 2
         full_text_size = len(f"\r{c_complete}{name} (100%) {'━' * int(100 / divider)} ({total_str}/{total_str} - 100MB)")
-        while os.get_terminal_size().columns < full_text_size:
+        while shutil.get_terminal_size().columns < full_text_size:
             divider = divider + 1
             full_text_size = len(f"\r{c_complete}{name} (100%) {'━' * int(100 / divider)} ({total_str}/{total_str} - 100MB)")
             if divider > 10: break


### PR DESCRIPTION
# Description
This fixes the issue where downloads are not working from the app.

`shutil.get_terminal_size()` will never raise an exception. If no terminal is used, then it will fallback to a size of (80, 24) per default, which will fix the problem as `os.get_terminal_size()` raises an exception if there is no terminal.

Fixes a lot of issues

**NOTE: should be merged ASAP and released, as downloads being not available from the app is quite blocking.**

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally
