### PR TITLE
fix: Offline components and runners not manageable

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -62,6 +62,7 @@ from bottles.backend.utils.gsettings_stub import GSettingsStub
 from bottles.backend.utils.lnk import LnkUtils
 from bottles.backend.utils.manager import ManagerUtils
 from bottles.backend.utils.singleton import Singleton
+from bottles.backend.utils.steam import SteamUtils
 from bottles.backend.utils.threading import RunAsync
 from bottles.backend.wine.reg import Reg
 from bottles.backend.wine.regkeys import RegKeys
@@ -346,7 +347,7 @@ class Manager(metaclass=Singleton):
 
         # lock winemenubuilder.exe
         for runner in runners:
-            if runner not in self.supported_proton_runners:
+            if not SteamUtils.is_proton(runner):
                 winemenubuilder_paths = [
                     f"{runner}lib64/wine/x86_64-windows/winemenubuilder.exe",
                     f"{runner}lib/wine/x86_64-windows/winemenubuilder.exe",
@@ -376,7 +377,7 @@ class Manager(metaclass=Singleton):
             _runner = os.path.basename(os.path.normpath(runner))
             runners_available.append(_runner)
 
-        runners_available = sorted(runners_available, reverse=True)
+        runners_available = self.__sort_runners(runners_available, "")
 
         runners_order = {
             "soda": [],
@@ -505,6 +506,57 @@ class Manager(metaclass=Singleton):
         if res:
             self.latencyflex_available = res
         return res is not False
+
+    def get_offline_components(self, component_type: str, extra_name_check: str = "") -> list:
+        components = {
+            "dxvk": {
+                "available": self.dxvk_available,
+                "supported": self.supported_dxvk,
+            },
+            "vkd3d": {
+                "available": self.vkd3d_available,
+                "supported": self.supported_vkd3d,
+            },
+            "nvapi": {
+                "available": self.nvapi_available,
+                "supported": self.supported_nvapi,
+            },
+            "latencyflex": {
+                "available": self.latencyflex_available,
+                "supported": self.supported_latencyflex,
+            },
+            "runner": {
+                "available": self.runners_available,
+                "supported": self.supported_wine_runners,
+            },
+            "runner:proton": {
+                "available": self.runners_available,
+                "supported": self.supported_proton_runners,
+            }
+        }
+        if component_type not in components:
+            logging.warning(f"Unknown component type found: {component_type}")
+            raise ValueError("Component type not supported.")
+
+        component_list = components[component_type]
+        offline_components = list(set(component_list["available"]).difference(component_list["supported"].keys()))
+
+        if component_type == "runner":
+            offline_components = [ runner for runner in offline_components \
+                                    if not runner.startswith("sys-") and \
+                                    not SteamUtils.is_proton(ManagerUtils.get_runner_path(runner)) ]
+        elif component_type == "runner:proton":
+            offline_components = [ runner for runner in offline_components \
+                                    if SteamUtils.is_proton(ManagerUtils.get_runner_path(runner)) ]
+
+        if extra_name_check and extra_name_check not in component_list["available"] \
+                and extra_name_check not in component_list["supported"]:
+            offline_components.append(extra_name_check)
+
+        try:
+            return sort_by_version(offline_components)
+        except ValueError:
+            return sorted(offline_components, reverse=True)
 
     def __check_component(self, component_type: str, install_latest: bool = True) -> Union[bool, list]:
         components = {
@@ -943,37 +995,28 @@ class Manager(metaclass=Singleton):
             to latest Soda. If there is no Soda, set it to the
             first one.
             '''
-            config.Runner = self.get_latest_runner("wine")
+            config.Runner = self.get_latest_runner()
 
         if config.DXVK not in self.dxvk_available:
             '''
             If the DXVK is not in the list of available DXVKs, set it to
-            highest version.
+            highest version which is the first in the list.
             '''
-            config.DXVK = sorted(
-                [dxvk for dxvk in self.dxvk_available],
-                key=lambda x: x.split("-")[-1]
-            )[-1]
+            config.DXVK = self.dxvk_available[0]
 
         if config.VKD3D not in self.vkd3d_available:
             '''
             If the VKD3D is not in the list of available VKD3Ds, set it to
-            highest version.
+            highest version which is the first in the list.
             '''
-            config.VKD3D = sorted(
-                [vkd3d for vkd3d in self.vkd3d_available],
-                key=lambda x: x.split("-")[-1]
-            )[-1]
+            config.VKD3D = self.vkd3d_available[0]
 
         if config.NVAPI not in self.nvapi_available:
             '''
             If the NVAPI is not in the list of available NVAPIs, set it to
-            highest version.
+            highest version which is the first in the list.
             '''
-            config.NVAPI = sorted(
-                [nvapi for nvapi in self.nvapi_available],
-                key=lambda x: x.split("-")[-1]
-            )[-1]
+            config.NVAPI = self.nvapi_available[0]
 
         # create the bottle path
         bottle_path = os.path.join(Paths.bottles, config.Name)
@@ -1375,34 +1418,31 @@ class Manager(metaclass=Singleton):
             data={"config": config}
         )
 
-    def __sort_runners(self, prefix: str, fallback: bool = True) -> sorted:
+    @staticmethod
+    def __sort_runners(runner_list: list, prefix: str) -> sorted:
         """
         Return a sorted list of runners for a given prefix. Fallback to the
         first available if fallback argument is True.
         """
-        runners = sorted(
-            [
-                runner
-                for runner in self.runners_available
-                if runner.startswith(prefix)
-            ],
-            key=lambda x: x.split("-")[1],
-            reverse=True
-        )
+        runners = [ runner for runner in runner_list if runner.startswith(prefix) ]
 
-        if len(runners) > 0:
-            return runners[0]
-
-        return self.runners_available[0] if fallback else []
-
-    def get_latest_runner(self, runner_type: str = "wine") -> list:
-        """Return the latest available runner for a given type."""
         try:
-            if runner_type in ["", "wine"]:
-                return self.__sort_runners("soda")
-            return self.__sort_runners("proton")
-        except IndexError:
-            return []
+            runners = sort_by_version(runners, "")
+        except ValueError:
+            runners = sorted(
+                runners,
+                key=lambda x: x.split("-")[1],
+                reverse=True
+            )
+
+        return runners
+
+    def get_latest_runner(self, runner_prefix: str = "soda") -> list:
+        """Return the latest available runner for a given prefix."""
+        runners = self.__sort_runners(self.runners_available, runner_prefix)
+        if not runners:
+            runners = self.__sort_runners(self.runners_available, "")
+        return runners[0] if runners else []
 
     def delete_bottle(self, config: BottleConfig) -> bool:
         """

--- a/bottles/backend/runner.py
+++ b/bottles/backend/runner.py
@@ -23,6 +23,7 @@ from bottles.backend.managers.runtime import RuntimeManager
 from bottles.backend.models.config import BottleConfig
 from bottles.backend.models.result import Result
 from bottles.backend.utils.manager import ManagerUtils
+from bottles.backend.utils.steam import SteamUtils
 from bottles.backend.wine.wineboot import WineBoot
 
 if TYPE_CHECKING:
@@ -89,7 +90,7 @@ class Runner:
         the host system. There are some exceptions, like the Soda and Wine-GE runners,
         which are built to work without the Steam Runtime.
         """
-        if runner in manager.supported_proton_runners and RuntimeManager.get_runtimes("steam"):
+        if SteamUtils.is_proton(ManagerUtils.get_runner_path(runner)) and RuntimeManager.get_runtimes("steam"):
             manager.update_config(config, "use_steam_runtime", True, "Parameters")
 
         return Result(

--- a/bottles/backend/utils/generic.py
+++ b/bottles/backend/utils/generic.py
@@ -92,7 +92,7 @@ def is_glibc_min_available():
 def sort_by_version(_list: list, extra_check: str = "async"):
     def natural_keys(text):
         result = [int(re.search(extra_check, text) is None)]
-        result.extend([int(c) for c in re.findall(r'\d+', text)])
+        result.extend([int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', text)])
         return result
 
     _list.sort(key=natural_keys, reverse=True)

--- a/bottles/backend/utils/steam.py
+++ b/bottles/backend/utils/steam.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import subprocess
+import os, subprocess
 from typing import Union, TextIO
 
 from bottles.backend.models.vdict import VDFDict
@@ -44,3 +44,22 @@ class SteamUtils:
         Saves a VDF file. Just a wrapper for vdf.dumps.
         """
         vdf.dump(data, fp, pretty=True)
+
+    @staticmethod
+    def is_proton(path: str) -> bool:
+        """
+        Checks if a directory is a Proton directory.
+        """
+        toolmanifest = os.path.join(path, f"toolmanifest.vdf")
+        if not os.path.isfile(toolmanifest):
+            return False
+
+        f = open(toolmanifest, "r", errors="replace")
+        data = SteamUtils.parse_vdf(f.read())
+        compat_layer_name = data.get("manifest", {}) \
+            .get("compatmanager_layer_name", {})
+
+        commandline = data.get("manifest", {}) \
+            .get("commandline", {})
+
+        return "proton" in compat_layer_name or "proton" in commandline

--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -25,6 +25,7 @@ from gi.repository import Gtk, Adw, Gio, GLib
 from bottles.backend.managers.data import DataManager, UserDataKeys
 from bottles.backend.state import EventManager, Events
 from bottles.backend.utils.threading import RunAsync
+from bottles.backend.utils.generic import sort_by_version
 from bottles.frontend.widgets.component import ComponentEntry, ComponentExpander
 
 
@@ -222,6 +223,25 @@ class PreferencesWindow(Adw.PreferencesWindow):
         return (not self.window.settings.get_boolean("release-candidate")
                     and component[1]["Channel"] in ["rc", "unstable"])
 
+    def __populate_component_list(self, component_type, supported_components, list_component):
+        offline_components = self.manager.get_offline_components(component_type)
+        supported_component_items = list(supported_components.items())
+        i, j = 0, 0
+        while i <= len(supported_component_items):
+            while j < len(offline_components) and \
+                    (i == len(supported_component_items) or \
+                    sort_by_version([offline_components[j], supported_component_items[i][0]])[0] == offline_components[j]):
+                offline_entry = [ offline_components[j], { "Installed": True} ]
+                supported_component_items.insert(i, offline_entry)
+                j += 1
+            i += 1
+        for component in supported_component_items:
+            if self.__check_release_candidate(component):
+                continue
+            _entry = ComponentEntry(self.window, component, component_type)
+            list_component.add(_entry)
+            self.__registry.append(_entry)
+
     def populate_runtimes_list(self):
         for runtime in self.manager.supported_runtimes.items():
             self.list_runtimes.add(ComponentEntry(self.window, runtime, "runtime", is_upgradable=True))
@@ -231,102 +251,95 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.list_winebridge.add(ComponentEntry(self.window, bridge, "winebridge", is_upgradable=True))
 
     def populate_dxvk_list(self):
-        for dxvk in self.manager.supported_dxvk.items():
-            if self.__check_release_candidate(dxvk):
-                continue
-            _entry = ComponentEntry(self.window, dxvk, "dxvk")
-            self.list_dxvk.add(_entry)
-            self.__registry.append(_entry)    
+        self.__populate_component_list("dxvk", self.manager.supported_dxvk, self.list_dxvk)
 
     def populate_vkd3d_list(self):
-        for vkd3d in self.manager.supported_vkd3d.items():
-            if self.__check_release_candidate(vkd3d):
-                continue
-            _entry = ComponentEntry(self.window, vkd3d, "vkd3d")
-            self.list_vkd3d.add(_entry)
-            self.__registry.append(_entry)    
+        self.__populate_component_list("vkd3d", self.manager.supported_vkd3d, self.list_vkd3d)
 
     def populate_nvapi_list(self):
-        for nvapi in self.manager.supported_nvapi.items():
-            if self.__check_release_candidate(nvapi):
-                continue
-            _entry = ComponentEntry(self.window, nvapi, "nvapi")
-            self.list_nvapi.add(_entry)
-            self.__registry.append(_entry)    
+        self.__populate_component_list("nvapi", self.manager.supported_nvapi, self.list_nvapi)
 
     def populate_latencyflex_list(self):
-        for latencyflex in self.manager.supported_latencyflex.items():
-            if self.__check_release_candidate(latencyflex):
+        self.__populate_component_list("latencyflex", self.manager.supported_latencyflex, self.list_latencyflex)
+
+    def __populate_runners_helper(self, runner_type, supported_runners_dict, identifiable_runners_struct):
+        offline_runners_list = self.manager.get_offline_components(runner_type)
+        for offline_runner in offline_runners_list:
+            _runner_name = offline_runner.lower()
+            for identifiable_runner in identifiable_runners_struct:
+                if _runner_name.startswith(identifiable_runner["prefix"]):
+                    identifiable_runner["offline_runners"].append(offline_runner)
+                    break
+
+        for supported_runner in supported_runners_dict.items():
+            _runner_name = supported_runner[0].lower()
+            if self.__check_release_candidate(supported_runner):
                 continue
-            _entry = ComponentEntry(self.window, latencyflex, "latencyflex")
-            self.list_latencyflex.add(_entry)
-            self.__registry.append(_entry)    
+
+            _entry = ComponentEntry(self.window, supported_runner, runner_type)
+            for identifiable_runner in identifiable_runners_struct:
+                if _runner_name.startswith(identifiable_runner["prefix"]):
+                    while identifiable_runner["offline_runners"] and \
+                            sort_by_version([identifiable_runner["offline_runners"][0], supported_runner[0]])[0] == identifiable_runner["offline_runners"][0]:
+                        offline_runner = [ identifiable_runner["offline_runners"][0], { "Installed": True} ]
+                        _offline_entry = ComponentEntry(self.window, offline_runner, runner_type)
+                        identifiable_runner["expander"].add_row(_offline_entry)
+                        identifiable_runner["count"] += 1
+                        identifiable_runner["offline_runners"].pop(0)
+                    identifiable_runner["expander"].add_row(_entry)
+                    identifiable_runner["count"] += 1
+                    break
+
+        # Don't forget left over offline runners
+        for identifiable_runner in identifiable_runners_struct:
+            while identifiable_runner["offline_runners"]:
+                offline_runner = [ identifiable_runner["offline_runners"][0], { "Installed": True} ]
+                _offline_entry = ComponentEntry(self.window, offline_runner, runner_type)
+                identifiable_runner["expander"].add_row(_offline_entry)
+                identifiable_runner["count"] += 1
+                identifiable_runner["offline_runners"].pop(0)
 
     def populate_runners_list(self):
-        exp_soda = ComponentExpander("Soda", _("Based on Valve's Wine, includes staging and Proton patches."))
-        exp_caffe = ComponentExpander("Caffe", _("Based on Wine upstream, includes staging and Proton patches."))
-        exp_wine_ge = ComponentExpander("GE Wine")
+        exp_soda = ComponentExpander("Soda", _("Based on Valve's Wine, includes Staging and Proton patches."))
+        exp_caffe = ComponentExpander("Caffe", _("Based on Wine upstream, includes Staging and Proton patches."))
+        exp_wine_ge = ComponentExpander("Wine GE", _("Based on the most recent bleeding-edge Valve's Proton Experimental Wine, "
+                                                     "includes Staging and custom patches. "
+                                                     "This is meant to be used with non-steam games outside of Steam."))
+        exp_kron4ek = ComponentExpander("Kron4ek", _("Based on Wine upstream, Staging, Staging-TkG and Proton patchset optionally available."))
         exp_lutris = ComponentExpander("Lutris")
-        exp_vaniglia = ComponentExpander("Vaniglia", _("Based on Wine upstream, includes staging patches."))
-        exp_proton = ComponentExpander("GE Proton", _("Based on Valve's Wine, includes staging, Proton and "
-                                                      "Steam-specific patches. Requires the Steam Runtime turned on."))
-        exp_other = ComponentExpander(_("Other"))
+        exp_vaniglia = ComponentExpander("Vaniglia", _("Based on Wine upstream, includes Staging patches."))
+        exp_proton_ge = ComponentExpander("Proton GE", _("Based on most recent bleeding-edge Valve's Proton Experimental, "
+                                                      "includes Staging and custom patches. "
+                                                      "Requires the Steam Runtime turned on."))
+        exp_other_wine = ComponentExpander(_("Other Wine runners"))
+        exp_other_proton = ComponentExpander(_("Other Proton runners"))
 
-        count = {"soda": 0, "caffe": 0, "wine-ge": 0, "lutris": 0, "vaniglia": 0, "proton": 0, "other": 0}
+        identifiable_wine_runners = [
+            { "prefix": "soda", "count": 0, "expander": exp_soda, "offline_runners": [] },
+            { "prefix": "caffe", "count": 0, "expander": exp_caffe, "offline_runners": [] },
+            { "prefix": "vaniglia", "count": 0, "expander": exp_vaniglia, "offline_runners": [] },
+            { "prefix": "wine-ge", "count": 0, "expander": exp_wine_ge, "offline_runners": [] },
+            { "prefix": "kron4ek", "count": 0, "expander": exp_kron4ek, "offline_runners": [] },
+            { "prefix": "lutris", "count": 0, "expander": exp_lutris, "offline_runners": [] },
+        ]
+        identifiable_proton_runners = [
+            { "prefix": "ge-proton", "count": 0, "expander": exp_proton_ge, "offline_runners": [] }
+        ]
+        other_wine_runners = [
+            { "prefix": "", "count": 0, "expander": exp_other_wine, "offline_runners": [] },
+        ]
+        other_proton_runners = [
+            { "prefix": "", "count": 0, "expander": exp_other_proton, "offline_runners": [] },
+        ]
 
-        for runner in self.manager.supported_wine_runners.items():
-            _runner_name = runner[0].lower()
-            if self.__check_release_candidate(runner):
-                continue
+        self.__populate_runners_helper("runner", \
+            self.manager.supported_wine_runners, identifiable_wine_runners + other_wine_runners)
+        self.__populate_runners_helper("runner:proton", \
+            self.manager.supported_proton_runners, identifiable_proton_runners + other_proton_runners)
 
-            _entry = ComponentEntry(self.window, runner, "runner")
-            if _runner_name.startswith("soda"):
-                exp_soda.add_row(_entry)
-                count["soda"] += 1
-            elif _runner_name.startswith("caffe"):
-                exp_caffe.add_row(_entry)
-                count["caffe"] += 1
-            elif _runner_name.startswith("wine-ge"):
-                exp_wine_ge.add_row(_entry)
-                count["wine-ge"] += 1
-            elif _runner_name.startswith("lutris"):
-                exp_lutris.add_row(_entry)
-                count["lutris"] += 1
-            elif _runner_name.startswith("vaniglia"):
-                exp_vaniglia.add_row(_entry)
-                count["vaniglia"] += 1
-            else:
-                exp_other.add_row(_entry)
-                count["other"] += 1
-
-        for runner in self.manager.supported_proton_runners.items():
-            if self.__check_release_candidate(runner):
-                continue
-
-            _entry = ComponentEntry(self.window, runner, "runner:proton")
-            exp_proton.add_row(_entry)
-            count["proton"] += 1
-
-        if count["soda"] > 0:
-            self.list_runners.add(exp_soda)
-            self.__registry.append(exp_soda)
-        if count["caffe"] > 0:
-            self.list_runners.add(exp_caffe)
-            self.__registry.append(exp_caffe)
-        if count["wine-ge"] > 0:
-            self.list_runners.add(exp_wine_ge)
-            self.__registry.append(exp_wine_ge)
-        if count["lutris"] > 0:
-            self.list_runners.add(exp_lutris)
-            self.__registry.append(exp_lutris)
-        if count["vaniglia"] > 0:
-            self.list_runners.add(exp_vaniglia)
-            self.__registry.append(exp_vaniglia)
-        if count["proton"] > 0:
-            self.list_runners.add(exp_proton)
-            self.__registry.append(exp_proton)
-        if count["other"] > 0:
-            self.list_runners.add(exp_other)
-            self.__registry.append(exp_other)
+        for runner in identifiable_wine_runners + identifiable_proton_runners + other_wine_runners + other_proton_runners:
+            if runner["count"] > 0:
+                self.list_runners.add(runner["expander"])
+                self.__registry.append(runner["expander"])
 
         self.installers_stack.set_visible_child_name("installers_list")

--- a/bottles/frontend/widgets/component.py
+++ b/bottles/frontend/widgets/component.py
@@ -61,6 +61,7 @@ class ComponentEntry(Adw.ActionRow):
 
         # populate widgets
         self.set_title(self.name)
+        self.set_can_focus(False)
 
         if component[1].get("Installed"):
             self.btn_browse.set_visible(True)
@@ -156,12 +157,15 @@ class ComponentEntry(Adw.ActionRow):
         self.box_download_status.set_visible(False)
         self.btn_browse.set_visible(True)
         self.btn_cancel.set_visible(False)
+        if not self.manager.component_manager.is_in_use(self.component_type, self.name):
+            self.btn_remove.set_visible(True)
 
     def set_uninstalled(self):
         self.btn_browse.set_visible(False)
         self.btn_err.set_visible(False)
         self.btn_download.set_visible(True)
-
+        if self.name in self.manager.get_offline_components(self.component_type, self.name):
+            self.set_visible(False)
 
 class ComponentExpander(Adw.ExpanderRow):
 


### PR DESCRIPTION
# Description

Reported fixes:

- Fixes #2956
- Preliminary work for #1244
- Use some feedback given on #2703: explains a bit more about the difference between `Proton GE` and `Wine GE`, which now use their correct name.

Unreported fixes:

- Fixes related to `Proton` being confused as a type where it's a name/prefix and vice versa.
- Fixes and optimizations related to runners/components ordering/sorting.
- Refactoring in `preferences.py` for less duplicate code.
- Other minor fixes

Notably, finally gives Kron4ek builds some love with a proper title and description. Those builds are updated regularly, integrated with the CI, and were responsible for 99% of the builds in `Other` (the 1% being old broken release which will be removed soon in the components repository), giving them a proper description makes sense.


https://github.com/bottlesdevs/Bottles/assets/85577251/0f18e068-a54e-405e-a848-c0e7a8030eba

I did not manage to make GNOME record the cursor, and the recording as a whole is potato quality because animation are disabled, but basically it shows that it is now possible to delete already installed runners/components that are not available to download. It includes manually installed one, and those installed normally but who are now deleted from the index.yml. I refer to them as "Offline components" in the code. The behavior is otherwise unchanged.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Tested on a local build.
