### PR TITLE
fix: Use correct xdpyinfo URL

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -133,9 +133,10 @@ modules:
   - name: xdpyinfo
     buildsystem: autotools
     sources:
-      - type: archive
-        url: https://github.com/freedesktop/xdpyinfo/archive/refs/tags/xdpyinfo-1.3.2.tar.gz
-        sha256: 4c6942cb55e965f1192c0e2efc78429e2f4281cc2bc185d6ea09d609f32c51de
+      - type: git
+        url: https://gitlab.freedesktop.org/xorg/app/xdpyinfo.git
+        tag: "xdpyinfo-1.3.3"
+        commit: 61bc4b764030bdc9a731ee74c7c56bf2b2a4bddf
 
 
   # Libraries


### PR DESCRIPTION
# Description
This uses the correct URL for xdpyinfo. The GitHub repo was deleted, so I'm using the GitLab repo instead.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] CI