### PR TITLE
fix: Create bottle crashing if no Nvidia GPU and NVAPI installs

### DIFF
--- a/bottles/backend/dlls/dll.py
+++ b/bottles/backend/dlls/dll.py
@@ -49,6 +49,10 @@ class DLLComponent:
     def check(self):
         found = self.dlls.copy()
 
+        if None in self.dlls:
+            logging.error(f"DLL(s) \"{self.dlls[None]}\" path haven't been found, ignoring...")
+            return
+
         for path in self.dlls:
             _path = os.path.join(self.base_path, path)
             if not os.path.exists(_path):
@@ -83,6 +87,10 @@ class DLLComponent:
         if exclude is None:
             exclude = []
 
+        if None in self.dlls:
+            logging.error(f"DLL(s) \"{self.dlls[None]}\" path haven't been found, ignoring...")
+            return
+
         for path in self.dlls:
             for dll in self.dlls[path]:
                 if dll not in exclude:
@@ -108,6 +116,10 @@ class DLLComponent:
 
         if exclude is None:
             exclude = []
+
+        if None in self.dlls:
+            logging.error(f"DLL(s) \"{self.dlls[None]}\" path haven't been found, ignoring...")
+            return
 
         for path in self.dlls:
             for dll in self.dlls[path]:

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -53,6 +53,8 @@ from bottles.backend.managers.epicgamesstore import EpicGamesStoreManager
 from bottles.backend.managers.ubisoftconnect import UbisoftConnectManager
 from bottles.backend.repos.repo import RepoStatus
 from bottles.backend.utils.file import FileUtils
+from bottles.backend.utils.gpu import GPUUtils
+from bottles.backend.utils.gpu import GPUVendors
 from bottles.backend.utils.lnk import LnkUtils
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.utils.generic import sort_by_version
@@ -1298,11 +1300,12 @@ class Manager:
 
             if not template and config.Parameters.dxvk_nvapi \
                     or (template and template["config"]["NVAPI"] != nvapi):
-                # perform nvapi installation if configured
-                logging.info("Installing DXVK-NVAPI…")
-                log_update(_("Installing DXVK-NVAPI…"))
-                self.install_dll_component(config, "nvapi", version=nvapi_name)
-                template_updated = True
+                if GPUUtils.is_gpu(GPUVendors.NVIDIA):
+                    # perform nvapi installation if configured
+                    logging.info("Installing DXVK-NVAPI…")
+                    log_update(_("Installing DXVK-NVAPI…"))
+                    self.install_dll_component(config, "nvapi", version=nvapi_name)
+                    template_updated = True
 
             for dep in env.get("Installed_Dependencies", []):
                 if template and dep in template["config"]["Installed_Dependencies"]:

--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -9,9 +9,6 @@ from typing.io import IO
 
 from bottles.backend.models.result import Result
 from bottles.backend.utils import yaml
-from bottles.backend.logger import Logger
-
-logging = Logger()
 
 # class name prefix "Bottle" is a workaround for:
 # https://github.com/python/cpython/issues/90104

--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -9,7 +9,9 @@ from typing.io import IO
 
 from bottles.backend.models.result import Result
 from bottles.backend.utils import yaml
+from bottles.backend.logger import Logger
 
+logging = Logger()
 
 # class name prefix "Bottle" is a workaround for:
 # https://github.com/python/cpython/issues/90104

--- a/bottles/backend/wine/reg.py
+++ b/bottles/backend/wine/reg.py
@@ -122,7 +122,7 @@ class Reg(WineProgram):
         winedbg.wait_for_process("reg.exe")
 
         res = self.launch(args, communicate=True, minimal=True, action_name="import_bundle")
-        logging.info(res, )
+        logging.info(f"Import bundle result: '{res.decode('utf-8')}'")
 
         # remove reg file
         os.remove(reg_file)


### PR DESCRIPTION
# Description
For some reasons, sometimes NVAPI wants to be installed even though the user doesn't have an Nvidia GPU. This PR adds another check to see if a DLL exists before check/install/uninstall. Also, a check to see if the user has a Nvidia card when creating a Bottle was implemented. This does not fix all occurences of the behavior, like for example when importing an existing Bottle, but it's a start. 

Fixes #2594

For reviewers to test: when not using a Nvidia card, create a bottle. You should not have any indication of NVAPI being installed.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [X] locally, while triggering manually the error with different means