### PR TITLE
manifest: Update GNOME runtime to 46 and fix automation

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.x'
           cache: 'pip'
 
-      - run: pip install pur req2flatpak pyyaml
+      - run: pip install setuptools pur req2flatpak pyyaml
 
       - name: Update requirements
         working-directory: "bottles-repository"

--- a/com.usebottles.bottles.pypi-deps.yaml
+++ b/com.usebottles.bottles.pypi-deps.yaml
@@ -39,8 +39,8 @@ sources:
   url: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
   sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
 - type: file
-  url: https://files.pythonhosted.org/packages/d1/57/d18e9d6e627a3bf9a6f3d98f300da10a0a414dcc2dbfe4c41f90fc6c3e44/orjson-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 414e5293b82373606acf0d66313aecb52d9c8c2404b1900683eb32c3d042dbd7
+  url: https://files.pythonhosted.org/packages/40/c8/bc8e7d389efcbb1e55cc7ddab05233ec66d4e764ada2dda19891cdb5b4de/orjson-3.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: e852a83d7803d3406135fb7a57cf0c1e4a3e73bac80ec621bd32f01c653849c5
   only-arches:
   - x86_64
 - type: file

--- a/com.usebottles.bottles.pypi-deps.yaml
+++ b/com.usebottles.bottles.pypi-deps.yaml
@@ -11,59 +11,61 @@ sources:
   url: https://files.pythonhosted.org/packages/f7/2f/cc09899755f94b36e7f570b9f9ca19a5fdff536e2614fd3ac1c28bb777f6/FVS-0.3.4.tar.gz
   sha256: c987741f37706ea07d91ec498c145162676ca16b59b5c8c2351cf464954ce422
 - type: file
-  url: https://files.pythonhosted.org/packages/1a/b5/228c1cdcfe138f1a8e01ab1b54284c8b83735476cb22b6ba251656ed13ad/Markdown-3.4.4-py3-none-any.whl
-  sha256: a4c1b65c0957b4bd9e7d86ddc7b3c9868fb9670660f6f99f6d1bca8954d5a941
+  url: https://files.pythonhosted.org/packages/fc/b3/0c0c994fe49cd661084f8d5dc06562af53818cc0abefaca35bdc894577c3/Markdown-3.6-py3-none-any.whl
+  sha256: 48f276f4d8cfb8ce6527c8f79e2ee29708508bf4d40aa410fbc3b4ee832c850f
 - type: file
-  url: https://files.pythonhosted.org/packages/ac/4a/f24ddf1d20cc4b56affc7921e29928559a06c922eb60077448392792b914/PyGObject-3.46.0.tar.gz
-  sha256: 481437b05af0a66b7c366ea052710eb3aacbb979d22d30b797f7ec29347ab1e6
+  url: https://files.pythonhosted.org/packages/a9/73/ff037ab99c40522ed53c759baa0e3969d03933d3650f02e50ee0cb639666/pygobject-3.48.1.tar.gz
+  sha256: 2c4cd7c805ee9e727904172423a7519338017fd7e122b62218ac211627436875
 - type: file
   url: https://files.pythonhosted.org/packages/7b/5e/efd033ab7199a0b2044dab3b9f7a4f6670e6a52c089de572e928d2873b06/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673
   only-arches:
   - x86_64
 - type: file
-  url: https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl
-  sha256: 92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
+  url: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
+  sha256: dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
 - type: file
   url: https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl
   sha256: e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970
 - type: file
-  url: https://files.pythonhosted.org/packages/ff/b6/9222090f396f33cd58aa5b08b9bbf8871416b746a0c7b412a41a973674a5/charset_normalizer-3.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: f0d1e3732768fecb052d90d62b220af62ead5748ac51ef61e7b32c266cac9293
+  url: https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8
   only-arches:
   - x86_64
 - type: file
   url: https://files.pythonhosted.org/packages/93/3f/da0ed756fb207a8685f5ff452569ffc287297cf24d6d7e7d9a0354a896ba/icoextract-0.1.4.tar.gz
   sha256: c741845743d46e4033a1426002aba9f5b1ddee262db46cb321935da3c2ac172a
 - type: file
-  url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
-  sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+  url: https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl
+  sha256: c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
 - type: file
-  url: https://files.pythonhosted.org/packages/0b/e1/2c6e894de23c1bb5c76eff087c99fc3c7ce8f317a793f8c80767f4225733/orjson-3.9.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: e5205ec0dfab1887dd383597012199f5175035e782cdb013c542187d280ca443
+  url: https://files.pythonhosted.org/packages/37/ee/22f74928f9df8d3d5a17fa61c7c5456ad854029b9390548bd28e9fcf79f2/orjson-3.9.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 12365576039b1a5a47df01aadb353b68223da413e2e7f98c02403061aad34bde
   only-arches:
   - x86_64
 - type: file
   url: https://files.pythonhosted.org/packages/0c/ab/673cce13ab635fd755d206b18c0a371ef6e28ddbe25fadba9ae6c59f22a5/pathvalidate-3.2.0-py3-none-any.whl
   sha256: cc593caa6299b22b37f228148257997e2fa850eea2daf7e4cc9205cef6908dee
 - type: file
