### PR TITLE
Add support for newer vkd3d-proton + bug fix

### DIFF
--- a/bottles/backend/dlls/dll.py
+++ b/bottles/backend/dlls/dll.py
@@ -20,6 +20,7 @@ import shutil
 from glob import glob
 from typing import NewType
 from abc import abstractmethod
+from copy import deepcopy
 
 from bottles.backend.logger import Logger
 from bottles.backend.models.config import BottleConfig
@@ -34,6 +35,7 @@ logging = Logger()
 class DLLComponent:
     base_path: str = None
     dlls: dict = {}
+    checked_dlls: dict = {}
     version: str = None
 
     def __init__(self, version: str):
@@ -47,7 +49,7 @@ class DLLComponent:
         pass
 
     def check(self):
-        found = self.dlls.copy()
+        found = deepcopy(self.dlls)
 
         if None in self.dlls:
             logging.error(f"DLL(s) \"{self.dlls[None]}\" path haven't been found, ignoring...")
@@ -66,7 +68,7 @@ class DLLComponent:
         if len(found) == 0:
             return False
 
-        self.dlls = found
+        self.checked_dlls = found
         return True
 
     def install(self, config: BottleConfig, overrides_only: bool = False, exclude=None):
@@ -77,12 +79,12 @@ class DLLComponent:
         if exclude is None:
             exclude = []
 
-        if None in self.dlls:
-            logging.error(f"DLL(s) \"{self.dlls[None]}\" path haven't been found, ignoring...")
+        if None in self.checked_dlls:
+            logging.error(f"DLL(s) \"{self.checked_dlls[None]}\" path haven't been found, ignoring...")
             return
 
-        for path in self.dlls:
-            for dll in self.dlls[path]:
+        for path in self.checked_dlls:
+            for dll in self.checked_dlls[path]:
                 if dll not in exclude:
                     dll_name = dll.split('/')[-1].split('.')[0]
                     if overrides_only:

--- a/bottles/backend/dlls/dll.py
+++ b/bottles/backend/dlls/dll.py
@@ -61,17 +61,7 @@ class DLLComponent:
             for dll in self.dlls[path]:
                 _dll = os.path.join(_path, dll)
                 if not os.path.exists(_dll):
-                    try:
-                        del found[path][dll]
-                    except TypeError:
-                        # WORKAROUND: I'm not able to find what is causing this
-                        #          TypeError, I've tested with some different
-                        #          setups and I've never been able to reproduce
-                        #          it, so I'm just providing a workaround for
-                        #          not breaking the app. Thiw workaround removes
-                        #          the path from the list of found dlls as it
-                        #          seems to empty in some cases.
-                        del found[path]
+                    found[path].remove(dll)
 
         if len(found) == 0:
             return False

--- a/bottles/backend/dlls/vkd3d.py
+++ b/bottles/backend/dlls/vkd3d.py
@@ -22,10 +22,12 @@ from bottles.backend.utils.manager import ManagerUtils
 class VKD3DComponent(DLLComponent):
     dlls = {
         "x86": [
-            "d3d12.dll"
+            "d3d12.dll",
+            "d3d12core.dll"
         ],
         "x64": [
-            "d3d12.dll"
+            "d3d12.dll",
+            "d3d12core.dll"
         ]
     }
 

--- a/bottles/backend/wine/executor.py
+++ b/bottles/backend/wine/executor.py
@@ -71,7 +71,7 @@ class WineExecutor:
         if override_vkd3d is not None \
             and not override_vkd3d \
             and self.config.Parameters.vkd3d:
-                env_dll_overrides.append("d3d12=b")
+                env_dll_overrides.append("d3d12=b;d3d12core=b,n")
 
         if override_nvapi is not None \
             and not override_nvapi \


### PR DESCRIPTION
# Description

Newer vkd3d-proton will include a new dll : `d3d12core.dll`.
The `d3d12.dll` now being a wrapper around this new dll, reference: https://github.com/HansKristian-Work/vkd3d-proton/commit/fbf03829ebaaf068f9166c668a7f1c9265999915

Additionally, I found why `del found[path][dll]` was throwing a `TypeError`: `found[path]` is a list not a dict, so we must use 
`found[path].remove(dll)` instead.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally using https://github.com/bottlesdevs/components/pull/236 allowing to use an up-to-date `vkd3d-proton` including the new dll.