### PR TITLE
Use the correct icon in dependency-entry.blp for downloads

### DIFF
--- a/bottles/frontend/ui/bottles.gresource.xml
+++ b/bottles/frontend/ui/bottles.gresource.xml
@@ -61,7 +61,7 @@
         <file alias="applications-system-symbolic.svg">../../../data/icons/symbolic/scalable/actions/applications-system-symbolic.svg</file>
         <file alias="application-x-addon-symbolic.svg">../../../data/icons/symbolic/scalable/actions/application-x-addon-symbolic.svg</file>
         <file alias="computer-symbolic.svg">../../../data/icons/symbolic/scalable/actions/computer-symbolic.svg</file>
-        <file alias="document-save-symbolic.svg">../../../data/icons/symbolic/scalable/actions/document-save-symbolic.svg</file>
+        <file alias="folder-download-symbolic.svg">../../../data/icons/symbolic/scalable/actions/folder-download-symbolic.svg</file>
         <file alias="go-next-symbolic.svg">../../../data/icons/symbolic/scalable/actions/go-next-symbolic.svg</file>
         <file alias="go-previous-symbolic.svg">../../../data/icons/symbolic/scalable/actions/go-previous-symbolic.svg</file>
         <file alias="media-playback-start-symbolic.svg">../../../data/icons/symbolic/scalable/actions/media-playback-start-symbolic.svg</file>

--- a/bottles/frontend/ui/component-entry.blp
+++ b/bottles/frontend/ui/component-entry.blp
@@ -44,7 +44,7 @@ template ComponentEntry : .AdwActionRow {
     visible: false;
     tooltip-text: _("Download & Install");
     valign: center;
-    icon-name: "document-save-symbolic";
+    icon-name: "folder-download-symbolic";
 
     styles [
       "flat",
@@ -59,7 +59,7 @@ template ComponentEntry : .AdwActionRow {
     }
 
     Image {
-      icon-name: "document-save-symbolic";
+      icon-name: "folder-download-symbolic";
     }
   }
 

--- a/bottles/frontend/ui/dependency-entry.blp
+++ b/bottles/frontend/ui/dependency-entry.blp
@@ -65,7 +65,7 @@ template DependencyEntry : .AdwActionRow {
       valign: center;
 
       Image {
-        icon-name: "document-save-symbolic";
+        icon-name: "folder-download-symbolic";
       }
 
       styles [

--- a/bottles/frontend/ui/importer-entry.blp
+++ b/bottles/frontend/ui/importer-entry.blp
@@ -49,7 +49,7 @@ template ImporterEntry : .AdwActionRow {
       valign: center;
 
       Image {
-        icon-name: "document-save-symbolic";
+        icon-name: "folder-download-symbolic";
       }
 
       styles [

--- a/bottles/frontend/ui/importer.blp
+++ b/bottles/frontend/ui/importer.blp
@@ -34,7 +34,7 @@ template ImporterView : .AdwBin {
     .AdwPreferencesPage {
       .AdwStatusPage status_page {
         vexpand: true;
-        icon-name: "document-save-symbolic";
+        icon-name: "folder-download-symbolic";
         title: _("No Prefixes Found");
         description: _("No external prefixes were found. Does Bottles have access to them?\nUse the icon on the top to import a bottle from a backup.");
       }

--- a/bottles/frontend/ui/installer-entry.blp
+++ b/bottles/frontend/ui/installer-entry.blp
@@ -50,7 +50,7 @@ template InstallerEntry : .AdwActionRow {
     Button btn_install {
       tooltip-text: _("Install this Program");
       valign: center;
-      icon-name: "document-save-symbolic";
+      icon-name: "folder-download-symbolic";
 
       styles [
         "flat",


### PR DESCRIPTION
# Description
I know bottles is design around Adwaita and Adwaita only.

but save icons are universally agreed to be floppy disks and adwaita is the one in the wrong here to make save a download icon

So bottles should use a download icon instead such as the one in this PR and the icon would be universally correct in all DEs and icon themes

Will not causing any harm

Fixes #2949

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Look at it using the adwaita icon theme.
- [x] Look at it using Papirus and vimix.
