### PR TITLE
Add "all files" to the "add shortcuts" file picker

### DIFF
--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -277,6 +277,7 @@ class BottleView(Adw.PreferencesPage):
         )
 
         add_executable_filters(dialog)
+        add_all_filters(dialog)
         dialog.set_modal(True)
         dialog.connect("response", set_path)
         dialog.show()


### PR DESCRIPTION
# Description
Fix for #3199 that adds a "all files" option to the "add shortcuts" file picker as a workaround for a gnome bug

Fixes #3199

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Open the "add shortcuts" file picker
