### PR TITLE
Add GitHub Action close issues if people are using a too old version

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -12,7 +12,7 @@ jobs:
         id: regex-match
         with:
           text: ${{ github.event.issue.body }}
-          regex: '202\d.\d\d.\d\d'
+          regex: 'Version:.*202\d.\d\d.\d\d'
       - if: ${{ steps.regex-match.outputs.match != '' }}
         name: Close Issue
         uses: peter-evans/close-issue@v2

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,21 @@
+name: close-issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.issue.body }}
+          regex: '202\d.\d\d.\d\d'
+      - if: ${{ steps.regex-match.outputs.match != '' }}
+        name: Close Issue
+        uses: peter-evans/close-issue@v2
+        with:
+          comment: |
+            It seems like you're using an old version of Bottles. Please upgrade to the version from Flathub [here](https://flathub.org/apps/details/com.usebottles.bottles), and try to reproduce the bug.


### PR DESCRIPTION
# Description
It could be improved by checking the actual shipped version of Bottles, and closing if it's too old.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] GitHub Actions
