### PR TITLE
frontend: Add toast when executing

### DIFF
--- a/bottles/frontend/ui/list-entry.blp
+++ b/bottles/frontend/ui/list-entry.blp
@@ -84,7 +84,6 @@ template BottleViewEntry : .AdwActionRow {
   }
 
   Button btn_run {
-    tooltip-text: _("Run .exe/.msi in this bottle");
     halign: center;
     valign: center;
     icon-name: "system-run-symbolic";

--- a/bottles/frontend/views/list.py
+++ b/bottles/frontend/views/list.py
@@ -86,6 +86,9 @@ class BottleViewEntry(Adw.ActionRow):
         self.label_env_context.add_class(
             "tag-%s" % self.config.Environment.lower())
 
+        # Set tooltip text
+        self.btn_run.set_tooltip_text(_(f"Run executable in \"{self.config.Name}\""))
+
         '''If config is broken'''
         if self.config.get("Broken"):
             for w in [self.btn_repair, self.icon_damaged]:
@@ -110,6 +113,11 @@ class BottleViewEntry(Adw.ActionRow):
         def set_path(_dialog, response):
             if response != Gtk.ResponseType.ACCEPT:
                 return
+
+            self.window.show_toast(_("Launching \"{0}\" in \"{1}\"…").format(
+                    dialog.get_file().get_basename(),
+                    self.config.Name)
+                )
 
             path = dialog.get_file().get_path()
             _executor = WineExecutor(self.config, exec_path=path)


### PR DESCRIPTION
# Description
This adds a toast whenever we want to run an executable from the list view:

[Screencast from 2023-02-23 17-13-28.webm](https://user-images.githubusercontent.com/50847364/221042773-a4d67e22-4e0d-49f8-902d-96c59b501789.webm)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] UI

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Locally