### PR TITLE
Exclude VFIO passthrough GPUs from detection. Fixes #940

### DIFF
--- a/bottles/backend/utils/display.py
+++ b/bottles/backend/utils/display.py
@@ -29,22 +29,6 @@ class DisplayUtils:
         return False
 
     @staticmethod
-    def check_nvidia_device():
-        """Check if there is an nvidia device connected"""
-        _query = "NVIDIA Corporation".lower()
-        _proc = subprocess.Popen(
-            "lspci | grep 'VGA'",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
-        ).communicate()[0].decode("utf-8").lower()
-
-        if _query in _proc:
-            return True
-        return False
-
-    @staticmethod
     def display_server_type():
         """Return the display server type"""
         return os.environ.get("XDG_SESSION_TYPE", "x11").lower()
-

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -168,7 +168,6 @@ class WineCommand:
 
         dll_overrides = []
         gpu = GPUUtils().get_gpu()
-        is_nvidia = DisplayUtils.check_nvidia_device()
         ld = []
 
         # Bottle environment variables
@@ -415,7 +414,7 @@ class WineCommand:
 
         if SteamUtils.is_proton(runner):
             '''
-            If the runner is Proton, set the path to /dist or /files 
+            If the runner is Proton, set the path to /dist or /files
             based on check if files exists.
             Additionally, check for its corresponding runtime.
             '''


### PR DESCRIPTION
# Description
GPUs designated for virtual machine passthrough with the `vfio-pci` driver are not usable by the host. They should be excluded from detection to prevent Bottles from attempting to launch programs with an unusable GPU as in #940.

This PR reworks the GPU detection logic to parse individual fields from the output of `lspci -mmkv` and exclude any GPUs which have the driver field set to `vfio-pci`.

I also noticed that the `is_nouveau` check was silently broken due to `lsmod` not existing in the Flatpak environment. It has been modified to use the same driver check used for `vfio-pci`, so this has been fixed as well.

Additionally, I have added `Display controller` as one of the PCI device classes recognized as GPUs. Previously, only `VGA compatible controller` and `3D controller` classes would be recognized as GPUs, which may be contributing to [this](https://github.com/bottlesdevs/Bottles/issues/2000#issuecomment-1230617083) issue.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
On a system with two GPUs from different vendors (iGPU should be fine):
1. Confirm that `health-check` shows both vendors.
2. Bind `vfio-pci` to one of the GPUs with these [instructions](https://wiki.archlinux.org/title/PCI_passthrough_via_OVMF#Binding_vfio-pci_via_device_ID).
3. Confirm that `vfio-pci` is correctly bound to the device with `lspci -k`.
4. Confirm that `health-check` no longer shows the vendor of the GPU bound with `vfio-pci`.
