### PR TITLE
cli/run: Require either `--executable` or `--program`

### DIFF
--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -660,6 +660,10 @@ class CLI:
         bottle = mng.local_bottles[_bottle]
         programs = mng.get_programs(bottle)
 
+        if _executable is None and _program is None:
+            sys.stderr.write(f"Please specify either --executable or --program\n")
+            exit(1)
+
         if _program is not None:
             if _executable is not None:
                 sys.stderr.write(f"Cannot specify both --program and --executable\n")


### PR DESCRIPTION
# Description
This prevents a crash when `bottles-cli run` is invoked without an `--executable` or `--program`.

Fixes #3559

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Without the fix:

```sh
$ flatpak run --command=bottles-cli com.usebottles.bottles run -b Default
05:35:27 (INFO) Forcing offline mode 
Traceback (most recent call last):
  File "/app/bin/bottles-cli", line 764, in <module>
    cli = CLI()
          ^^^^^
  File "/app/bin/bottles-cli", line 236, in __init__
    self.__process_args()
  File "/app/bin/bottles-cli", line 285, in __process_args
    self.run_program()
  File "/app/bin/bottles-cli", line 687, in run_program
    _executable = _executable.replace("file://", "")
                  ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```

- [x] With the fix:

```sh
$ flatpak run --command=bottles-cli com.usebottles.bottles run -b Default
05:41:20 (INFO) Forcing offline mode 
Please specify either --executable or --program
```
