### PR TITLE
Improve bad connections handling

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -103,7 +103,7 @@ class Manager(metaclass=Singleton):
     supported_dependencies = {}
     supported_installers = {}
 
-    def __init__(self, g_settings: Any = None, is_cli: bool = False, **kwargs):
+    def __init__(self, g_settings: Any = None, check_connection: bool = True, is_cli: bool = False, **kwargs):
         super().__init__(**kwargs)
 
         times = {"start": time.time()}
@@ -113,8 +113,11 @@ class Manager(metaclass=Singleton):
         self.settings = g_settings or GSettingsStub
         self.utils_conn = ConnectionUtils(force_offline=self.is_cli)
         self.data_mgr = DataManager()
-        _offline = not self.utils_conn.check_connection()
-
+        _offline = True
+        
+        if check_connection:
+            _offline = not self.utils_conn.check_connection()
+        
         # validating user-defined Paths.bottles
         if user_bottles_path := self.data_mgr.get(UserDataKeys.CustomBottlesPath):
             if os.path.exists(user_bottles_path):
@@ -126,7 +129,11 @@ class Manager(metaclass=Singleton):
                 )
 
         # sub-managers
-        self.repository_manager = RepositoryManager()
+        self.repository_manager = RepositoryManager(get_index= not _offline)
+        if self.repository_manager.aborted_connections > 0:
+            self.utils_conn.status = False
+            _offline = True
+        
         times["RepositoryManager"] = time.time()
         self.versioning_manager = VersioningManager(self)
         times["VersioningManager"] = time.time()
@@ -137,6 +144,7 @@ class Manager(metaclass=Singleton):
         times["ImportManager"] = time.time()
         self.steam_manager = SteamManager()
         times["SteamManager"] = time.time()
+
 
         if not self.is_cli:
             times.update(self.checks(install_latest=False, first_run=True).data)

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -111,7 +111,7 @@ class Manager(metaclass=Singleton):
         # common variables
         self.is_cli = is_cli
         self.settings = g_settings or GSettingsStub
-        self.utils_conn = ConnectionUtils(force_offline=self.is_cli)
+        self.utils_conn = ConnectionUtils(force_offline=self.is_cli or self.settings.get_boolean("force-offline"))
         self.data_mgr = DataManager()
         _offline = True
         

--- a/bottles/backend/managers/repository.py
+++ b/bottles/backend/managers/repository.py
@@ -50,9 +50,14 @@ class RepositoryManager:
         }
     }
 
-    def __init__(self):
+    def __init__(self, get_index=True):
+        self.do_get_index = True
+        self.aborted_connections = 0
+        SignalManager.connect(Signals.ForceStopNetworking, self.__stop_index)
+        
         self.__check_locals()
-        self.__get_index()
+        if get_index:
+            self.__get_index()
 
     def get_repo(self, name: str, offline: bool = False):
         if name in self.__repositories:
@@ -88,6 +93,18 @@ class RepositoryManager:
             else:
                 logging.error(f"Local {repo} path does not exist: {_path}")
 
+
+    def __curl_progress(self, _download_t, _download_d, _upload_t, _upload_d):
+        if self.do_get_index:
+            return pycurl.E_OK
+        else:
+            self.aborted_connections+=1
+            return pycurl.E_ABORTED_BY_CALLBACK
+    
+    def __stop_index(self, res: Result):
+        if res.status:
+            self.do_get_index = False
+        
     def __get_index(self):
         total = len(self.__repositories)
 
@@ -104,6 +121,8 @@ class RepositoryManager:
                     c.setopt(c.NOBODY, True)
                     c.setopt(c.FOLLOWLOCATION, True)
                     c.setopt(c.TIMEOUT, 10)
+                    c.setopt(c.NOPROGRESS, False)
+                    c.setopt(c.XFERINFOFUNCTION, self.__curl_progress) 
 
                     try:
                         c.perform()
@@ -127,3 +146,5 @@ class RepositoryManager:
 
         for t in threads:
             t.join()
+
+        self.do_get_index = True

--- a/bottles/backend/state.py
+++ b/bottles/backend/state.py
@@ -28,6 +28,7 @@ class Signals(Enum):
     """Signals backend support"""
     ManagerLocalBottlesLoaded = "Manager.local_bottles_loaded"  # no extra data
 
+    ForceStopNetworking = "LoadingView.stop_networking" # status(bool): Force Stop network operations
     RepositoryFetched = "RepositoryManager.repo_fetched"  # status: fetch success or not, data(int): total repositories
     NetworkStatusChanged = "ConnectionUtils.status_changed"  # status(bool): network ready or not
 

--- a/bottles/frontend/ui/loading.blp
+++ b/bottles/frontend/ui/loading.blp
@@ -15,6 +15,17 @@ template LoadingView : .AdwBin {
         vexpand: true;
       }
 
