### PR TITLE
appdata: Correct translation type file name

### DIFF
--- a/data/com.usebottles.bottles.metainfo.xml.in
+++ b/data/com.usebottles.bottles.metainfo.xml.in
@@ -46,7 +46,7 @@
       <image>https://raw.githubusercontent.com/bottlesdevs/Bottles/main/data/appstream/5.png</image>
     </screenshot>
   </screenshots>
-  <translation type="gettext">com.usebottles.bottles</translation>
+  <translation type="gettext">bottles</translation>
   <content_rating type="oars-1.1"/>
   <url type="homepage">https://usebottles.com</url>
   <url type="bugtracker">https://github.com/bottlesdevs/Bottles/issues</url>


### PR DESCRIPTION
# Description

Use the real file name for translation entry in appdata file.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-translation

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
flatpak run --devel --command=sh com.usebottles.bottles
ls /app/share/locale/tr/LC_MESSAGES/
```