-  url: https://files.pythonhosted.org/packages/43/94/52243ddff508780dd2d8110964320ab4851134a55ab102285b46e740f76a/patool-1.12-py2.py3-none-any.whl
-  sha256: 3f642549c9a78f5b8bef1af92df385b521d360520d1f34e4dba3fd1dee2a21bc
+  url: https://files.pythonhosted.org/packages/e6/64/e9dd887985305d4cc88b09bcaaaafe5053197e5ebbeba62473f8c3cf6d80/patool-2.2.0-py2.py3-none-any.whl
+  sha256: 21db6cc2fcd77acd37768258d1ad5aa3df0f676331fd80dfb1eb628626bc9155
 - type: file
   url: https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl
   sha256: da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6
 - type: file
-  url: https://files.pythonhosted.org/packages/db/f1/45f288a45215e12dea5a107a2e686e33902701d5485219437b5d64d1080a/pycairo-1.25.0.tar.gz
-  sha256: 37842b9bfa6339c45a5025f752e1d78d5840b1a0f82303bdd5610846ad8b5c4f
+  url: https://files.pythonhosted.org/packages/1c/41/91955188e97c7b85fbaac6bbf4e33de028899e0aa31bdce99b1afe2eeb17/pycairo-1.26.0.tar.gz
+  sha256: 2dddd0a874fbddb21e14acd9b955881ee1dc6e63b9c549a192d613a907f9cbeb
 - type: file
-  url: https://files.pythonhosted.org/packages/a8/af/24d3acfa76b867dbd8f1166853c18eefc890fc5da03a48672b38ea77ddae/pycurl-7.45.2.tar.gz
-  sha256: 5730590be0271364a5bddd9e245c9cc0fb710c4cbacbdd95264a3122d23224ca
+  url: https://files.pythonhosted.org/packages/d1/64/82fc5c3584fa11462732ddbf76cf23215d725bb224910517099f53017a3b/pycurl-7.45.3-cp311-cp311-manylinux_2_28_x86_64.whl
+  sha256: 1e0d32d6ed3a7ba13dbbd3a6fb50ca76c40c70e6bc6fe347f90677478d3422c7
+  only-arches:
+  - x86_64
 - type: file
   url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl
   sha256: 58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
 - type: file
-  url: https://files.pythonhosted.org/packages/26/40/9957270221b6d3e9a3b92fdfba80dd5c9661ff45a664b47edd5d00f707f5/urllib3-2.0.6-py3-none-any.whl
-  sha256: 7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2
+  url: https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl
+  sha256: 450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
 - type: file
-  url: https://files.pythonhosted.org/packages/b8/8b/31273bf66016be6ad22bb7345c37ff350276cfd46e389a0c2ac5da9d9073/wheel-0.41.2-py3-none-any.whl
-  sha256: 75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8
+  url: https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl
+  sha256: 55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81

--- a/com.usebottles.bottles.pypi-deps.yaml
+++ b/com.usebottles.bottles.pypi-deps.yaml
@@ -14,8 +14,8 @@ sources:
   url: https://files.pythonhosted.org/packages/fc/b3/0c0c994fe49cd661084f8d5dc06562af53818cc0abefaca35bdc894577c3/Markdown-3.6-py3-none-any.whl
   sha256: 48f276f4d8cfb8ce6527c8f79e2ee29708508bf4d40aa410fbc3b4ee832c850f
 - type: file
-  url: https://files.pythonhosted.org/packages/a9/73/ff037ab99c40522ed53c759baa0e3969d03933d3650f02e50ee0cb639666/pygobject-3.48.1.tar.gz
-  sha256: 2c4cd7c805ee9e727904172423a7519338017fd7e122b62218ac211627436875
+  url: https://files.pythonhosted.org/packages/f9/9e/6bab1ed3bd878f0912d9a0600c21f3d88bab0e8a8d4c3ce50f5cf336faaf/pygobject-3.48.2.tar.gz
+  sha256: c3c0a7afbe5b2c1c64dc0530109b4dd571085153dbedfbccb8ec7c5ad233f977
 - type: file
   url: https://files.pythonhosted.org/packages/7b/5e/efd033ab7199a0b2044dab3b9f7a4f6670e6a52c089de572e928d2873b06/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673
@@ -36,11 +36,11 @@ sources:
   url: https://files.pythonhosted.org/packages/93/3f/da0ed756fb207a8685f5ff452569ffc287297cf24d6d7e7d9a0354a896ba/icoextract-0.1.4.tar.gz
   sha256: c741845743d46e4033a1426002aba9f5b1ddee262db46cb321935da3c2ac172a
 - type: file
-  url: https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl
-  sha256: c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+  url: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
+  sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
 - type: file
