### PR TITLE
fix: Add missing context for generic noun "Bottles"

### DIFF
--- a/bottles/frontend/ui/list.blp
+++ b/bottles/frontend/ui/list.blp
@@ -39,7 +39,7 @@ template BottleView : .AdwBin {
 
       .AdwStatusPage bottle_status {
         icon-name: "com.usebottles.bottles-symbolic";
-        title: _("Bottles");
+        title: C_("generic-noun", "Bottles");
         hexpand: true;
         vexpand: true;
         child: 

--- a/bottles/frontend/windows/main_window.py
+++ b/bottles/frontend/windows/main_window.py
@@ -197,7 +197,7 @@ class MainWindow(Adw.ApplicationWindow):
             self.main_leaf.get_page(self.page_importer).set_navigatable(False)
 
             self.stack_main.add_titled(
-                child=self.page_list, name="page_list", title=_("Bottles")
+                child=self.page_list, name="page_list", title=C_("generic-noun", "Bottles")
             ).set_icon_name("com.usebottles.bottles-symbolic")
             self.stack_main.add_titled(
                 child=self.page_library, name="page_library", title=_("Library")


### PR DESCRIPTION
# Description
This simple string "Bottles" is used in different contexts:

- as a generic noun; referring to wine prefixes
- as a proper noun, referring to the app name

Adding context allows us to add different translations for each context.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Run `meson setup builddir --prefix=/usr -Ddevel=true`
- [ ] Run `ninja -C builddir`
- [ ] Run `ninja -C builddir bottles-pot`
- [ ] Open `po/bottles.pot` and see the string "Bottles" in these two different contexts are registered as different texts:

```
1767 #: bottles/frontend/ui/list.blp:42 bottles/frontend/windows/main_window.py:200
1768 msgctxt "generic-noun"
1769 msgid "Bottles"
1770 msgstr ""
:

2831 #: data/com.usebottles.bottles.metainfo.xml.in:7
2832 msgid "Bottles"
2833 msgstr ""
```