### PR TITLE
Fail on unsuccessful cab_extract download

### DIFF
--- a/bottles/backend/managers/dependency.py
+++ b/bottles/backend/managers/dependency.py
@@ -403,6 +403,8 @@ class DependencyManager:
                         destination=dest
                 ):
                     return False
+            else:
+                return False
 
         elif step["url"].startswith("temp/"):
             path = step["url"]


### PR DESCRIPTION
# Description
The ```__step_cab_extract``` method currently returns ```True``` even if the download fails. This leads to Bottles showing a dependency as installed when it isn't. This fix adds the needed return logic for such cases.

Fixes #3145

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
Minimal change -> not tested.
