### PR TITLE
Don't load in GTK when using the CLI frontend

### DIFF
--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -23,9 +23,6 @@ import os
 import signal
 import sys
 import uuid
-import warnings
-
-import gi
 
 APP_VERSION = "@APP_VERSION@"
 pkgdatadir = "@pkgdatadir@"

--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -27,9 +27,6 @@ import warnings
 
 import gi
 
-warnings.filterwarnings("ignore")  # suppress GTK warnings
-gi.require_version('Gtk', '4.0')
-
 APP_VERSION = "@APP_VERSION@"
 pkgdatadir = "@pkgdatadir@"
 # noinspection DuplicatedCode


### PR DESCRIPTION
# Description
We shouldn't be loading in GTK when using the CLI frontend, at least not directly.

Fixes https://github.com/bottlesdevs/Bottles/issues/3041

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Not yet. Waiting for CI bundles.