### PR TITLE
frontend: Fix applying style classes

### DIFF
--- a/bottles/frontend/ui/details-bottle.blp
+++ b/bottles/frontend/ui/details-bottle.blp
@@ -146,6 +146,10 @@ template DetailsBottle : .AdwPreferencesPage {
     .AdwStatusPage {
       icon-name: system-run-symbolic;
       title: _("Drop files to execute them");
+
+      styles [
+        "dragndrop_overlay",
+      ]
     }
   }
   .AdwPreferencesGroup {

--- a/bottles/frontend/ui/dialog-installer.blp
+++ b/bottles/frontend/ui/dialog-installer.blp
@@ -109,9 +109,9 @@ template InstallerDialog : .AdwWindow {
               margin-bottom: 12;
               show-text: true;
 
-            styles [
-              "installer",
-            ]
+              styles [
+                "installer",
+              ]
             }
           }
         }

--- a/bottles/frontend/ui/dialog-installer.blp
+++ b/bottles/frontend/ui/dialog-installer.blp
@@ -108,6 +108,10 @@ template InstallerDialog : .AdwWindow {
               margin-top: 10;
               margin-bottom: 12;
               show-text: true;
+
+            styles [
+              "installer",
+            ]
             }
           }
         }

--- a/bottles/frontend/ui/style.css
+++ b/bottles/frontend/ui/style.css
@@ -165,3 +165,10 @@ entry.heading_1 {
   border-radius: 0 0 12px 0;
 }
 
+.dragndrop_overlay { 
+  background: rgba(41, 65, 94, 0.2);
+}
+
+progressbar.installer {
+  line-height: 2.0;
+}

--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -149,14 +149,6 @@ class BottleView(Adw.PreferencesPage):
             "flatpak/black-screen-or-silent-crash"
         )
 
-        gtk_context = self.drop_overlay.get_style_context()
-        Gtk.StyleContext.add_class(gtk_context, "dragndrop_overlay")
-        self.style_provider.load_from_data(b".dragndrop_overlay { background: rgba(41, 65, 94, 0.2);}")
-        Gtk.StyleContext.add_provider(
-            gtk_context,
-            self.style_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_USER
-        )
 
         if "FLATPAK_ID" in os.environ:
             '''

--- a/bottles/frontend/windows/installer.py
+++ b/bottles/frontend/windows/installer.py
@@ -99,12 +99,6 @@ class InstallerDialog(Adw.Window):
     def __init__(self, window, config, installer, **kwargs):
         super().__init__(**kwargs)
         self.set_transient_for(window)
-        self.style_provider.load_from_data(b"progressbar { line-height: 2.0; }")
-        Gtk.StyleContext.add_provider(
-            self.progressbar.get_style_context(),
-            self.style_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
 
         self.window = window
         self.manager = window.manager


### PR DESCRIPTION
# Description
Removes the silly code adding styles and bundles them in CSS instead, has a sideeffect of not causing a crash on GTK 4.10
Fixes #2788

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
