### PR TITLE
Make window remember dimensions

### DIFF
--- a/bottles/frontend/ui/window.blp
+++ b/bottles/frontend/ui/window.blp
@@ -1,10 +1,11 @@
 using Gtk 4.0;
 
 template MainWindow : .AdwApplicationWindow {
+
   title: "Bottles";
-  default-width: "880";
-  default-height: "640";
   icon-name: "com.usebottles.bottles";
+
+  close-request => on_close_request();
 
   .AdwToastOverlay toasts {
     .AdwLeaflet main_leaf {

--- a/bottles/frontend/ui/window.blp
+++ b/bottles/frontend/ui/window.blp
@@ -1,10 +1,8 @@
 using Gtk 4.0;
 
 template MainWindow : .AdwApplicationWindow {
-
   title: "Bottles";
   icon-name: "com.usebottles.bottles";
-
   close-request => on_close_request();
 
   .AdwToastOverlay toasts {

--- a/bottles/frontend/windows/main_window.py
+++ b/bottles/frontend/windows/main_window.py
@@ -74,7 +74,11 @@ class MainWindow(Adw.ApplicationWindow):
     argument_executed = False
 
     def __init__(self, arg_bottle, **kwargs):
-        super().__init__(**kwargs)
+
+        width = self.settings.get_int("window-width")
+        height = self.settings.get_int("window-height")
+
+        super().__init__(**kwargs, default_width=width, default_height=height)
 
         self.disable_onboard = False
         self.utils_conn = ConnectionUtils()
@@ -116,6 +120,11 @@ class MainWindow(Adw.ApplicationWindow):
 
         self.__on_start()
         logging.info("Bottles Started!", )
+
+    @Gtk.Template.Callback()
+    def on_close_request(self, *args):
+        self.settings.set_int("window-width", self.get_width())
+        self.settings.set_int("window-height", self.get_height())
 
     # region Backend signal handlers
     def network_changed_handler(self, res: Result):

--- a/data/com.usebottles.bottles.gschema.xml
+++ b/data/com.usebottles.bottles.gschema.xml
@@ -32,12 +32,12 @@
       <description>Toggle ubisoft connect listing.</description>
     </key>
     <key type="i" name="window-width">
-      <default>850</default>
+      <default>880</default>
       <summary>Window width</summary>
       <description>Change the window width.</description>
     </key>
     <key type="i" name="window-height">
-      <default>600</default>
+      <default>640</default>
       <summary>Window height</summary>
       <description>Change the window height.</description>
     </key>


### PR DESCRIPTION
# Description
Main window will now remain the same size as it was before closing.
There already was fields in gschema but unused for some reason

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Tested by @TheEvilSkeleton
