### PR TITLE
fix inconsistent return type for WineCommand

### DIFF
--- a/bottles/backend/logger.py
+++ b/bottles/backend/logger.py
@@ -44,8 +44,8 @@ class Logger(logging.getLoggerClass()):
         'datefmt': '%H:%M:%S',
     }
 
-    def __color(self, level, message):
-        if message is not None and "\n" in message:
+    def __color(self, level, message: str):
+        if message and "\n" in message:
             message = message.replace("\n", "\n\t") + "\n"
         color_id = self.__color_map[level]
         return "\033[%dm%s\033[0m" % (color_id, message)

--- a/bottles/backend/utils/generic.py
+++ b/bottles/backend/utils/generic.py
@@ -45,6 +45,8 @@ def detect_encoding(text: bytes) -> Optional[str]:
     Detect the encoding of a text by its bytes. Return None if it
     can't be detected.
     """
+    if not text:  # when empty
+        return 'utf-8'
     return chardet.detect(text).get('encoding')
 
 

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -609,9 +609,7 @@ class WineCommand:
         if None in [self.runner, self.env]:
             return
 
-        if vmtouch_available \
-            and self.config.Parameters.vmtouch \
-            and not self.terminal:
+        if vmtouch_available and self.config.Parameters.vmtouch and not self.terminal:
             self.vmtouch_preload()
 
         if self.config.Parameters.sandbox:
@@ -650,9 +648,7 @@ class WineCommand:
         res = proc.communicate()[0]
         enc = detect_encoding(res)
 
-        if vmtouch_available \
-            and self.config.Parameters.vmtouch \
-            and not self.terminal:
+        if vmtouch_available and self.config.Parameters.vmtouch and not self.terminal:
             self.vmtouch_free()
 
         if enc is not None:


### PR DESCRIPTION
# Description
cheery pick from `decoupled-backend` branch

fixed `WineCommand.run()` returning `bytes` when stdout result is empty(which introduced in https://github.com/bottlesdevs/Bottles/pull/2585), then logger will crash because of this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
any feature using `WineCommand` are working now
