### PR TITLE
Add Gamescope toggle as an override for individual programs

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -729,6 +729,7 @@ class Manager(metaclass=Singleton):
                     "vkd3d": _program.get("vkd3d"),
                     "dxvk_nvapi": _program.get("dxvk_nvapi"),
                     "fsr": _program.get("fsr"),
+                    "gamescope": _program.get("gamescope"),
                     "pulseaudio_latency": _program.get("pulseaudio_latency"),
                     "virtual_desktop": _program.get("virtual_desktop"),
                     "removed": _program.get("removed"),

--- a/bottles/backend/models/samples.py
+++ b/bottles/backend/models/samples.py
@@ -47,6 +47,7 @@ class Samples:
         "WINE_FULLSCREEN_FSR": ("fsr", True),
         "WINE_FULLSCREEN_FSR_STRENGTH": ("fsr_sharpening_strength", 2),
         "WINE_FULLSCREEN_FSR_MODE": ("fsr_quality_mode", "none"),
+        "GAMESCOPE": ("gamescope", False),
         "DRI_PRIME": ("discrete_gpu", True),
         "__NV_PRIME_RENDER_OFFLOAD": ("discrete_gpu", True),
         "PULSE_LATENCY_MSEC": ("pulseaudio_latency", True),

--- a/bottles/backend/wine/executor.py
+++ b/bottles/backend/wine/executor.py
@@ -238,8 +238,6 @@ class WineExecutor:
         #         data={"output": res}
         #     )
         winepath = WinePath(self.config)
-        if self.use_gamescope:
-            return self.__launch_with_gamescope()
         if self.use_virt_desktop:
             if winepath.is_unix(self.exec_path):
                 self.exec_path = winepath.to_windows(self.exec_path)
@@ -335,9 +333,6 @@ class WineExecutor:
         )
         self.__set_monitors()
         return Result(status=res.status, data={"output": res.data})
-
-    def __launch_with_gamescope(self):
-        self.__launch_exe()
 
     @staticmethod
     def __launch_dll():

--- a/bottles/backend/wine/executor.py
+++ b/bottles/backend/wine/executor.py
@@ -40,6 +40,7 @@ class WineExecutor:
         program_vkd3d: Optional[bool] = None,
         program_nvapi: Optional[bool] = None,
         program_fsr: Optional[bool] = None,
+        program_gamescope: Optional[bool] = None,
         program_virt_desktop: Optional[bool] = None,
     ):
         logging.info("Launching an executable…")
@@ -121,6 +122,7 @@ class WineExecutor:
             program_vkd3d=program.get("vkd3d"),
             program_nvapi=program.get("dxvk_nvapi"),
             program_fsr=program.get("fsr"),
+            program_gamescope=program.get("fsr"),
             program_virt_desktop=program.get("virtual_desktop"),
         ).run()
 

--- a/bottles/backend/wine/executor.py
+++ b/bottles/backend/wine/executor.py
@@ -65,6 +65,7 @@ class WineExecutor:
         self.pre_script = pre_script
         self.post_script = post_script
         self.monitoring = monitoring
+        self.use_gamescope = program_gamescope
         self.use_virt_desktop = program_virt_desktop
 
         env_dll_overrides = []
@@ -96,6 +97,9 @@ class WineExecutor:
                 self.environment["WINE_FULLSCREEN_FSR_MODE"] = str(
                     self.config.Parameters.fsr_quality_mode
                 )
+        
+        if program_gamescope is not None and program_gamescope != self.config.Parameters.gamescope:
+            self.environment["GAMESCOPE"] = "1" if program_gamescope else "0"
 
         if env_dll_overrides:
             if "WINEDLLOVERRIDES" in self.environment:
@@ -122,7 +126,7 @@ class WineExecutor:
             program_vkd3d=program.get("vkd3d"),
             program_nvapi=program.get("dxvk_nvapi"),
             program_fsr=program.get("fsr"),
-            program_gamescope=program.get("fsr"),
+            program_gamescope=program.get("gamescope"),
             program_virt_desktop=program.get("virtual_desktop"),
         ).run()
 
@@ -234,6 +238,8 @@ class WineExecutor:
         #         data={"output": res}
         #     )
         winepath = WinePath(self.config)
+        if self.use_gamescope:
+            return self.__launch_with_gamescope()
         if self.use_virt_desktop:
             if winepath.is_unix(self.exec_path):
                 self.exec_path = winepath.to_windows(self.exec_path)
@@ -329,6 +335,9 @@ class WineExecutor:
         )
         self.__set_monitors()
         return Result(status=res.status, data={"output": res.data})
