### PR TITLE
Create shortcuts in subdirectory

### DIFF
--- a/bottles/backend/globals.py
+++ b/bottles/backend/globals.py
@@ -33,7 +33,8 @@ class Paths:
     base = f"{xdg_data_home}/bottles"
 
     # User applications path
-    applications = f"{xdg_data_home}/applications/"
+    applications = f"{xdg_data_home}/applications"
+    applications_bottles = f"{applications}/bottles/"
 
     temp = f"{base}/temp"
     runtimes = f"{base}/runtimes"

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -1461,7 +1461,7 @@ class Manager(metaclass=Singleton):
             return False
 
         logging.info(f"Removing applications installed with the bottle…")
-        for inst in glob(f"{Paths.applications}/{config.Name}--*"):
+        for inst in glob(f"{Paths.applications}/{config.Name}--*") + glob(f"{Paths.applications_bottles}/{config.Name}--*"):
             os.remove(inst)
 
         logging.info(f"Removing library entries associated with this bottle…")

--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -206,6 +206,8 @@ class ManagerUtils:
                              use_xdp: bool = False) -> bool:
         if not os.path.exists(Paths.applications) and not use_xdp:
             return False
+        else:
+            os.makedirs(Paths.applications_bottles, exist_ok=True)
 
         cmd_legacy = "bottles"
         cmd_cli = "bottles-cli"
@@ -223,13 +225,13 @@ class ManagerUtils:
         if not use_xdp:
             file_name_template = "%s/%s--%s--%s.desktop"
             existing_files = glob(file_name_template % (
-                Paths.applications,
+                Paths.applications_bottles,
                 config.Name,
                 program.get("name"),
                 "*"
             ))
             desktop_file = file_name_template % (
-                Paths.applications,
+                Paths.applications_bottles,
                 config.Name,
                 program.get("name"),
                 datetime.now().timestamp()

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -17,6 +17,7 @@ finish-args:
   - --socket=pulseaudio
   - --device=all
   - --filesystem=xdg-download
+  - --filesystem=xdg-data/applications/bottles:create
   - --system-talk-name=org.freedesktop.UDisks2
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/


### PR DESCRIPTION
# Description
Fixes #2264 by creating and giving the rights to create shortcuts into a specific applications directory.
We no longer need to run `flatpak override com.usebottles.bottles --user --filesystem=xdg-data/applications`, the permission is given by default.
There is no security application since Bottles only has the right to create and remove shortcuts in its specific `~/.local/share/applications/bottles` directory.
`~/.local/share/applications` still need to exist.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- build `flatpak run org.flatpak.Builder --user --install --force-clean --ccache build-dir com.usebottles.bottles.yml`
- run ` flatpak run --env=DEBUG_MODE=true com.usebottles.bottles`
- create a bottle then a shortcut
- remove the shortcut and/or bottle

