### PR TITLE
windows 10 is 10.0 not 6.3

### DIFF
--- a/bottles/backend/wine/catalogs.py
+++ b/bottles/backend/wine/catalogs.py
@@ -4,7 +4,7 @@ win_versions = {
         "CSDVersionHex": "0",
         "CurrentBuild": "22000",
         "CurrentBuildNumber": "22000",
-        "CurrentVersion": "6.3",
+        "CurrentVersion": "10.0",
         "CurrentMinorVersionNumber": "0",
         "CurrentMajorVersionNumber": "a",  # 10
         "ProductType": "WinNT",
@@ -15,7 +15,7 @@ win_versions = {
         "CSDVersionHex": "0",
         "CurrentBuild": "19043",
         "CurrentBuildNumber": "19043",
-        "CurrentVersion": "6.3",
+        "CurrentVersion": "10.0",
         "CurrentMinorVersionNumber": "0",
         "CurrentMajorVersionNumber": "a",  # 10
         "ProductType": "WinNT",


### PR DESCRIPTION
# Description
changes CurrentVersion of Windows 10 and Windows 11 back to "10.0"

Fixes #(issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
