### PR TITLE
Allow special characters in bottle names

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import hashlib
 import contextlib
 import fnmatch
 import os
@@ -1025,8 +1026,8 @@ class Manager(metaclass=Singleton):
             '''
             config.NVAPI = self.nvapi_available[0]
 
-        # create the bottle path
-        bottle_path = os.path.join(Paths.bottles, config.Name)
+        # create the bottle path; use MD5 hash as path
+        bottle_path = os.path.join(Paths.bottles, hashlib.md5(config.Name.encode()).hexdigest())
 
         if not os.path.exists(bottle_path):
             '''
@@ -1167,7 +1168,8 @@ class Manager(metaclass=Singleton):
 
         # define bottle parameters
         bottle_name = name
-        bottle_name_path = bottle_name.replace(" ", "-")
+        # bottle_name_path = bottle_name.replace(" ", "-")
+        bottle_name_path = hashlib.md5(bottle_name.encode()).hexdigest()
         bottle_name_path = pathvalidate.sanitize_filename(bottle_name_path, platform="universal")
 
         # get bottle path

--- a/bottles/frontend/ui/details-bottle.blp
+++ b/bottles/frontend/ui/details-bottle.blp
@@ -163,6 +163,7 @@ template DetailsBottle : .AdwPreferencesPage {
         max-width-chars: 30;
         label: _("My bottle");
         wrap-mode: word_char;
+      	use-markup: false;
 
         styles [
           "title-1",

--- a/bottles/frontend/ui/list-entry.blp
+++ b/bottles/frontend/ui/list-entry.blp
@@ -3,6 +3,7 @@ using Gtk 4.0;
 template BottleViewEntry : .AdwActionRow {
   activatable: true;
   title: _("Bottle name");
+  use-markup: false;
 
   Box list_labels {
     spacing: 1;

--- a/bottles/frontend/ui/new.blp
+++ b/bottles/frontend/ui/new.blp
@@ -50,6 +50,7 @@ template NewView : .AdwWindow {
 
           .AdwPreferencesGroup {
             .AdwEntryRow entry_name {
+	            use-markup: false;
               title: _("Name");
 
               [suffix]


### PR DESCRIPTION
- disabled Pango markup for bottle names in dialogs
- use bottle names md5 hash for directory creation

# Description
Currently, bottle names in the UI are treated as Pango markup. This causes problems when using special characters like '<'. To fix this, the md5 hash of a bottles name is used to create the directory. This shouldn't be a problem as the bottles name for UI is taken from bottles.yml. So, the user will be able to use those characters now. One downside is that the directory for a bottle is not named like it is shown in the UI. On the other hand, Bottles is a manager for bottles and as a user it shouldn't require me to work manually within the filesystem.

These changes does not affect already existing bottles, as far as I could test it. It just works for newly created ones. Well, this is a kind of brute force attempt and might be tested by others as I'm sure I didn't seen all possible dialogs using a bottles name.

Fixes #(issue)
https://github.com/bottlesdevs/Bottles/issues/3106

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.

- Open 'New Bottle' dialog
- Name the bottle 'This is a nasty < Test with {}[]\/'
- Click create.
