### PR TITLE
fix incorrect text codec detection

### DIFF
--- a/bottles/backend/utils/generic.py
+++ b/bottles/backend/utils/generic.py
@@ -20,7 +20,9 @@ import random
 import re
 import string
 import subprocess
-import sys
+from typing import Optional
+
+import chardet as chardet
 
 
 def validate_url(url: str):
@@ -38,54 +40,12 @@ def validate_url(url: str):
     return re.match(regex, url) is not None
 
 
-def detect_encoding(text: bytes):
+def detect_encoding(text: bytes) -> Optional[str]:
     """
     Detect the encoding of a text by its bytes. Return None if it
     can't be detected.
     """
-    encodings = [
-        "ascii",
-        "utf-8",
-        "utf-16",
-        "utf-32",
-        "latin-1",
-        "big5",
-        "gb2312",
-        "gb18030",
-        "euc_jp",
-        "euc_jis_2004",
-        "euc_jisx0213",
-        "shift_jis",
-        "shift_jis_2004",
-        "shift_jisx0213",
-        "iso2022_jp",
-        "iso2022_jp_1",
-        "iso2022_jp_2",
-        "iso2022_jp_2004",
-        "iso2022_jp_3",
-        "iso2022_jp_ext",
-        "iso2022_kr",
-        "utf_32_be",
-        "utf_32_le",
-        "utf_16_be",
-        "utf_16_le",
-        "utf_7",
-        "utf_8_sig",
-        "utf_16_be_sig",
-        "utf_16_le_sig",
-        "utf_32_be_sig",
-        "utf_32_le_sig"
-    ]
-
-    if sys.stdout is not None:
-        encodings.append(sys.stdout.encoding)
-
-    for encoding in encodings:
-        with contextlib.suppress(UnicodeDecodeError):
-            text.decode(encoding)
-            return encoding
-
-    return None
+    return chardet.detect(text).get('encoding')
 
 
 def is_glibc_min_available():


### PR DESCRIPTION
# Description
Current implementation of `generic.detect_encoding()` use a guess list to detect text encoding
which will break all codecs which use similar encoding method to the codec ordered before it
affect `WineCommand` output log afaik

For example:
- `codepage 936` use by Wine by default when setting language to Simplified Chinese, which is actually `gb2312`/`gbk` in different Windows version
- `gb2312` use one or two bytes for encoding
- `utf-16` use two bytes for encoding
- they use different codepoint table
- `utf-16` ordered before `gb2312` in guess list
- `gb2312` encoded bytes will be matched as `utf-16`

then garbled text happened:
```Python
>>> '你好'.encode('gb2312').decode('utf-16')
'\ue3c4쎺'
```
or
```Python
>>> 'こんにちは'.encode('euc-jp').decode('utf-16')
'뎤\uf3a4쮤솤쾤'
```

This PR replaced the `detect_encoding()` with `chardet` library
which is already included in Bottles

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Change to CJK language and install font via Bottles, then `reg add` log will print correct message that piped from command stdout
