### PR TITLE
Update DXVK subtitles to include Direct3D 8

### DIFF
--- a/bottles/frontend/ui/details-preferences.blp
+++ b/bottles/frontend/ui/details-preferences.blp
@@ -25,7 +25,7 @@ template DetailsPreferences : .AdwPreferencesPage {
 
       .AdwComboRow combo_dxvk {
         title: _("DXVK");
-        subtitle: _("Improve Direct3D 9/10/11 compatibility by translating it to Vulkan.");
+        subtitle: _("Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan.");
         Spinner spinner_dxvk {
           tooltip-text: _("Updating DXVK, please wait…");
           valign: center;

--- a/po/ar.po
+++ b/po/ar.po
@@ -627,7 +627,7 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr "حسِّن تكامل دايركت‌ثري‌دي ١١/١٠/٩ عبر ترجمتها لفولكَن."
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/az.po
+++ b/po/az.po
@@ -615,7 +615,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/be.po
+++ b/po/be.po
@@ -621,7 +621,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/bg.po
+++ b/po/bg.po
@@ -644,9 +644,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Подобрява съвместимостта с Direct3D 9/10/11, чрез превеждане към „Vulkan“."
+"Подобрява съвместимостта с Direct3D 8/9/10/11, чрез превеждане към „Vulkan“."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/bn.po
+++ b/po/bn.po
@@ -657,7 +657,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/bottles.pot
+++ b/po/bottles.pot
@@ -624,7 +624,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/bs.po
+++ b/po/bs.po
@@ -619,7 +619,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/ca.po
+++ b/po/ca.po
@@ -647,7 +647,7 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -675,7 +675,7 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/cs.po
+++ b/po/cs.po
@@ -642,8 +642,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Zlepšení kompatibility Direct3D 9/10/11 převodem do Vulkanu."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Zlepšení kompatibility Direct3D 8/9/10/11 převodem do Vulkanu."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"
@@ -656,7 +656,7 @@ msgstr "VKD3D"
 
 #: bottles/frontend/ui/details-preferences.blp:41
 msgid "Improve Direct3D 12 compatibility by translating it to Vulkan."
-msgstr "Zlepšení kompatibility Direct3D 9/10/11 převodem do Vulkanu."
+msgstr "Zlepšení kompatibility Direct3D 8/9/10/11 převodem do Vulkanu."
 
 #: bottles/frontend/ui/details-preferences.blp:43
 msgid "Updating VKD3D, please wait…"

--- a/po/da.po
+++ b/po/da.po
@@ -666,7 +666,7 @@ msgid "DXVK"
 msgstr "DXVK Heads-up-skærm"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/de.po
+++ b/po/de.po
@@ -647,9 +647,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Direct3D 9/10/11-Kompatibilität durch die Übersetzung zu Vulkan verbessern."
+"Direct3D 8/9/10/11-Kompatibilität durch die Übersetzung zu Vulkan verbessern."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/el.po
+++ b/po/el.po
@@ -651,7 +651,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/eo.po
+++ b/po/eo.po
@@ -672,7 +672,7 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/es.po
+++ b/po/es.po
@@ -645,8 +645,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Mejorar la compatibilidad de Direct3D 9/10/11 traduciéndolo a Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Mejorar la compatibilidad de Direct3D 8/9/10/11 traduciéndolo a Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/et.po
+++ b/po/et.po
@@ -617,7 +617,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/eu.po
+++ b/po/eu.po
@@ -640,7 +640,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/fa.po
+++ b/po/fa.po
@@ -632,7 +632,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/fi.po
+++ b/po/fi.po
@@ -647,8 +647,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Paranna Direct3D 9/10/11 -yhteensopivuutta kääntämällä se Vulkanille."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Paranna Direct3D 8/9/10/11 -yhteensopivuutta kääntämällä se Vulkanille."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/fr.po
+++ b/po/fr.po
@@ -649,8 +649,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Améliorez la compatibilité Direct3D 9/10/11 en traduisant vers Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Améliorez la compatibilité Direct3D 8/9/10/11 en traduisant vers Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/gl.po
+++ b/po/gl.po
@@ -642,7 +642,7 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/he.po
+++ b/po/he.po
@@ -621,7 +621,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/hi.po
+++ b/po/hi.po
@@ -640,7 +640,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/hr.po
+++ b/po/hr.po
@@ -641,8 +641,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Poboljšaj kompatibilnost s Direct3D 9/10/11 prevođenjem na Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Poboljšaj kompatibilnost s Direct3D 8/9/10/11 prevođenjem na Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/hu.po
+++ b/po/hu.po
@@ -641,8 +641,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "A Direct3D 9/10/11 kompatibilitás javítása Vulkanra való fordítással."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "A Direct3D 8/9/10/11 kompatibilitás javítása Vulkanra való fordítással."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/id.po
+++ b/po/id.po
@@ -656,10 +656,10 @@ msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
 #, fuzzy
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 "Aktifkan dukungan Direct3D 12 dan tingkatkan permintaan menerjemahkan "
-"kinerja Direct3D 9/10/11 ke Vulkan."
+"kinerja Direct3D 8/9/10/11 ke Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/ie.po
+++ b/po/ie.po
@@ -620,7 +620,7 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/it.po
+++ b/po/it.po
@@ -643,8 +643,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Migliora la compatibilità di Direct3D 9/10/11 traducendolo in Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Migliora la compatibilità di Direct3D 8/9/10/11 traducendolo in Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/ja.po
+++ b/po/ja.po
@@ -643,8 +643,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Direct3D 9/10/11 を Vulkan に変換することで、互換性を向上します。"
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Direct3D 8/9/10/11 を Vulkan に変換することで、互換性を向上します。"
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/ko.po
+++ b/po/ko.po
@@ -633,8 +633,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Vulkan으로 번역하여 Direct3D 9/10/11 호환성을 개선합니다."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Vulkan으로 번역하여 Direct3D 8/9/10/11 호환성을 개선합니다."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/lt.po
+++ b/po/lt.po
@@ -622,7 +622,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/ms.po
+++ b/po/ms.po
@@ -674,7 +674,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -699,9 +699,9 @@ msgstr "Bruk DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
 #, fuzzy
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Skru på Direct3D 12-støtte og forbedre Direct3D 9/19/11-ytelse ved "
+"Skru på Direct3D 12-støtte og forbedre Direct3D 8/9/10/11-ytelse ved "
 "oversetting av forespørsler til Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/nl.po
+++ b/po/nl.po
@@ -647,9 +647,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Verbeter compatibiliteit van Direct3D 9/10/11 door deze te vertalen naar "
+"Verbeter compatibiliteit van Direct3D 8/9/10/11 door deze te vertalen naar "
 "Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/pl.po
+++ b/po/pl.po
@@ -646,8 +646,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Ulepsz kompatybilność z Direct3D 9/10/11, tłumacząc go na Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Ulepsz kompatybilność z Direct3D 8/9/10/11, tłumacząc go na Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/pt.po
+++ b/po/pt.po
@@ -646,9 +646,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Melhore a compatibilidade do Direct3D 9,10 ou 11 traduzindo-o para Vulkan."
+"Melhore a compatibilidade do Direct3D 8/9/10/11 traduzindo-o para Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -645,9 +645,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Melhore a compatibilidade do Direct3D 9,10 ou 11 traduzindo-o para Vulkan."
+"Melhore a compatibilidade do Direct3D 8/9/10/11 traduzindo-o para Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/ro.po
+++ b/po/ro.po
@@ -646,9 +646,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Îmbunătățește compatibilitatea Direct3D 9/10/11 prin traducerea acestuia în "
+"Îmbunătățește compatibilitatea Direct3D 8/9/10/11 prin traducerea acestuia în "
 "Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/ru.po
+++ b/po/ru.po
@@ -643,8 +643,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Улучшает совместимость с Direct3D 9/10/11 путём перевода их в Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Улучшает совместимость с Direct3D 8/9/10/11 путём перевода их в Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/sk.po
+++ b/po/sk.po
@@ -643,8 +643,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Vylepšite kompatibilitu s Direct3D 9/10/11 prevodom do Vulkanu."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Vylepšite kompatibilitu s Direct3D 8/9/10/11 prevodom do Vulkanu."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"
@@ -657,7 +657,7 @@ msgstr "VKD3D"
 
 #: bottles/frontend/ui/details-preferences.blp:41
 msgid "Improve Direct3D 12 compatibility by translating it to Vulkan."
-msgstr "Vylepšite kompatibilitu s Direct3D 9/10/11 prevodom do Vulkanu."
+msgstr "Vylepšite kompatibilitu s Direct3D 8/9/10/11 prevodom do Vulkanu."
 
 #: bottles/frontend/ui/details-preferences.blp:43
 msgid "Updating VKD3D, please wait…"

--- a/po/sl.po
+++ b/po/sl.po
@@ -621,7 +621,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/sr.po
+++ b/po/sr.po
@@ -641,8 +641,8 @@ msgid "DXVK"
 msgstr "ДКСВК"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Побољшај компатибилност Direct3D 9/10/11 превођењем у Вулкан."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Побољшај компатибилност Direct3D 8/9/10/11 превођењем у Вулкан."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/sv.po
+++ b/po/sv.po
@@ -657,10 +657,10 @@ msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
 #, fuzzy
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 "Aktivera Direct3D 12-stöd och förbättrad prestanda vid överföringsbegäran "
-"för Direct3D 9/10/11 till Vulkan."
+"för Direct3D 8/9/10/11 till Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/ta.po
+++ b/po/ta.po
@@ -640,8 +640,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Direct3D 9/10/11 இணக்கத்தன்மையை வல்கனுக்கு மொழிபெயர்ப்பதன் மூலம் மேம்படுத்தவும்."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Direct3D 8/9/10/11 இணக்கத்தன்மையை வல்கனுக்கு மொழிபெயர்ப்பதன் மூலம் மேம்படுத்தவும்."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/th.po
+++ b/po/th.po
@@ -641,7 +641,7 @@ msgid "DXVK"
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/tr.po
+++ b/po/tr.po
@@ -640,9 +640,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Direct3D 9/10/11 uyumluluğunu Vulkan'a çevirerek performansı geliştirin."
+"Direct3D 8/9/10/11 uyumluluğunu Vulkan'a çevirerek performansı geliştirin."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/uk.po
+++ b/po/uk.po
@@ -644,8 +644,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Покращення сумісності Direct3D 9/10/11 шляхом переведення на Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Покращення сумісності Direct3D 8/9/10/11 шляхом переведення на Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/vi.po
+++ b/po/vi.po
@@ -640,9 +640,9 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
 msgstr ""
-"Cải thiện độ tương thích Direct3D 9/10/11 bằng cách phiên dịch nó sang "
+"Cải thiện độ tương thích Direct3D 8/9/10/11 bằng cách phiên dịch nó sang "
 "Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -633,8 +633,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "通过将它翻译为 Vulkan 改进 Direct3D 9/10/11 兼容性。"
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "通过将它翻译为 Vulkan 改进 Direct3D 8/9/10/11 兼容性。"
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -631,8 +631,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "將 Direct3D 9/10/11 轉譯成 Vulkan，以改善相容性。"
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "將 Direct3D 8/9/10/11 轉譯成 Vulkan，以改善相容性。"
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"


### PR DESCRIPTION
# Description

Just a simple update to cover DXVK's recent support of D3D8 (which is already a thing in Bottles b1cd8a2b1286cf5a441f89ec71f0e0da44d82c77 but not reflected in the UI, yet).

Probably can close #2641 too.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/524c4600-a297-41c8-8064-cb305fa60d76)
![image](https://github.com/user-attachments/assets/8a8c3c0c-e7fb-4ff4-9999-47e8402fa991)
![image](https://github.com/user-attachments/assets/fbaec589-a892-44f3-aede-d5b7f2aa46e5)

