### PR TITLE
Block the use of GTK_THEME in bottles

### DIFF
--- a/bottles/frontend/bottles.py
+++ b/bottles/frontend/bottles.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+os.environ.pop('GTK_THEME')
 import sys
 import signal
 import gettext


### PR DESCRIPTION
# Description
Makes Bottles ignore the `GTK_THEME` environment variable.

Fixes any issue that complained about GTK_THEME

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- set `GTK_THEME` using flatseal
- restart Bottles
- Bottles still uses the usual libadwaita stylesheet
