### PR TITLE
Make unspecified 'Arch' to be listed for 32-bit and 64-bit architecture

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -139,12 +139,15 @@ class DependencyManager:
                     _res = self.install(config, [_ext_dep, _dep])
                     if not _res.status:
                         return _res
-
         for step in manifest.get("Steps"):
             """
             Here we execute all steps in the manifest.
             Steps are the actions performed to install the dependency.
             """
+            arch = step.get("for", "win64_win32")
+            if config.Arch not in arch:
+                continue
+
             res = self.__perform_steps(config, step)
             if not res.status:
                 GLib.idle_add(self.__operation_manager.remove_task, task_id)

--- a/bottles/frontend/ui/details-dependencies.blp
+++ b/bottles/frontend/ui/details-dependencies.blp
@@ -81,6 +81,14 @@ Popover pop_context {
       tooltip-text: _("Read Documentation.");
       text: _("Documentation");
     }
+    .GtkModelButton btn_show_all {
+      tooltip-text: _("Show all dependencies.");
+      text: _("Show All Dependencies");
+    }
+    .GtkModelButton btn_show_allowed {
+      tooltip-text: _("Show allowed dependencies.");
+      text: _("Show Allowed Dependencies");
+    }
   }
 }
 

--- a/bottles/frontend/views/bottle_dependencies.py
+++ b/bottles/frontend/views/bottle_dependencies.py
@@ -129,7 +129,8 @@ class DependenciesView(Adw.Bin):
                     if dep[0] in self.config.Installed_Dependencies:
                         continue  # Do not list already installed dependencies'
 
-                    if dep[1].get("Arch", "win64") != self.config.Arch:
+                    dependency_arch = dep[1].get("Arch")
+                    if dependency_arch is not None and dependency_arch != self.config.get("Arch"):
                         # NOTE: avoid listing dependencies not supported by the bottle arch
                         continue
 

--- a/bottles/frontend/views/bottle_dependencies.py
+++ b/bottles/frontend/views/bottle_dependencies.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 import time
 from typing import Optional
 
@@ -35,6 +34,8 @@ class DependenciesView(Adw.Bin):
     # region Widgets
     list_dependencies = Gtk.Template.Child()
     btn_report = Gtk.Template.Child()
+    btn_show_all = Gtk.Template.Child()
+    btn_show_allowed = Gtk.Template.Child()
     btn_help = Gtk.Template.Child()
     entry_search = Gtk.Template.Child()
     actions = Gtk.Template.Child()
@@ -53,6 +54,7 @@ class DependenciesView(Adw.Bin):
         self.manager = details.window.manager
         self.config = config
         self.queue = details.queue
+        self.show_all = False
 
         self.ev_controller.connect("key-released", self.__search_dependencies)
 
@@ -61,11 +63,28 @@ class DependenciesView(Adw.Bin):
 
         self.btn_report.connect("clicked", open_doc_url, "contribute/missing-dependencies")
         self.btn_help.connect("clicked", open_doc_url, "bottles/dependencies")
+        self.btn_show_all.connect("clicked", self.__show_all_dependencies)
+        self.btn_show_allowed.connect("clicked", self.__show_allowed_dependencies)
 
-        if self.manager.utils_conn.status == False:
+        self.btn_show_all.set_visible(not self.show_all)
+        self.btn_show_allowed.set_visible(self.show_all)
+
+        if not self.manager.utils_conn.status:
             self.stack.set_visible_child_name("page_offline") 
 
         self.spinner_loading.start()
+
+    def __show_all_dependencies(self, widget):
+        self.show_all = True
+        self.update(False, self.config)
+        self.btn_show_allowed.set_visible(self.show_all)
+        self.btn_show_all.set_visible(not self.show_all)
+
+    def __show_allowed_dependencies(self, widget):
+        self.show_all = False
+        self.update(False, self.config)
+        self.btn_show_all.set_visible(not self.show_all)
+        self.btn_show_allowed.set_visible(self.show_all)
 
     def __search_dependencies(self, *_args):
         """
@@ -129,11 +148,9 @@ class DependenciesView(Adw.Bin):
                     if dep[0] in self.config.Installed_Dependencies:
                         continue  # Do not list already installed dependencies'
 
-                    dependency_arch = dep[1].get("Arch")
-                    if dependency_arch is not None and dependency_arch != self.config.get("Arch"):
+                    if self.config.Arch not in dep[1].get("Arch", "win64_win32") and not self.show_all:
                         # NOTE: avoid listing dependencies not supported by the bottle arch
                         continue
-
                     GLib.idle_add(new_dependency, dep)
 
             if len(self.config.Installed_Dependencies) > 0:

--- a/po/bottles.pot
+++ b/po/bottles.pot
@@ -529,6 +529,22 @@ msgstr ""
 msgid "Report Missing Dependency"
 msgstr ""
 
+#: bottles/frontend/ui/details-dependencies.blp:85
+msgid "Show all dependencies."
+msgstr ""
+
+#: bottles/frontend/ui/details-dependencies.blp:86
+msgid "Show All Dependencies"
+msgstr ""
+
+#: bottles/frontend/ui/details-dependencies.blp:89
+msgid "Show allowed dependencies."
+msgstr ""
+
+#: bottles/frontend/ui/details-dependencies.blp:90
+msgid "Show Allowed Dependencies"
+msgstr ""
+
 #: bottles/frontend/ui/details-dependencies.blp:47
 msgid "Read Documentation."
 msgstr ""


### PR DESCRIPTION
# Description
Make unspecified 'Arch' to be listed for 32-bit and 64-bit architecture. As we know that nearly all of the dependencies listed on the repository doesn't have 'Arch' attribute, and with the missing of these attributes, nearly all of the dependencies listed on the repo can't be seen on the 32-bit bottle environment. It happen due to the way the code return 'Win64' on null or missing attribute.

Fixes #2166

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Local Machine

[image of installed dependencies on 32-bit environment](https://imgur.com/ZWPlb6J)
[image of installed program using the modified bottle](https://imgur.com/a/82yNkeU)
