### PR TITLE
main: Fix crash when `GTK_THEME` doesn't exist

### DIFF
--- a/bottles/frontend/bottles.py
+++ b/bottles/frontend/bottles.py
@@ -29,7 +29,9 @@ localedir = "@localedir@"
 gresource_path = f"{pkgdatadir}/bottles.gresource"
 sys.path.insert(1, pkgdatadir)
 
-os.environ.pop('GTK_THEME')
+# Remove GTK_THEME variable to prevent breakages
+os.unsetenv("GTK_THEME")
+
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 gettext.install('bottles', localedir)
 


### PR DESCRIPTION
# Description
This fixes KeyError when `GTK_THEME` doesn't exist.

```
  File "/var/home/TheEvilSkeleton/Projects/Bottles/./build/bin/bottles", line 32, in <module>
    os.environ.pop('GTK_THEME')
  File "/usr/lib/python3.10/_collections_abc.py", line 957, in pop
    value = self[key]
  File "/usr/lib/python3.10/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'GTK_THEME'
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Locally