### PR TITLE
make BottleConfig Json serializable

### DIFF
--- a/bottles/backend/managers/conf.py
+++ b/bottles/backend/managers/conf.py
@@ -1,7 +1,7 @@
 import os
-import json
-from bottles.backend.utils import yaml
 from configparser import ConfigParser
+
+from bottles.backend.utils import yaml, json
 
 
 class ConfigManager(object):
@@ -39,7 +39,7 @@ class ConfigManager(object):
             elif self.config_type == 'json':
                 with open(self.config_file, 'r') as f:
                     res = json.load(f)
-            elif self.config_type == 'yaml' or self.config_type == 'yml' :
+            elif self.config_type == 'yaml' or self.config_type == 'yml':
                 with open(self.config_file, 'r') as f:
                     res = yaml.load(f)
             else:
@@ -80,14 +80,14 @@ class ConfigManager(object):
 
         for section in self.config_dict:
             config.add_section(section)
-            
+
             for key, value in self.config_dict[section].items():
                 config.set(section, key, value)
 
         with open(self.config_file, 'w') as f:
             config.write(f)
 
-    def write_dict(self, config_file: str=None):
+    def write_dict(self, config_file: str = None):
         if self.config_file is None and config_file is None:
             raise ValueError('No config path specified')
         elif self.config_file is None and config_file is not None:

--- a/bottles/backend/managers/epicgamesstore.py
+++ b/bottles/backend/managers/epicgamesstore.py
@@ -17,10 +17,10 @@
 
 import os
 import uuid
-import json
 from typing import Union
 
 from bottles.backend.models.config import BottleConfig
+from bottles.backend.utils import json
 from bottles.backend.utils.manager import ManagerUtils
 
 

--- a/bottles/backend/managers/origin.py
+++ b/bottles/backend/managers/origin.py
@@ -16,11 +16,8 @@
 #
 
 import os
-import uuid
-import json
-from typing import Union, NewType
+from typing import Union
 
-from bottles.backend.logger import Logger
 from bottles.backend.models.config import BottleConfig
 from bottles.backend.utils.manager import ManagerUtils
 

--- a/bottles/backend/managers/ubisoftconnect.py
+++ b/bottles/backend/managers/ubisoftconnect.py
@@ -17,10 +17,8 @@
 
 import os
 import uuid
-import json
-from typing import Union, NewType
+from typing import Union
 
-from bottles.backend.logger import Logger
 from bottles.backend.models.config import BottleConfig
 from bottles.backend.utils.manager import ManagerUtils
 
@@ -64,8 +62,8 @@ class UbisoftConnectManager:
         reg_key = "register: HKEY_LOCAL_MACHINE\\SOFTWARE\\Ubisoft\\Launcher\\Installs\\"
         conf_path = UbisoftConnectManager.find_conf_path(config)
         games_path = os.path.join(
-                ManagerUtils.get_bottle_path(config),
-                "drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/games")
+            ManagerUtils.get_bottle_path(config),
+            "drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/games")
 
         if conf_path is None:
             return []

--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -22,6 +22,10 @@ class DictCompatMixIn:
         dict_repr = data.to_dict()
         return dumper.represent_dict(dict_repr)
 
+    @staticmethod
+    def json_serialize_handler(data):
+        return data.to_dict()
+
     def keys(self):
         return self.__dict__.keys()
 
@@ -150,11 +154,11 @@ class BottleConfig(DictCompatMixIn):
         """
         Dump config to file
 
-        :file: filepath str or IO-like object.
-        :mode: when param 'file' is filepath, use this mode to open file, otherwise ignored.
+        :param file: filepath str or IO-like object.
+        :param mode: when param 'file' is filepath, use this mode to open file, otherwise ignored.
                default is 'w'
-        :encoding: file content encoding, default is None(Decide by Python IO)
-        :indent: file indent width, default is 4
+        :param encoding: file content encoding, default is None(Decide by Python IO)
+        :param indent: file indent width, default is 4
         """
         f = file if isinstance(file, IOBase) else open(file, mode=mode)
         try:
