### PR TITLE
Fixed ability to change drive location

### DIFF
--- a/bottles/backend/wine/drives.py
+++ b/bottles/backend/wine/drives.py
@@ -36,14 +36,16 @@ class Drives:
     def set_drive_path(self, letter: str, path: str):
         """Change a drives path in the bottle"""
         letter = f"{letter}:".lower()
+        drive_sym_path = os.path.join(self.dosdevices_path, letter)
         if not os.path.exists(self.dosdevices_path):
             os.makedirs(self.dosdevices_path)
-        try:
-            os.symlink(path, os.path.join(self.dosdevices_path, letter))
+        if not os.path.exists(drive_sym_path):
+            os.symlink(path, drive_sym_path)
             logging.info(f"New drive {letter} added to the bottle")
-        except FileExistsError:
-            os.remove(os.path.join(self.dosdevices_path, letter))
-            os.symlink(path, os.path.join(self.dosdevices_path, letter))
+        else:
+            os.remove(drive_sym_path)
+            os.symlink(path, drive_sym_path)
+            logging.info(f"Drive {letter} path changed to {path}")
 
     def remove_drive(self, letter: str):
         """Remove a drive from the bottle"""

--- a/bottles/backend/wine/drives.py
+++ b/bottles/backend/wine/drives.py
@@ -33,8 +33,8 @@ class Drives:
             return self.get_all().get(letter)
         return None
 
-    def new_drive(self, letter: str, path: str):
-        """Add a new drive to the bottle"""
+    def set_drive_path(self, letter: str, path: str):
+        """Change a drives path in the bottle"""
         letter = f"{letter}:".lower()
         if not os.path.exists(self.dosdevices_path):
             os.makedirs(self.dosdevices_path)
@@ -42,7 +42,8 @@ class Drives:
             os.symlink(path, os.path.join(self.dosdevices_path, letter))
             logging.info(f"New drive {letter} added to the bottle")
         except FileExistsError:
-            logging.warning(f"Drive {letter} already exists in the bottle, no drive added")
+            os.remove(os.path.join(self.dosdevices_path, letter))
+            os.symlink(path, os.path.join(self.dosdevices_path, letter))
 
     def remove_drive(self, letter: str):
         """Remove a drive from the bottle"""

--- a/bottles/frontend/windows/drives.py
+++ b/bottles/frontend/windows/drives.py
@@ -64,7 +64,7 @@ class DriveEntry(Adw.ActionRow):
                 return
 
             path = dialog.get_file().get_path()
-            Drives(self.config).new_drive(self.drive[0], path)
+            Drives(self.config).set_drive_path(self.drive[0], path)
             self.set_subtitle(path)
 
         dialog = Gtk.FileChooserNative.new(


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed (if available). 
Please also include relevant motivation and context.

Fixes the ability to change the path of a drive in a bottle. Works by removing the symlink before adding a new changed symlink to prevent errors.

Fixes #(issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Test A
1. Change directory of drive 
2. Error appears "Drive a: already exists in the bottle, no drive added"
- [x] Test B
1. Change directory of drive 
2. No error appears and directory changes.
