### PR TITLE
Run_script echo output to console, and capture errors from script

### DIFF
--- a/bottles/backend/managers/installer.py
+++ b/bottles/backend/managers/installer.py
@@ -249,13 +249,18 @@ class InstallerManager:
                 return False
 
         logging.info(f"Executing installer script…")
-        subprocess.Popen(
+        result = subprocess.run(
             f"bash -c '{script}'",
             shell=True,
             cwd=ManagerUtils.get_bottle_path(config),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        ).communicate()
+            capture_output=True,
+        )
+        logging.info(f"Output: \n{result.stdout.decode()}\n")
+        if result.returncode != 0:
+            # an error happened!
+            err_msg = "Status: FAIL \nError: %s\nCode: %s" % (result.stderr.decode(), result.returncode)
+            logging.error(err_msg)
+            # raise Exception(err_msg) #Raise blocking error
         logging.info(f"Finished executing installer script.")
 
     @staticmethod


### PR DESCRIPTION
# Description
run_script steps are now run with output echoed into the terminal, allowing the user to see the status of a script.
Errors raised from the script are now have handling.

Any Raised errors other than 0, will create an error message but continue with the rest of the manifest (non blocking)
However it could be advisable to gracefully terminate the application installation with a GUI message?

Fixes #3275

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [x] Run any application manifest with a "run_script" step. The output will be echoed into the terminal. 