@@ -171,8 +175,8 @@ class BottleConfig(DictCompatMixIn):
         """
         Load config from file
 
-        :file: filepath str or IO-like object.
-        :mode: when param 'file' is filepath, use this mode to open file, otherwise ignored.
+        :param file: filepath str or IO-like object.
+        :param mode: when param 'file' is filepath, use this mode to open file, otherwise ignored.
                default is 'r'
         """
         f = None

--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -3,9 +3,7 @@ import logging
 import os
 from dataclasses import dataclass, field, replace, asdict, is_dataclass
 from io import IOBase
-from typing import List, Dict, Union, Optional, ItemsView, Container
-
-from typing.io import IO
+from typing import List, Dict, Union, Optional, ItemsView, Container, IO
 
 from bottles.backend.models.result import Result
 from bottles.backend.utils import yaml

--- a/bottles/backend/utils/json.py
+++ b/bottles/backend/utils/json.py
@@ -1,0 +1,52 @@
+"""This should be a drop-in replacement for the json module built in CPython"""
+import json as _json
+from typing import Optional, IO, Any, Type
+
+from bottles.backend.models.config import DictCompatMixIn
+
+
+class ExtJSONEncoder(_json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, DictCompatMixIn):
+            return o.json_serialize_handler(o)
+        return super().default(o)
+
+
+def load(fp: IO[str | bytes]) -> Any:
+    return _json.load(fp)
+
+
+def loads(s: str | bytes) -> Any:
+    """Deserialize s (a str, bytes or bytearray instance containing a JSON document) to a Python object."""
+    return _json.loads(s)
+
+
+def dump(
+        obj: Any, fp: IO[str], *,
+        indent: Optional[str | int] = None, cls: Optional[Type[_json.JSONEncoder]] = None
+) -> None:
+    """
+    Serialize obj as a JSON formatted stream to fp (a .write()-supporting file-like object).
+
+    :param obj: the object you want to serialize
+    :param fp: the file-like object you want to write
+    :param indent: `None` for compact output, `0` for newline only, non-negative integer for indent level
+    :param cls: Custom JsonEncoder subclass, use ExtJsonEncoder if not provided
+    """
+    if cls is None:  # replace default JsonEncoder
+        cls = ExtJSONEncoder
+    return _json.dump(obj, fp, indent=indent, cls=cls)
+
+
+def dumps(obj: Any, *, indent: Optional[str | int] = None, cls: Optional[Type[_json.JSONEncoder]] = None) -> str:
+    """
+    Serialize obj to a JSON formatted str.
+
+    :param obj: the object you want to serialize
+    :param indent: `None` for compact output, `0` for newline only, non-negative integer for indent level
+    :param cls: Custom JsonEncoder subclass, use ExtJsonEncoder if not provided
+    :return: serialized result
+    """
+    if cls is None:  # replace default JsonEncoder
+        cls = ExtJSONEncoder
+    return _json.dumps(obj, indent=indent, cls=cls)

--- a/bottles/backend/utils/json.py
+++ b/bottles/backend/utils/json.py
@@ -1,8 +1,11 @@
 """This should be a drop-in replacement for the json module built in CPython"""
+import json
 import json as _json
 from typing import Optional, IO, Any, Type
 
 from bottles.backend.models.config import DictCompatMixIn
+
+JSONDecodeError = json.JSONDecodeError
 
 
 class ExtJSONEncoder(_json.JSONEncoder):

--- a/bottles/backend/utils/json.py
+++ b/bottles/backend/utils/json.py
@@ -16,6 +16,7 @@ class ExtJSONEncoder(_json.JSONEncoder):
 
 
 def load(fp: IO[str | bytes]) -> Any:
+    """Deserialize fp (a .read()-supporting file-like object containing a JSON document) to a Python object."""
     return _json.load(fp)
 
 

--- a/bottles/backend/utils/meson.build
+++ b/bottles/backend/utils/meson.build
@@ -19,7 +19,8 @@ bottles_sources = [
   'imagemagick.py',
   'proc.py',
   'yaml.py',
-  'nvidia.py'
+  'nvidia.py',
+  'json.py'
 ]
 
 install_data(bottles_sources, install_dir: utilsdir)

