### PR TITLE
frontend: Use active instead of state property

### DIFF
--- a/bottles/frontend/windows/gamescope.py
+++ b/bottles/frontend/windows/gamescope.py
@@ -77,7 +77,7 @@ class GamescopeDialog(Adw.Window):
         self.spin_gamescope_height.set_value(parameters.gamescope_window_height)
         self.spin_fps_limit.set_value(parameters.gamescope_fps)
         self.spin_fps_limit_no_focus.set_value(parameters.gamescope_fps_no_focus)
-        self.switch_scaling.set_state(parameters.gamescope_scaling)
+        self.switch_scaling.set_active(parameters.gamescope_scaling)
         self.toggle_borderless.set_active(parameters.gamescope_borderless)
         self.toggle_fullscreen.set_active(parameters.gamescope_fullscreen)
 
@@ -91,7 +91,7 @@ class GamescopeDialog(Adw.Window):
                     "gamescope_window_height": self.spin_gamescope_height.get_value(),
                     "gamescope_fps": self.spin_fps_limit.get_value(),
                     "gamescope_fps_no_focus": self.spin_fps_limit_no_focus.get_value(),
-                    "gamescope_scaling": self.switch_scaling.get_state(),
+                    "gamescope_scaling": self.switch_scaling.get_active(),
                     "gamescope_borderless": self.toggle_borderless.get_active(),
                     "gamescope_fullscreen": self.toggle_fullscreen.get_active()}
 

--- a/bottles/frontend/windows/vkbasalt.py
+++ b/bottles/frontend/windows/vkbasalt.py
@@ -127,7 +127,7 @@ class VkBasaltDialog(Adw.Window):
         # If configuration file doesn't exist, set everything to default
         else:
             self.btn_save.set_sensitive(True)
-            self.switch_default.set_state(True)
+            self.switch_default.set_active(True)
             self.smaa_edge_detection = "luma"
             self.effects_widgets(False)
             self.group_effects.set_sensitive(False)
@@ -146,7 +146,7 @@ class VkBasaltDialog(Adw.Window):
         conf = ManagerUtils.get_bottle_path(self.config)
 
         # Apply default settings and close the dialog if default setting is enabled
-        if self.switch_default.get_state() is True:
+        if self.switch_default.get_active() is True:
             VkBasaltSettings.default = True
             VkBasaltSettings.output = False
             conf = os.path.join(conf, "vkBasalt.conf")

--- a/bottles/frontend/windows/vmtouch.py
+++ b/bottles/frontend/windows/vmtouch.py
@@ -46,10 +46,10 @@ class VmtouchDialog(Adw.Window):
         self.__update(config)
 
     def __update(self, config):
-        self.switch_cache_cwd.set_state(config.Parameters.vmtouch_cache_cwd)
+        self.switch_cache_cwd.set_active(config.Parameters.vmtouch_cache_cwd)
 
     def __idle_save(self, *_args):
-        settings = {"vmtouch_cache_cwd": self.switch_cache_cwd.get_state()}
+        settings = {"vmtouch_cache_cwd": self.switch_cache_cwd.get_active()}
 
         for setting in settings.keys():
             self.manager.update_config(


### PR DESCRIPTION
# Description
`state` should only be used when the switch is in a working state.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Locally