+      Button btn_go_offline {
+        valign: center;
+        halign: center;
+        label: _("Skip and go offline");
+
+        styles [
+          "destructive-action",
+          "pill",
+        ]
+      }
+
       Label label_fetched {
         styles [
           "dim-label",

--- a/bottles/frontend/ui/loading.blp
+++ b/bottles/frontend/ui/loading.blp
@@ -16,9 +16,10 @@ template LoadingView : .AdwBin {
       }
 
       Button btn_go_offline {
+        margin-bottom: 20;
         valign: center;
         halign: center;
-        label: _("Skip and go offline");
+        label: _("Continue Offline");
 
         styles [
           "destructive-action",

--- a/bottles/frontend/ui/preferences.blp
+++ b/bottles/frontend/ui/preferences.blp
@@ -139,6 +139,16 @@ template PreferencesWindow : Adw.PreferencesWindow {
       }
 
       Adw.ActionRow {
+        title: _("Force Offline Mode");
+        subtitle: _("Force disable any network activity even with available network connection.");
+        activatable-widget: switch_force_offline;
+
+        Switch switch_force_offline {
+          valign: center;
+        }
+      }
+
+      Adw.ActionRow {
         title: _("Bottles Directory");
         subtitle: _("Directory that contains the data of your Bottles.");
         activatable-widget: btn_bottles_path;

--- a/bottles/frontend/views/loading.py
+++ b/bottles/frontend/views/loading.py
@@ -20,6 +20,7 @@ from gettext import gettext as _
 from gi.repository import Gtk, Adw
 
 from bottles.backend.models.result import Result
+from bottles.backend.state import SignalManager, Signals
 from bottles.frontend.utils.gtk import GtkUtils
 
 
@@ -31,8 +32,12 @@ class LoadingView(Adw.Bin):
     # region widgets
     label_fetched = Gtk.Template.Child()
     label_downloading = Gtk.Template.Child()
-
+    btn_go_offline = Gtk.Template.Child()
     # endregion
+    
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.btn_go_offline.connect("clicked", self.go_offline)
 
     @GtkUtils.run_in_main_loop
     def add_fetched(self, res: Result):
@@ -40,3 +45,6 @@ class LoadingView(Adw.Bin):
         self.__fetched += 1
         self.label_downloading.set_text(_("Downloading ~{0} of packages…").format("20kb"))
         self.label_fetched.set_text(_("Fetched {0} of {1} packages").format(self.__fetched, total))
+
+    def go_offline(self, _widget):
+        SignalManager.send(Signals.ForceStopNetworking, Result(status=True))

--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -43,6 +43,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
     row_theme = Gtk.Template.Child()
     switch_theme = Gtk.Template.Child()
     switch_notifications = Gtk.Template.Child()
+    switch_force_offline = Gtk.Template.Child()
     switch_temp = Gtk.Template.Child()
     switch_release_candidate = Gtk.Template.Child()
     switch_steam = Gtk.Template.Child()
@@ -91,6 +92,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         # bind widgets
         self.settings.bind("dark-theme", self.switch_theme, "active", Gio.SettingsBindFlags.DEFAULT)
         self.settings.bind("notifications", self.switch_notifications, "active", Gio.SettingsBindFlags.DEFAULT)
+        self.settings.bind("force-offline", self.switch_force_offline, "active", Gio.SettingsBindFlags.DEFAULT)
         self.settings.bind("temp", self.switch_temp, "active", Gio.SettingsBindFlags.DEFAULT)
         # Connect RC signal to another func
         self.settings.bind("release-candidate", self.switch_release_candidate, "active", Gio.SettingsBindFlags.DEFAULT)

--- a/bottles/frontend/windows/main_window.py
+++ b/bottles/frontend/windows/main_window.py
@@ -81,7 +81,7 @@ class MainWindow(Adw.ApplicationWindow):
         super().__init__(**kwargs, default_width=width, default_height=height)
 
         self.disable_onboard = False
-        self.utils_conn = ConnectionUtils()
+        self.utils_conn = ConnectionUtils(force_offline=self.settings.get_boolean("force-offline"))
         self.manager = None
         self.arg_bottle = arg_bottle
         self.app = kwargs.get("application")

--- a/bottles/frontend/windows/main_window.py
+++ b/bottles/frontend/windows/main_window.py
@@ -226,7 +226,9 @@ class MainWindow(Adw.ApplicationWindow):
         def get_manager():
             if self.utils_conn.check_connection():
                 SignalManager.connect(Signals.RepositoryFetched, self.page_loading.add_fetched)
-            mng = Manager(g_settings=self.settings)
+            
+            # do not redo connection if aborted connection 
+            mng = Manager(g_settings=self.settings, check_connection=self.utils_conn.aborted_connections == 0) 
             return mng
 
         self.check_core_deps()

--- a/data/com.usebottles.bottles.gschema.xml
+++ b/data/com.usebottles.bottles.gschema.xml
@@ -11,6 +11,11 @@
       <summary>Dark theme</summary>
       <description>Force the use of dark theme.</description>
     </key>
+    <key type="b" name="force-offline">
+      <default>false</default>
+      <summary>Force Offline</summary>
+      <description>"Force disable any network activity even with available network connection."</description>
+    </key>
     <key type="b" name="update-date">
       <default>false</default>
       <summary>Toggle update date in list</summary>


### PR DESCRIPTION
# Description
Adds a button to skip startup connections and go to offline mode to help with Bottles startup on slow and unstable connections.
Adds "Force Offline Mode" setting in preferences/General/Advanced as option to immediately start Bottles on slow and unstable connections.

Fixes #2954 problem for me

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- `sudo wondershaper $NET_INTERFACE 100 100` to limit your connection speed
- run Bottles and test.

Skip button correctly handles skipping 2 stage connection pings and downloading of repositories indexes