+
+    def __launch_with_gamescope(self):
+        self.__launch_exe()
 
     @staticmethod
     def __launch_dll():

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -108,8 +108,8 @@ class WineCommand:
         self.cwd = self._get_cwd(cwd)
         self.runner, self.runner_runtime = self._get_runner_info()
         self.gamescope_activated = (
-            self.config.Parameters.gamescope
-            or environment.get("GAMESCOPE", "0") == "1"
+            environment["GAMESCOPE"] == "1" if "GAMESCOPE" in environment
+            else self.config.Parameters.gamescope
         )
         self.command = self.get_cmd(
             command, pre_script, post_script, environment=_environment

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -107,6 +107,10 @@ class WineCommand:
         self.arguments = arguments
         self.cwd = self._get_cwd(cwd)
         self.runner, self.runner_runtime = self._get_runner_info()
+        self.gamescope_activated = (
+            self.config.Parameters.gamescope
+            or environment.get("GAMESCOPE", "0") == "1"
+        )
         self.command = self.get_cmd(
             command, pre_script, post_script, environment=_environment
         )
@@ -330,7 +334,7 @@ class WineCommand:
         if (
             params.mangohud
             and not self.minimal
-            and not (gamescope_available and params.gamescope)
+            and not (gamescope_available and self.gamescope_activated)
         ):
             env.add("MANGOHUD", "1")
             env.add("MANGOHUD_DLSYM", "1")
@@ -506,13 +510,13 @@ class WineCommand:
                 else:
                     command = f"gamemode {command}"
 
-            if mangohud_available and params.mangohud and not params.gamescope:
+            if mangohud_available and params.mangohud and not self.gamescope_activated:
                 if not return_steam_cmd:
                     command = f"{mangohud_available} {command}"
                 else:
                     command = f"mangohud {command}"
 
-            if gamescope_available and params.gamescope:
+            if gamescope_available and self.gamescope_activated:
                 gamescope_run = tempfile.NamedTemporaryFile(mode="w", suffix=".sh").name
 
                 # Create temporary sh script in /tmp where Gamescope will execute it
@@ -605,7 +609,7 @@ class WineCommand:
         params = config.Parameters
         gamescope_cmd = []
 
-        if gamescope_available and params.gamescope:
+        if gamescope_available and self.gamescope_activated:
             gamescope_cmd = [gamescope_available]
             if return_steam_cmd:
                 gamescope_cmd = ["gamescope"]

--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -640,6 +640,7 @@ class CLI:
         _program_vkd3d = None
         _program_dxvk_nvapi = None
         _program_fsr = None
+        _program_gamescope = None
         _program_virt_desktop = None
 
         mng = Manager(g_settings=self.settings, is_cli=True)
@@ -682,6 +683,7 @@ class CLI:
             _program_vkd3d = program.get("vkd3d")
             _program_dxvk_nvapi = program.get("dxvk_nvapi")
             _program_fsr = program.get("fsr")
+            _program_gamescope = program.get("gamescope")
             _program_virt_desktop = program.get("virtual_desktop")
 
         _executable = _executable.replace("file://", "")
@@ -701,6 +703,7 @@ class CLI:
             program_vkd3d=_program_vkd3d,
             program_nvapi=_program_dxvk_nvapi,
             program_fsr=_program_fsr,
+            program_gamescope=_program_gamescope,
             program_virt_desktop=_program_virt_desktop,
         ).run_cli()
 

--- a/bottles/frontend/ui/dialog-launch-options.blp
+++ b/bottles/frontend/ui/dialog-launch-options.blp
@@ -192,6 +192,15 @@ template LaunchOptionsDialog : .AdwWindow {
           }
         }
 
