### PR TITLE
Don't enable Steam Runtime when switching to `wine-ge-proton`

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -345,17 +345,16 @@ class Manager:
 
         # lock winemenubuilder.exe
         for runner in runners:
-            winemenubuilder_paths = [
-                f"{runner}lib64/wine/x86_64-windows/winemenubuilder.exe",
-                f"{runner}lib/wine/x86_64-windows/winemenubuilder.exe",
-                f"{runner}lib32/wine/i386-windows/winemenubuilder.exe",
-                f"{runner}lib/wine/i386-windows/winemenubuilder.exe",
-            ]
-            for winemenubuilder in winemenubuilder_paths:
-                if winemenubuilder.startswith("Proton"):
-                    continue
-                if os.path.isfile(winemenubuilder):
-                    os.rename(winemenubuilder, f"{winemenubuilder}.lock")
+            if runner not in self.supported_proton_runners:
+                winemenubuilder_paths = [
+                    f"{runner}lib64/wine/x86_64-windows/winemenubuilder.exe",
+                    f"{runner}lib/wine/x86_64-windows/winemenubuilder.exe",
+                    f"{runner}lib32/wine/i386-windows/winemenubuilder.exe",
+                    f"{runner}lib/wine/i386-windows/winemenubuilder.exe",
+                ]
+                for winemenubuilder in winemenubuilder_paths:
+                    if os.path.isfile(winemenubuilder):
+                        os.rename(winemenubuilder, f"{winemenubuilder}.lock")
 
         # check system wine
         if shutil.which("wine") is not None:

--- a/bottles/backend/runner.py
+++ b/bottles/backend/runner.py
@@ -93,7 +93,7 @@ class Runner:
         the host system. There are some exceptions, like the Soda and Wine-GE runners,
         which are built to work without the Steam Runtime.
         """
-        if "proton" in runner.lower() and RuntimeManager.get_runtimes("steam"):
+        if runner in manager.supported_proton_runners and RuntimeManager.get_runtimes("steam"):
             manager.update_config(config, "use_steam_runtime", True, "Parameters")
 
         return Result(


### PR DESCRIPTION
# Description
`wine-ge-proton` contains `proton` in its name, which caused Bottles to enable the Steam Runtime.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
