### PR TITLE
Escape braces for runner path

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -468,6 +468,8 @@ class WineCommand:
             runner = f"{runner}64"
 
         runner = runner.replace(" ", "\\ ")
+        runner = runner.replace("(", "\\(")
+        runner = runner.replace(")", "\\)")
 
         return runner, runner_runtime
 


### PR DESCRIPTION
# Description
Hello, as you all know braces `()` are commonly used in filenames, steam's Proton 9 is still named `Proton 9.0 (Beta)`. The braces caused an sh syntax error as per attached issue. This PR escapes the braces for runner path.

Fixes #3407 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- Use a runner with braces in the name
- run a windows program
- run legacy wine tools 
  - winecfg
  - explorer
  - uninstaller
  - debugger
  - control panel
  - taskmgr
