### PR TITLE
Fix forum URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <hr />
 
   <a href="https://docs.usebottles.com">Documentation</a> ·
-  <a href="https://forums.usebottles.com">Forums</a> · 
+  <a href="https://forum.usebottles.com">Forums</a> · 
   <a href="https://t.me/usebottles">Telegram group</a> · 
   <a href="https://usebottles.com/funding">Funding</a>
 </div>


### PR DESCRIPTION
# Description
The old URL went to a link that had a certificate with a CN of forum.usebottles.com. This this makes the URL that so that people don't get a certificate error.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
N/A
