### PR TITLE
workflows/*: Bump version of actions

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -8,11 +8,11 @@ jobs:
     name: "build-packages"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-43
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: actions/checkout@v3
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: bottles.flatpak
         manifest-path: com.usebottles.bottles.yml

--- a/.github/workflows/pylint-checker.yml
+++ b/.github/workflows/pylint-checker.yml
@@ -9,7 +9,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install Ubuntu dependencies
@@ -33,7 +33,7 @@ jobs:
         python3 utils/pylint-parser.py > output/pylint-result
         cat output/pylint-result
         echo ${{ github.event.number }} > output/pr-number
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: pylint-result
         path: output/

--- a/.github/workflows/pylint-commenter.yml
+++ b/.github/workflows/pylint-commenter.yml
@@ -16,7 +16,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({


### PR DESCRIPTION
# Description

I bumped the versions of actions checkout, flatpak builder and its gnome version to 44.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

