### PR TITLE
fix: Steam and Proton usage

### DIFF
--- a/bottles/backend/managers/runtime.py
+++ b/bottles/backend/managers/runtime.py
@@ -134,6 +134,10 @@ class RuntimeManager:
             return available_runtimes
 
         lookup = {
+            "sniper": {
+                "name": "sniper",
+                "entry_point": os.path.join(steam_manager.steam_path, "steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point"),
+            },
             "soldier": {
                 "name": "soldier",
                 "entry_point": os.path.join(steam_manager.steam_path, "steamapps/common/SteamLinuxRuntime_soldier/_v2-entry-point"),

--- a/bottles/backend/managers/steam.py
+++ b/bottles/backend/managers/steam.py
@@ -122,7 +122,7 @@ class SteamManager:
             return None
 
         with open(library_folders_path, "r", errors="replace") as f:
-            _library_folders = SteamUtils.parse_acf(f.read())
+            _library_folders = SteamUtils.parse_vdf(f.read())
 
         if _library_folders is None or not _library_folders.get("libraryfolders"):
             logging.warning(f"Could not parse libraryfolders.vdf")
@@ -155,7 +155,7 @@ class SteamManager:
             return {}
 
         with open(self.localconfig_path, "r", errors="replace") as f:
-            data = SteamUtils.parse_acf(f.read())
+            data = SteamUtils.parse_vdf(f.read())
 
         if data is None:
             logging.warning(f"Could not parse localconfig.vdf")
@@ -191,14 +191,18 @@ class SteamManager:
                 logging.error(f"{config_info} is not valid, cannot get Steam Proton path")
                 return None
 
-            proton_path = lines[2].strip()[:-5]
-            proton_name = os.path.basename(proton_path.rsplit("/", 1)[0])
+            proton_path = lines[1].strip().removesuffix("/share/fonts/")
 
-            if not os.path.isdir(proton_path):
+            if proton_path.endswith("/files"):
+                proton_path = proton_path.removesuffix("/files")
+            elif proton_path.endswith("/dist"):
+                proton_path = proton_path.removesuffix("/dist")
+
+            if not SteamUtils.is_proton(proton_path):
                 logging.error(f"{proton_path} is not a valid Steam Proton path")
                 return None
 
-            return proton_name, proton_path
+            return proton_path
 
     def list_apps_ids(self) -> dict:
         """List all apps in Steam"""
@@ -272,7 +276,7 @@ class SteamManager:
             _launch_options = self.get_launch_options(appid, appdata)
             _dir_name = os.path.basename(_path)
             _acf = self.get_acf_data(_library_path, _dir_name)
-            _runner = self.get_runner_path(_path)
+            _runner_path = self.get_runner_path(_path)
             _creation_date = datetime.fromtimestamp(os.path.getctime(_path)) \
                 .strftime("%Y-%m-%d %H:%M:%S.%f")
 
@@ -284,11 +288,12 @@ class SteamManager:
                 logging.warning(f"A Steam prefix was found, but there is no ACF for it: {_dir_name}, skipping…")
                 continue
 
-            if "Proton" in _acf["AppState"]["name"]:
+            if SteamUtils.is_proton(os.path.join(_library_path, "steamapps/common", _acf["AppState"]["installdir"])):
                 # skip Proton default prefix
+                logging.warning(f"A Steam prefix was found, but it is a Proton one: {_dir_name}, skipping…")
                 continue
 
-            if _runner is None:
+            if _runner_path is None:
                 logging.warning(f"A Steam prefix was found, but there is no Proton for it: {_dir_name}, skipping…")
                 continue
 
@@ -297,8 +302,8 @@ class SteamManager:
             _conf.Environment = "Steam"
             _conf.CompatData = _dir_name
             _conf.Path = os.path.join(_path, "pfx")
-            _conf.Runner = _runner[0]
-            _conf.RunnerPath = _runner[1]
+            _conf.Runner = os.path.basename(_runner_path)
+            _conf.RunnerPath = _runner_path
             _conf.WorkingDir = os.path.join(_conf["Path"], "drive_c")
             _conf.Creation_Date = _creation_date
             _conf.Update_Date = datetime.fromtimestamp(

--- a/bottles/backend/utils/steam.py
+++ b/bottles/backend/utils/steam.py
@@ -61,7 +61,10 @@ class SteamUtils:
         compat_layer_name = data.get("manifest", {}) \
             .get("compatmanager_layer_name", {})
 
-        return "proton" in compat_layer_name
+        commandline = data.get("manifest", {}) \
+            .get("commandline", {})
+
+        return "proton" in compat_layer_name or "proton" in commandline
 
     @staticmethod
     def get_associated_runtime(path: str) -> str:

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -17,6 +17,7 @@ from bottles.backend.utils.generic import detect_encoding
 from bottles.backend.utils.gpu import GPUUtils
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.utils.terminal import TerminalUtils
+from bottles.backend.utils.steam import SteamUtils
 
 logging = Logger()
 
@@ -98,7 +99,7 @@ class WineCommand:
         self.minimal = minimal
         self.arguments = arguments
         self.cwd = self._get_cwd(cwd)
-        self.runner = self._get_runner()
+        self.runner, self.runner_runtime = self._get_runner_info()
         self.command = self.get_cmd(command, post_script)
         self.terminal = terminal
         self.env = self.get_env(environment)
@@ -151,10 +152,15 @@ class WineCommand:
         if environment is None:
             environment = {}
 
+        bottle = ManagerUtils.get_bottle_path(config)
+        runner_path = ManagerUtils.get_runner_path(config.Runner)
+
         if config.Environment == "Steam":
             bottle = config.Path
-        else:
-            bottle = ManagerUtils.get_bottle_path(config)
+            runner_path = config.RunnerPath
+
+        if SteamUtils.is_proton(runner_path):
+            runner_path = SteamUtils.get_dist_directory(runner_path)
 
         # Clean some env variables which can cause trouble
         # ref: <https://github.com/bottlesdevs/Bottles/issues/2127>
@@ -224,7 +230,6 @@ class WineCommand:
                 logging.warning("Bottles runtime was requested but not found")
 
         # Get Runner libraries
-        runner_path = ManagerUtils.get_runner_path(config.Runner)
         if arch == "win64":
             runner_libs = [
                 "lib",
@@ -399,10 +404,11 @@ class WineCommand:
 
         return env.get()["envs"]
 
-    def _get_runner(self) -> str:
+    def _get_runner_info(self) -> (str, str):
         config = self.config
-        runner = config.Runner
+        runner = ManagerUtils.get_runner_path(config.Runner)
         arch = config.Arch
+        runner_runtime = None
 
         if config.Environment == "Steam":
             runner = config.RunnerPath
@@ -410,25 +416,14 @@ class WineCommand:
         if runner in [None, ""]:
             return ""
 
-        if "Proton" in runner \
-                and "lutris" not in runner \
-                and config.Environment != "Steam":
+        if SteamUtils.is_proton(runner):
             '''
-            If the runner is Proton, set the pat to /dist or /files 
+            If the runner is Proton, set the path to /dist or /files 
             based on check if files exists.
+            Additionally, check for its corresponding runtime.
             '''
-            _runner = f"{runner}/files"
-            if os.path.exists(f"{Paths.runners}/{runner}/dist"):
-                _runner = f"{runner}/dist"
-            runner = f"{Paths.runners}/{_runner}/bin/wine"
-
-        elif config.Environment == "Steam":
-            '''
-            If the environment is Steam, runner path is defined
-            in the bottle configuration and point to the right
-            main folder.
-            '''
-            runner = f"{runner}/bin/wine"
+            runner_runtime = SteamUtils.get_associated_runtime(runner)
+            runner = os.path.join(SteamUtils.get_dist_directory(runner), f"bin/wine")
 
         elif runner.startswith("sys-"):
             '''
@@ -438,14 +433,14 @@ class WineCommand:
             runner = shutil.which("wine")
 
         else:
-            runner = f"{Paths.runners}/{runner}/bin/wine"
+            runner = f"{runner}/bin/wine"
 
         if arch == "win64":
             runner = f"{runner}64"
 
         runner = runner.replace(" ", "\\ ")
 
-        return runner
+        return runner, runner_runtime
 
     def get_cmd(
             self,
@@ -509,13 +504,22 @@ class WineCommand:
             _picked = {}
 
             if _rs:
-                if "soldier" in _rs.keys() and "proton" in self.runner.lower():
-                    ''' 
-                    Soldier doesn't works with Soda/Caffe and maybe other Wine runners, but it
-                    works with Proton. So, if the runner is Proton, use the soldier runtime.
+                if "sniper" in _rs.keys() and "sniper" in self.runner_runtime:
+                    '''
+                    Sniper is the default runtime used by Proton version >= 8.0
+                    '''
+                    _picked = _rs["sniper"]
+                if "soldier" in _rs.keys() and "soldier" in self.runner_runtime:
+                    '''
+                    Sniper is the default runtime used by Proton version >= 5.13 and < 8.0
                     '''
                     _picked = _rs["soldier"]
                 elif "scout" in _rs.keys():
+                    '''
+                    For Wine runners, we cannot make assumption about which runtime would suits
+                    them the best, as it would depend on their build environment.
+                    Sniper/Soldier are not backward-compatible, defaulting to Scout should maximize compatibility.
+                    '''
                     _picked = _rs["scout"]
             else:
                 logging.warning("Steam runtime was requested but not found")

--- a/bottles/backend/wine/wineserver.py
+++ b/bottles/backend/wine/wineserver.py
@@ -5,6 +5,7 @@ import time
 from bottles.backend.logger import Logger
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.utils.proc import ProcUtils
+from bottles.backend.utils.steam import SteamUtils
 from bottles.backend.wine.wineprogram import WineProgram
 
 logging = Logger()
@@ -34,6 +35,9 @@ class WineServer(WineProgram):
             bottle = config.Path
             runner = config.RunnerPath
 
+        if SteamUtils.is_proton(runner):
+            runner = SteamUtils.get_dist_directory(runner)
+
         env = os.environ.copy()
         env["WINEPREFIX"] = bottle
         env["PATH"] = f"{runner}/bin:{env['PATH']}"
@@ -55,6 +59,13 @@ class WineServer(WineProgram):
         config = self.config
         bottle = ManagerUtils.get_bottle_path(config)
         runner = ManagerUtils.get_runner_path(config.Runner)
+
+        if config.Environment == "Steam":
+            bottle = config.Path
+            runner = config.RunnerPath
+
+        if SteamUtils.is_proton(runner):
+            runner = SteamUtils.get_dist_directory(runner)
 
         env = os.environ.copy()
         env["WINEPREFIX"] = bottle

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -41,6 +41,14 @@ add-extensions:
     version: "43"
     no-autodownload: true
 
+  com.valvesoftware.Steam.CompatibilityTool:
+    subdirectories: true
+    directory: share/steam/compatibilitytools.d
+    version: stable
+    versions: stable;beta;test
+    no-autodownload: true
+    autodelete: false
+
   com.valvesoftware.Steam.Utility:
     subdirectories: true
     directory: utils
@@ -49,7 +57,7 @@ add-extensions:
     add-ld-path: lib
     merge-dirs: bin
     no-autodownload: true
-    autodelete: true
+    autodelete: false
 
 x-compat-i386-opts: &compat_i386_opts
   prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
@@ -77,6 +85,7 @@ cleanup:
 
 cleanup-commands:
   - mkdir -p /app/utils
+  - mkdir -p /app/share/steam/compatibilitytools.d
 
 modules:
   # PYPI modules


### PR DESCRIPTION
# Description
Fixes #2952
Fixes #2850

To completely fix those issues, `Proton-GE` runners manifests should be updated in the [components](https://github.com/bottlesdevs/components) repository. It is independent from this PR and will not require further `Bottles` code change.

I described what the issue is and how to fix it in the linked issues, pasting those comments for reference: 
>There is two bugs here.
The first one is on the [component](https://github.com/bottlesdevs/components) side and match what you described: there is a mismatch between the component name (lower-case) and the extracted component directory (which contains capitalized letters). 
Concerning the fix: should we change the extracted folder name to lower-case, or the component name to include those capitalized letters? Capitalizing (e.g. `ge-proton7-51` to `GE-Proton7-51`) will require the least changes/hacks, and would be more consistent with the upstream name, but I'll submit a PR there based on the decision of a maintainer.
The second bug is on the Bottles side and is actually identical to what's described in #2593, so the fix would be the same. What is happening is that the backed still uses the name of the component to decide if a runner is Proton or Wine, instead of what's included in its manifest. And it causes issues with Wine runners which contains `[pP]roton` in their name, like Kron4ek's [wine-proton-8.0-1-amd64](https://github.com/Kron4ek/Wine-Builds/releases/tag/proton-8.0-1) or GloriousEggroll's [Wine-GE-Proton7-43](https://github.com/GloriousEggroll/wine-ge-custom/releases/tag/GE-Proton7-43).

_Originally posted by @koplo199 in https://github.com/bottlesdevs/Bottles/issues/2850#issuecomment-1519078006_

>It's probably not a permission issue, I think there's two different causes to the bug.
First, in Bottles, the code responsible for detecting the proton path is not robust at all: 
https://github.com/bottlesdevs/Bottles/blob/9132667ae41a04769b286a09471306ba4deed980/bottles/backend/managers/steam.py#L194
It seems Bottles expect the third line to always end by `/lib/`, thus stripping those five characters to retrieve the path. But here, at least with the `Proton-GE` installed by flatpak, this line ends with `/lib32/`, which would be seven characters. Stripping only five would give `Proton-GE/l` and this is exactly what shows in the logs.
The Bottles code definitively needs a more reliable method for retrieving the path, but I strongly suspect using the `lib32`/`lib` folder structure instead of the regular `lib`/`lib64` is also a bug on its own as it may be the source of other [issues](https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton-GE/issues/48).
Somewhat related note: there is still other issues that needs to be fixed for a flawless steam experience, since the 8.0 version Proton is using the [sniper](https://github.com/ValveSoftware/Proton/commit/28aeb63901c47dca236ccfb4db2f111086338c59) runtime instead of the much older `soldier` one, but Bottles [does not support it](https://github.com/bottlesdevs/Bottles/blob/9132667ae41a04769b286a09471306ba4deed980/bottles/backend/managers/runtime.py#L136-L145) at the moment.

_Originally posted by @koplo199 in https://github.com/bottlesdevs/Bottles/issues/2952#issuecomment-1630361702_
            

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Tested with flatpak build artifacts 
