### PR TITLE
Use bottle name instead of path in launch options when adding a Steam shortcut

### DIFF
--- a/bottles/backend/managers/steam.py
+++ b/bottles/backend/managers/steam.py
@@ -526,7 +526,7 @@ class SteamManager:
             "StartDir": ManagerUtils.get_bottle_path(self.config),
             "icon": ManagerUtils.extract_icon(self.config, program_name, program_path),
             "ShortcutPath": "",
-            "LaunchOptions": args.format(self.config.Path, program_name),
+            "LaunchOptions": args.format(self.config.Name, program_name),
             "IsHidden": 0,
             "AllowDesktopConfig": 1,
             "AllowOverlay": 1,


### PR DESCRIPTION
# Description

Fixes #2148, fixes #2855

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] locally