--- a/bottles/backend/utils/yaml.py
+++ b/bottles/backend/utils/yaml.py
@@ -15,18 +15,19 @@ def dump(data, stream=None, **kwargs):
     """
     Serialize a Python object into a YAML stream.
     If stream is None, return the produced string instead.
-    Note: This function is a replacement for PyYAML's dump() function, using
-          the CDumper class instead of the default Dumper, to achieve best 
-          performance.
+    Note: This function is a replacement for PyYAML's dump() function,
+          using the CDumper class instead of the default Dumper, to achieve
+          the best performance.
     """
     return _yaml.dump(data, stream, Dumper=SafeDumper, **kwargs)
 
 
+# noinspection PyPep8Naming
 def load(stream, Loader=SafeLoader):
     """
     Load a YAML stream.
     Note: This function is a replacement for PyYAML's safe_load() function, 
           using the CLoader class instead of the default Loader, to achieve 
-          best performance.
+          the best performance.
     """
     return _yaml.load(stream, Loader=Loader)

--- a/bottles/backend/wine/register.py
+++ b/bottles/backend/wine/register.py
@@ -17,7 +17,8 @@
 
 import os
 import uuid
-import json
+
+from bottles.backend.utils import json
 
 
 class WinRegister:

--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -18,14 +18,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import gi
+import argparse
 import os
+import signal
 import sys
 import uuid
-import json
-import signal
-import argparse
 import warnings
+
+import gi
+
+from bottles.backend.utils import json
 
 warnings.filterwarnings("ignore")  # suppress GTK warnings
 gi.require_version('Gtk', '4.0')
@@ -137,7 +139,7 @@ class CLI:
         run_parser.add_argument("-e", "--executable", help="Path to the executable")
         run_parser.add_argument("-p", "--program", help="Program to run")
         run_parser.add_argument("--args-replace", action='store_false', dest='keep_args',
-            help="Replace current program arguments, instead of append")
+                                help="Replace current program arguments, instead of append")
         run_parser.add_argument("args", nargs="*", action="extend", help="Arguments to pass to the executable")
 
         standalone_parser = subparsers.add_parser("standalone", help="Generate a standalone script to launch commands "

--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -27,8 +27,6 @@ import warnings
 
 import gi
 
-from bottles.backend.utils import json
-
 warnings.filterwarnings("ignore")  # suppress GTK warnings
 gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gio
@@ -59,6 +57,7 @@ from bottles.backend.wine.winecfg import WineCfg
 from bottles.backend.wine.explorer import Explorer
 from bottles.backend.wine.regkeys import RegKeys
 from bottles.backend.runner import Runner
+from bottles.backend.utils import json
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.frontend.utils.connection import ConnectionUtils
 

--- a/bottles/frontend/windows/crash.py
+++ b/bottles/frontend/windows/crash.py
@@ -15,15 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
-import json
 import contextlib
-import webbrowser
 import urllib.request
-from urllib.parse import quote
+import webbrowser
+from gettext import gettext as _
+
 from gi.repository import Gtk, Adw
 
-from bottles.frontend.params import APP_VERSION
+from bottles.backend.utils import json
 
 
 class SimilarReportEntry(Adw.ActionRow):
@@ -135,7 +134,7 @@ class CrashReportDialog(Adw.Window):
     @staticmethod
     def __get_similar_issues(log):
         """
-        This function will get the similar reports from the github
+        This function will get the similar reports from the GitHub
         api and return them as a list. It will return an empty list
         if there are no similar reports.
         """


### PR DESCRIPTION
# Description
Fix bug reported by Slowpokefarm@Discord
```
(1)(deck@steamdeck ~)$ flatpak run --command=bottles-cli com.usebottles.bottles -j list bottles

(process:2): Gtk-WARNING **: 13:46:18.764: Locale not supported by C library.
        Using the fallback 'C' locale.
Traceback (most recent call last):
  File "/app/bin/bottles-cli", line 657, in <module>
    cli = CLI()
  File "/app/bin/bottles-cli", line 151, in __init__
    self.__process_args()
  File "/app/bin/bottles-cli", line 170, in __process_args
    self.list_bottles(c_filter=_filter)
  File "/app/bin/bottles-cli", line 237, in list_bottles
    sys.stdout.write(json.dumps(bottles))
  File "/usr/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type BottleConfig is not JSON serializable
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] tested locally with a success `flatpak run --command=bottles-cli com.usebottles.bottles -j list bottles`
