### PR TITLE
Fix gtk style loader

### DIFF
--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -151,7 +151,8 @@ class BottleView(Adw.PreferencesPage):
 
         gtk_context = self.drop_overlay.get_style_context()
         Gtk.StyleContext.add_class(gtk_context, "dragndrop_overlay")
-        self.style_provider.load_from_data(b".dragndrop_overlay { background: rgba(41, 65, 94, 0.2);}")
+        style_data = ".dragndrop_overlay { background: rgba(41, 65, 94, 0.2);}"
+        self.style_provider.load_from_data(style_data, len(style_data))
         Gtk.StyleContext.add_provider(
             gtk_context,
             self.style_provider,

--- a/bottles/frontend/windows/installer.py
+++ b/bottles/frontend/windows/installer.py
@@ -99,7 +99,8 @@ class InstallerDialog(Adw.Window):
     def __init__(self, window, config, installer, **kwargs):
         super().__init__(**kwargs)
         self.set_transient_for(window)
-        self.style_provider.load_from_data(b"progressbar { line-height: 2.0; }")
+        style_data = "progressbar { line-height: 2.0; }"
+        self.style_provider.load_from_data(style_data, len(style_data))
         Gtk.StyleContext.add_provider(
             self.progressbar.get_style_context(),
             self.style_provider,


### PR DESCRIPTION
# Description
Bottles no longer works with GTK 4.10.

```
Traceback (most recent call last):
  File "/usr/share/bottles/bottles/frontend/windows/main_window.py", line 149, in set_manager
    self.page_details = DetailsView(self)
  File "/usr/share/bottles/bottles/frontend/views/details.py", line 78, in __init__
    self.view_bottle = BottleView(self, config)
  File "/usr/share/bottles/bottles/frontend/views/bottle_details.py", line 163, in __init__
    self.style_provider.load_from_data(b".dragndrop_overlay { background: rgba(41, 65, 94, 0.2);}")
TypeError: Gtk.CssProvider.load_from_data() takes exactly 3 arguments (2 given)
```
as reported on [AUR](https://aur.archlinux.org/packages/bottles)

Fixes #2788 #2699

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Cloned from github
- [x] Ran meson setup builddir && cd builddir && meson compile && meson install
- [x] Bottles was able to start up again 
