### PR TITLE
Download stable component on first launch

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -417,6 +417,7 @@ class Manager:
                         for runner in self.supported_wine_runners.items():
                             if runner[1]["Channel"] not in ["rc", "unstable"]:
                                 tmp_runners.append(runner)
+                                break
                         runner_name = next(iter(tmp_runners))[0]
                     else:
                         tmp_runners = self.supported_wine_runners
@@ -557,7 +558,16 @@ class Manager:
             if self.utils_conn.check_connection():
                 # if connected, install the latest component from repository
                 try:
-                    component_version = next(iter(component["supported"]))
+                    if not self.settings.get_boolean("release-candidate"):
+                        tmp_components = []
+                        for cpnt in component["supported"].items():
+                            if cpnt[1]["Channel"] not in ["rc", "unstable"]:
+                                tmp_components.append(cpnt)
+                                break
+                        component_version = next(iter(tmp_components))[0]
+                    else:
+                        tmp_components = component["supported"]
+                        component_version = next(iter(tmp_components))
                     self.component_manager.install(component_type, component_version)
                     component["available"] = [component_version]
                 except StopIteration:

--- a/bottles/frontend/ui/preferences.blp
+++ b/bottles/frontend/ui/preferences.blp
@@ -128,6 +128,16 @@ template PreferencesWindow : Adw.PreferencesWindow {
     Adw.PreferencesGroup {
       title: _("Advanced");
 
+      Adw.ActionRow action_prerelease {
+        title: _("Pre-Release");
+        subtitle: _("Display unstable versions of runners and components.");
+        activatable-widget: switch_release_candidate;
+
+        Switch switch_release_candidate {
+          valign: center;
+        }
+      }
+
       Adw.ActionRow {
         title: _("Bottles Directory");
         subtitle: _("Directory that contains the data of your Bottles.");
@@ -205,15 +215,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
           Adw.PreferencesGroup list_runners {
             vexpand: true;
             hexpand: true;
-            Adw.ActionRow action_prerelease {
-              title: _("Pre-Release");
-              subtitle: _("Display unstable versions of runners.");
-              activatable-widget: switch_release_candidate;
-
-              Switch switch_release_candidate {
-                valign: center;
-              }
-            }
           }
         };
       }


### PR DESCRIPTION
# Description
On first launch, download stable components instead of unstable/experimental builds.
Additionally, the pre-release/unstable switch now includes components as well.

Basically this PR extends the existing behavior of runners to runners _and_ components.
Fixes #2825

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally on a clean environment.
