### PR TITLE
Remove the package maintainer section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,6 @@ Bottles is officially provided as [Flatpak](https://flathub.org/apps/details/com
 Read [here](https://docs.usebottles.com/getting-started/installation) how to
 install Bottles on your distribution.
 
-### Notices for package maintainers
-We are happy to see packaged Bottles but we ask you to respect some small rules:
-- The package must be `bottles`. In other distributions it is possible to use suffixes (e.g. `bottles-git` on Arch Linux for the git based package) while on others the RDNN format is required (e.g. `com.usebottles.bottles` on elementary OS and Flathub repository). All other nomenclatures are discouraged.
-- Do not package external files and do not make changes to the code, no hard script. Obviously with the exception of files essential for packaging.
-- Package version should follow the CalVer model (year.month.day) and the release cycle of the project. Bottles has 2 releases per month: one on 14th and one on 28th. When a hotfix is released, this will be appended to the release version (e.g. 2022.2.14-1). Bottles has a codename too which is not mandatory and currently only used by the Flatpak.
-
 ## Shortcuts
 | Shortcut |         Action          |
 |:--------:|:-----------------------:|


### PR DESCRIPTION
# Description
It's pretty clear that the Bottles developers don't want the package to be packaged at all for distributions. Having rules on your README gives the notion that you *are* actually in favour of people doing so. Removing this section will remove that doubt.