-  url: https://files.pythonhosted.org/packages/37/ee/22f74928f9df8d3d5a17fa61c7c5456ad854029b9390548bd28e9fcf79f2/orjson-3.9.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 12365576039b1a5a47df01aadb353b68223da413e2e7f98c02403061aad34bde
+  url: https://files.pythonhosted.org/packages/d1/57/d18e9d6e627a3bf9a6f3d98f300da10a0a414dcc2dbfe4c41f90fc6c3e44/orjson-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 414e5293b82373606acf0d66313aecb52d9c8c2404b1900683eb32c3d042dbd7
   only-arches:
   - x86_64
 - type: file

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -3,7 +3,7 @@ sdk: org.gnome.Sdk
 runtime: org.gnome.Platform
 base: org.winehq.Wine
 base-version: stable-23.08
-runtime-version: &runtime-version '45'
+runtime-version: &runtime-version '46'
 command: bottles
 
 finish-args:

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -187,8 +187,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ImageMagick/ImageMagick
-        tag: 7.1.1-29
-        commit: 0deac72ed480ac2ec8e9d766c15ddb3bca055952
+        tag: 7.1.1-30
+        commit: dd459b01fd3dba99a5190aaca458c628293de0a3
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+-[\d]+)$
@@ -213,8 +213,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/jwestman/blueprint-compiler
-        tag: v0.10.0
-        commit: 2a39a16391122af2f3d812e478c1c1398c98b972
+        tag: v0.12.0
+        commit: 66b43c36cf1017c878762007373964a096b3d2a5
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -187,8 +187,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ImageMagick/ImageMagick
-        tag: 7.1.1-30
-        commit: dd459b01fd3dba99a5190aaca458c628293de0a3
+        tag: 7.1.1-31
+        commit: 2f6d2de838390a054af74822e80d74b7799633cb
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+-[\d]+)$
@@ -257,8 +257,8 @@ modules:
         sources:
           - type: git
             url: https://gitlab.gnome.org/GNOME/vte
-            tag: 0.76.0
-            commit: 3c29bfef30c34afec4982ba5ec37f944cfacbba2
+            tag: 0.76.1
+            commit: 2b413dab1dcc6a5d4ff200ad0703240a81c82d06
             x-checker-data:
               type: git
               tag-pattern: ^([\d.]+)$

--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -187,8 +187,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ImageMagick/ImageMagick
-        tag: 7.1.1-23
-        commit: 54b13e91d262b1083e27fc8c02532c89d3ff649c
+        tag: 7.1.1-29
+        commit: 0deac72ed480ac2ec8e9d766c15ddb3bca055952
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+-[\d]+)$
@@ -257,8 +257,8 @@ modules:
         sources:
           - type: git
             url: https://gitlab.gnome.org/GNOME/vte
-            tag: 0.74.2
-            commit: 3f66edbf598129bafde3baa91ccfb345056418c3
+            tag: 0.76.0
+            commit: 3c29bfef30c34afec4982ba5ec37f944cfacbba2
             x-checker-data:
               type: git
               tag-pattern: ^([\d.]+)$

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 # Updated using pur -r requirements.txt
-pytest==8.1.1
+pytest==8.1.2
 requirements-parser==0.9.0
-mypy==1.9.0
+mypy==1.10.0
 types_Markdown
 types-PyYAML
 types-Pygments

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 # Updated using pur -r requirements.txt
 pytest==8.1.1
-requirements-parser==0.5.0
+requirements-parser==0.9.0
 mypy==1.9.0
 types_Markdown
 types-PyYAML

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 # Updated using pur -r requirements.txt
-pytest==7.4.3
+pytest==8.1.1
 requirements-parser==0.5.0
-mypy==1.8.0
+mypy==1.9.0
 types_Markdown
 types-PyYAML
 types-Pygments

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ icoextract==0.1.4
 patool==2.2.0
 pathvalidate==3.2.0
 FVS==0.3.4
-orjson==3.9.15
+orjson==3.10.0
 pycairo==1.26.0
-PyGObject==3.48.1
+PyGObject==3.48.2
 charset-normalizer==3.3.2
-idna==3.6
+idna==3.7
 urllib3==2.2.1
 certifi==2024.2.2
 pefile==2023.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ icoextract==0.1.4
 patool==2.2.0
 pathvalidate==3.2.0
 FVS==0.3.4
-orjson==3.10.0
+orjson==3.10.1
 pycairo==1.26.0
 PyGObject==3.48.2
 charset-normalizer==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 # Updated using pur -r requirements.txt
-wheel==0.42.0
+wheel==0.43.0
 PyYAML==6.0.1
-pycurl==7.45.2
+pycurl==7.45.3
 chardet==5.2.0
 requests[use_chardet_on_py3]==2.31.0
-Markdown==3.5.1
+Markdown==3.6
 icoextract==0.1.4
-patool==2.0.0
+patool==2.2.0
 pathvalidate==3.2.0
 FVS==0.3.4
 orjson==3.9.15
-pycairo==1.25.1
-PyGObject==3.46.0
+pycairo==1.26.0
+PyGObject==3.48.1
 charset-normalizer==3.3.2
 idna==3.6
-urllib3==2.1.0
-certifi==2023.11.17
+urllib3==2.2.1
+certifi==2024.2.2
 pefile==2023.2.7


### PR DESCRIPTION
Update GNOME runtime to 46.
Also update every other dependencies (automated).
Fix `update-manifest.yml`