### PR TITLE
Bug Fix: added $@ parameter in the Gamescope wrapper script

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -517,11 +517,9 @@ class WineCommand:
 
                 # Create temporary sh script in /tmp where Gamescope will execute it
                 file = [f"#!/usr/bin/env sh\n"]
+                file.append(f"{command} $@")
                 if mangohud_available and params.mangohud:
-                    file.append(f"{command}&\nmangoapp")
-                else:
-                    file.append(command)
-
+                    file.append(f" &\nmangoapp")
                 with open(gamescope_run, "w") as f:
                     f.write("".join(file))
 


### PR DESCRIPTION
# Description
The generated Gamescope wrapper script should pass all its arguments to the target application. This PR enables the correct behavior expected by users who have Gamescope enabled.

Fixes #3194

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
For the following tests, the target application should react in some way to command arguments.
- [x] Launch any application that accepts arguments through Bottles (GUI) with Gamescope enabled
- [x] Launch any application that accepts arguments through Bottles (GUI) with Gamescope and MangoHud enabled
- [x] Launch any application that accepts arguments through bottles-cli with Gamescope enabled
- [x] Launch any application that accepts arguments through bottles-cli with Gamescope and MangoHud enabled
