### PR TITLE
Remove Futex2 sync

### DIFF
--- a/bottles/backend/models/samples.py
+++ b/bottles/backend/models/samples.py
@@ -45,7 +45,6 @@ class Samples:
         "ENABLE_VKBASALT": ("vkbasalt", True),
         "WINEESYNC": ("sync", "esync"),
         "WINEFSYNC": ("sync", "fsync"),
-        "WINEFSYNC_FUTEX2": ("sync", "futex2"),
         "WINE_FULLSCREEN_FSR": ("fsr", True),
         "WINE_FULLSCREEN_FSR_STRENGTH": ("fsr_sharpening_strength", 2),
         "WINE_FULLSCREEN_FSR_MODE": ("fsr_quality_mode", "none"),

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -324,10 +324,6 @@ class WineCommand:
         if params.sync == "fsync":
             env.add("WINEFSYNC", "1")
 
-        # Futex2 environment variable
-        if params.sync == "futex2":
-            env.add("WINEFSYNC_FUTEX2", "1")
-
         # Wine debug level
         if not return_steam_env:
             debug_level = "fixme-all"

--- a/bottles/frontend/ui/details-preferences.blp
+++ b/bottles/frontend/ui/details-preferences.blp
@@ -193,7 +193,6 @@ template DetailsPreferences : .AdwPreferencesPage {
           _("System"),
           _("Esync"),
           _("Fsync"),
-          _("Futex2"),
         ]
       };
     }

--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -412,7 +412,6 @@ class PreferencesView(Adw.PreferencesPage):
         # self.toggle_sync.set_active(parameters["sync"] == "wine")
         # self.toggle_esync.set_active(parameters["sync"] == "esync")
         # self.toggle_fsync.set_active(parameters["sync"] == "fsync")
-        # self.toggle_futex2.set_active(parameters["sync"] == "futex2")
 
         self.switch_discrete.set_active(parameters.discrete_gpu)
 
@@ -492,7 +491,6 @@ class PreferencesView(Adw.PreferencesPage):
             "wine",
             "esync",
             "fsync",
-            "futex2",
         ]
         for sync in sync_types:
             if sync == parameters.sync:
@@ -594,13 +592,12 @@ class PreferencesView(Adw.PreferencesPage):
 
     def __set_sync_type(self, *_args):
         """
-        Set the sync type (wine, esync, fsync, futext2)
+        Set the sync type (wine, esync, fsync)
         """
         sync_types = [
             "wine",
             "esync",
             "fsync",
-            "futex2",
         ]
         self.queue.add_task()
         self.combo_sync.set_sensitive(False)

--- a/po/bottles.pot
+++ b/po/bottles.pot
@@ -743,10 +743,6 @@ msgstr ""
 msgid "Fsync"
 msgstr ""
 
-#: bottles/frontend/ui/details-preferences.blp:196
-msgid "Futex2"
-msgstr ""
-
 #: bottles/frontend/ui/details-preferences.blp:202
 msgid "Monitor Performance"
 msgstr ""


### PR DESCRIPTION
# Description
The environment variable `WINEFSYNC_FUTEX2` is not used anymore be various runners: both Wine-GE and TKG dropped support for it (and regular Wine never had it to begin with).
This PR removes the Futex2 option from the settings, since it's likely for a user to use a runner that doesn't support it. Other programs like Heroic or Lutris already don't offer a toggle for it.

For TKG, the patch to support it was moved to legacy https://github.com/Frogging-Family/wine-tkg-git/commit/389ce313e519267cfa0ab35930c78eb6528049bc, then the setting was moved to legacy https://github.com/Frogging-Family/wine-tkg-git/commit/5bcf238d26b493b9b21967f6999d7e1a63a71b03, and finally disabled by default https://github.com/Frogging-Family/wine-tkg-git/commit/6d28be5e28224557f6979c2a931e0a82f81c915f.
`_fsync_futex2` is still enabled on [Caffe](https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg.cfg) and [Soda](https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg.cfg) (which are based on TKG), though.

Related to #1198 and #1980.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Kinda none of these? It's not a bug fix nor a new feature, and it's not a breaking change: if someone set `futex2` and then updates Bottles, everything would still work fine. Lastly, it's not in the documentation.

# How Has This Been Tested?
Compiled Bottles myself, opened Bottles, everything was fine.
