### PR TITLE
fixed steam runtime path in WineCommand:get_cmd

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -508,7 +508,7 @@ class WineCommand:
                     Sniper is the default runtime used by Proton version >= 8.0
                     '''
                     _picked = _rs["sniper"]
-                if "soldier" in _rs.keys() and "soldier" in self.runner_runtime:
+                elif "soldier" in _rs.keys() and "soldier" in self.runner_runtime:
                     '''
                     Sniper is the default runtime used by Proton version >= 5.13 and < 8.0
                     '''


### PR DESCRIPTION
# Description
Currently the `get_cmd` function always ignores "sniper" if "scout" is presented while setting steam runtime, the second `if` should be `elif`.
[Bottles/bottles/backend/wine/winecommand.py: 506](https://github.com/bottlesdevs/Bottles/blob/c2c323706b620fe696d3f27ffa700a8e4d06fe10/bottles/backend/wine/winecommand.py#L506C12-L506C12)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Tested with flatpak build artifacts
