### PR TITLE
frontend: Gracefully handle ridiculous names

### DIFF
--- a/bottles/frontend/ui/details-bottle.blp
+++ b/bottles/frontend/ui/details-bottle.blp
@@ -154,7 +154,11 @@ template DetailsBottle : .AdwPreferencesPage {
 
       Label label_name {
         halign: center;
+        justify: center;
+        wrap: true;
+        max-width-chars: 30;
         label: _("My bottle");
+        wrap-mode: word_char;
 
         styles [
           "title-1",

--- a/bottles/frontend/ui/library-entry.blp
+++ b/bottles/frontend/ui/library-entry.blp
@@ -106,7 +106,8 @@ template LibraryEntry : Box {
           Label label_name {
             halign: start;
             label: _("Item name");
-
+            max-width-chars: 20;
+            ellipsize: middle;
             styles [
               "title",
             ]
@@ -115,7 +116,8 @@ template LibraryEntry : Box {
           Label label_bottle {
             halign: start;
             label: _("Bottle name");
-
+            max-width-chars: 20;
+            ellipsize: middle;
             styles [
               "caption",
             ]
@@ -130,8 +132,7 @@ template LibraryEntry : Box {
             tooltip-text: _("Remove from Library");
 
             styles [
-              "flat",
-              "circular",
+              "flat"
             ]
           }
 
@@ -142,8 +143,7 @@ template LibraryEntry : Box {
             tooltip-text: _("Stop");
 
             styles [
-              "flat",
-              "circular",
+              "flat"
             ]
           }
         }


### PR DESCRIPTION
# Description
Ellipsizes or wraps long names when there's no space:
![image](https://user-images.githubusercontent.com/27908024/218261177-42b2cfbd-3763-4862-b4b7-b22864e1630c.png)
![image](https://user-images.githubusercontent.com/27908024/218261183-48623851-0a25-43a4-9d44-484e02e2d29a.png)

Fixes #2670

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
