### PR TITLE
configuration: Set python version to 3 in sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=bottlesdevs_Bottles_AYiLYqAz9CPJrZw6oxDU
 sonar.projectName=Bottles
 
 sonar.sources=.
+sonar.python.version=3
 
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-


### PR DESCRIPTION
Fix the following analysis warning:

`Your code is analyzed as compatible with python 2 and 3 by default. This will prevent the detection of issues specific to python 2 or python 3. You can get a more precise analysis by setting a python version in your configuration via the parameter "sonar.python.version"`