### PR TITLE
fix: duplicate installed dependencies after reinstall

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -16,14 +16,14 @@
 #
 
 import os
-import uuid
 import shutil
 import traceback
-from glob import glob
+import uuid
 from functools import lru_cache
+from glob import glob
 from typing import Union
-import patoolib
 
+import patoolib
 from gi.repository import GLib
 
 from bottles.backend.models.config import BottleConfig
@@ -82,12 +82,7 @@ class DependencyManager:
         catalog = dict(sorted(catalog.items()))
         return catalog
 
-    def install(
-            self,
-            config: BottleConfig,
-            dependency: list,
-            reinstall: bool = False
-    ) -> Result:
+    def install(self, config: BottleConfig, dependency: list) -> Result:
         """
         Install a given dependency in a bottle. It will
         return True if the installation was successful.
@@ -155,8 +150,7 @@ class DependencyManager:
             if not res.data.get("uninstaller"):
                 uninstaller = False
 
-        if dependency[0] not in config.Installed_Dependencies \
-                or reinstall:
+        if dependency[0] not in config.Installed_Dependencies:
             """
             If the dependency is not already listed in the installed
             dependencies list of the bottle, add it.

--- a/bottles/frontend/widgets/dependency.py
+++ b/bottles/frontend/widgets/dependency.py
@@ -72,7 +72,7 @@ class DependencyEntry(Adw.ActionRow):
 
         # connect signals
         self.btn_install.connect("clicked", self.install_dependency)
-        self.btn_reinstall.connect("clicked", self.install_dependency, True)
+        self.btn_reinstall.connect("clicked", self.install_dependency)
         self.btn_remove.connect("clicked", self.remove_dependency)
         self.btn_manifest.connect("clicked", self.open_manifest)
         self.btn_license.connect("clicked", self.open_license)
@@ -119,7 +119,7 @@ class DependencyEntry(Adw.ActionRow):
         )
         webbrowser.open(manifest["License_url"])
 
-    def install_dependency(self, widget, reinstall=False):
+    def install_dependency(self, widget):
         """
         This function install the dependency in the bottle, it
         will also prevent user from installing other dependencies
@@ -138,7 +138,6 @@ class DependencyEntry(Adw.ActionRow):
             callback=self.set_install_status,
             config=self.config,
             dependency=self.dependency,
-            reinstall=reinstall
         )
 
     def remove_dependency(self, widget):


### PR DESCRIPTION
# Description
Fix duplicate item in `BottleConfig.Installed_Dependencies` after reinstall any dependency

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Not test yet