+        .AdwActionRow action_gamescope {
+          title: _("Gamescope");
+          activatable-widget: "switch_gamescope";
+
+          Switch switch_gamescope {
+            valign: center;
+          }
+        }
+
         .AdwActionRow action_virt_desktop {
           title: _("Virtual Desktop");
           activatable-widget: "switch_virt_desktop";

--- a/bottles/frontend/windows/launchoptions.py
+++ b/bottles/frontend/windows/launchoptions.py
@@ -97,6 +97,7 @@ class LaunchOptionsDialog(Adw.Window):
         self.toggled["vkd3d"] = False
         self.toggled["dxvk_nvapi"] = False
         self.toggled["fsr"] = False
+        self.toggled["gamescope"] = False
         self.toggled["virtual_desktop"] = False
 
         # connect signals
@@ -159,7 +160,7 @@ class LaunchOptionsDialog(Adw.Window):
             "state-set", self.__check_override, self.action_fsr, "fsr"
         )
         self.switch_gamescope.connect(
-            "state-set", self.__check_override, self.action_gamescope, "fsr"
+            "state-set", self.__check_override, self.action_gamescope, "gamescope"
         )
         self.switch_virt_desktop.connect(
             "state-set",

--- a/bottles/frontend/windows/launchoptions.py
+++ b/bottles/frontend/windows/launchoptions.py
@@ -47,11 +47,13 @@ class LaunchOptionsDialog(Adw.Window):
     switch_vkd3d = Gtk.Template.Child()
     switch_nvapi = Gtk.Template.Child()
     switch_fsr = Gtk.Template.Child()
+    switch_gamescope = Gtk.Template.Child()
     switch_virt_desktop = Gtk.Template.Child()
     action_dxvk = Gtk.Template.Child()
     action_vkd3d = Gtk.Template.Child()
     action_nvapi = Gtk.Template.Child()
     action_fsr = Gtk.Template.Child()
+    action_gamescope = Gtk.Template.Child()
     action_cwd = Gtk.Template.Child()
     action_virt_desktop = Gtk.Template.Child()
     # endregion
@@ -113,6 +115,7 @@ class LaunchOptionsDialog(Adw.Window):
         self.global_vkd3d = program_vkd3d = config.Parameters.vkd3d
         self.global_nvapi = program_nvapi = config.Parameters.dxvk_nvapi
         self.global_fsr = program_fsr = config.Parameters.fsr
+        self.global_gamescope = program_gamescope = config.Parameters.gamescope
         self.global_virt_desktop = program_virt_desktop = (
             config.Parameters.virtual_desktop
         )
@@ -129,6 +132,9 @@ class LaunchOptionsDialog(Adw.Window):
         if self.program.get("fsr") is not None:
             program_fsr = self.program.get("fsr")
             self.action_fsr.set_subtitle(self.__msg_override)
+        if self.program.get("gamescope") is not None:
+            program_gamescope = self.program.get("gamescope")
+            self.action_gamescope.set_subtitle(self.__msg_override)
         if self.program.get("virtual_desktop") is not None:
             program_virt_desktop = self.program.get("virtual_desktop")
             self.action_virt_desktop.set_subtitle(self.__msg_override)
@@ -137,6 +143,7 @@ class LaunchOptionsDialog(Adw.Window):
         self.switch_vkd3d.set_active(program_vkd3d)
         self.switch_nvapi.set_active(program_nvapi)
         self.switch_fsr.set_active(program_fsr)
+        self.switch_gamescope.set_active(program_gamescope)
         self.switch_virt_desktop.set_active(program_virt_desktop)
 
         self.switch_dxvk.connect(
@@ -150,6 +157,9 @@ class LaunchOptionsDialog(Adw.Window):
         )
         self.switch_fsr.connect(
             "state-set", self.__check_override, self.action_fsr, "fsr"
+        )
+        self.switch_gamescope.connect(
+            "state-set", self.__check_override, self.action_gamescope, "fsr"
         )
         self.switch_virt_desktop.connect(
             "state-set",
@@ -195,12 +205,14 @@ class LaunchOptionsDialog(Adw.Window):
         program_vkd3d = self.switch_vkd3d.get_state()
         program_nvapi = self.switch_nvapi.get_state()
         program_fsr = self.switch_fsr.get_state()
+        program_gamescope = self.switch_gamescope.get_state()
         program_virt_desktop = self.switch_virt_desktop.get_state()
 
         self.__set_override("dxvk", program_dxvk, self.global_dxvk)
         self.__set_override("vkd3d", program_vkd3d, self.global_vkd3d)
         self.__set_override("dxvk_nvapi", program_nvapi, self.global_nvapi)
         self.__set_override("fsr", program_fsr, self.global_fsr)
+        self.__set_override("gamescope", program_gamescope, self.global_gamescope)
         self.__set_override(
             "virtual_desktop", program_virt_desktop, self.global_virt_desktop
         )
@@ -331,11 +343,13 @@ class LaunchOptionsDialog(Adw.Window):
         self.switch_vkd3d.set_active(self.global_vkd3d)
         self.switch_nvapi.set_active(self.global_nvapi)
         self.switch_fsr.set_active(self.global_fsr)
+        self.switch_gamescope.set_active(self.global_gamescope)
         self.switch_virt_desktop.set_active(self.global_virt_desktop)
         self.action_dxvk.set_subtitle("")
         self.action_vkd3d.set_subtitle("")
         self.action_nvapi.set_subtitle("")
         self.action_fsr.set_subtitle("")
+        self.action_gamescope.set_subtitle("")
         self.action_virt_desktop.set_subtitle("")
         self.__set_disabled_switches()
         for name in self.toggled:


### PR DESCRIPTION
# Description

Allows Gamescope to be toggled on a program-by-program basis, instead of just bottle-wide. This means that you can either leave the global toggle off and enable it for individual programs (default settings will be used) or leave it global-on and disable on specific ones.

![image](https://github.com/user-attachments/assets/60495944-f2c8-4075-afc8-d177307a027f)

All in all, avoids the hassle of having to manage two near-identical instances of the same bottle just to deal with gamescope-ness.

Closes #3377 (well-requested feature).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Try toying with different values for Gamescope (global setting and individual override):
- Override not set (`gamescope: null` in `bottle.yml`) should just be ignored
- Override toggled on (`gamescope: true`) should _always_ start said game with Gamescope
- Override toggled off (`gamescope: false`) should _never_ start said game with Gamescope
