### PR TITLE
Gamescope: flag changes

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -560,7 +560,7 @@ class WineCommand:
             if params.gamescope_borderless:
                 gamescope_cmd.append("-b")
             if params.gamescope_scaling:
-                gamescope_cmd.append("-n")
+                gamescope_cmd.append("-S integer")
             if params.fsr:
                 gamescope_cmd.append("-F fsr")
                 # Upscaling sharpness is from 0 to 20. There are 5 FSR upscaling levels,

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -562,7 +562,7 @@ class WineCommand:
             if params.gamescope_scaling:
                 gamescope_cmd.append("-n")
             if params.fsr:
-                gamescope_cmd.append("-U")
+                gamescope_cmd.append("-F fsr")
                 # Upscaling sharpness is from 0 to 20. There are 5 FSR upscaling levels,
                 # so multiply by 4 to reach 20
                 gamescope_cmd.append(f"--fsr-sharpness {params.fsr_sharpening_strength * 4}")


### PR DESCRIPTION
# Description
Gamescope recently changed a few flags.
Notably FSR and integer scaling(at least that is what I assume the -n flag meant according to the bottles UI)

https://github.com/ValveSoftware/gamescope/commit/7a1fe2def38e9c3ed4d12adb9f1bb81b6f9dcbe5

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Tried running software with gamescope and integer scaling turned on in the settings
- [ ] Tried running software with gamescope and FSR


# Additional info
Terminal outputs of the issue:
```
gamescope-brokey: invalid option -- 'U'
See --help for a list of options.
```

```
gamescope-brokey: invalid option -- 'n'
See --help for a list of options.
```