### PR TITLE
fix[close #3599]: CLI no longer works when starting a Bottle

### DIFF
--- a/bottles/frontend/cli/cli.py
+++ b/bottles/frontend/cli/cli.py
@@ -686,17 +686,23 @@ class CLI:
             _program_gamescope = program.get("gamescope")
             _program_virt_desktop = program.get("virtual_desktop")
 
-        if _executable:
+            WineExecutor.run_program(bottle, program | {"arguments": _args})
+
+        elif _executable:
             _executable = _executable.replace("file://", "")
             if _executable.startswith('"') and _executable.endswith('"'):
                 _executable = _executable[1:-1]
             elif _executable.startswith("'") and _executable.endswith("'"):
                 _executable = _executable[1:-1]
-        else:
-            sys.stderr.write("No executable specified or found\n")
-            exit(1)
 
-        WineExecutor.run_program(bottle, program)
+            WineExecutor(
+                bottle,
+                exec_path=_executable,
+                args=_args,
+            ).run_cli()
+        else:
+            sys.stderr.write("No program or executable specified, you must use either --program or --executable\n")
+            exit(1)
 
     # endregion
 


### PR DESCRIPTION
Fix starting an --executable from the CLI.

# Description
Seems like this is broken since commit f31c0a7, which was an improvement for the `--program` case but neglected the `--executable` case.

Fixes #3599 #3601

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Right-click on a program.exe on Nautilus and open it with Bottles.  
Command lines:
```
flatpak run --command=bottles-cli com.usebottles.bottles.Devel run --bottle test-cli --program linksider
flatpak run --command=bottles-cli com.usebottles.bottles.Devel run --bottle test-cli --executable /path/to/linksider.exe
flatpak run com.usebottles.bottles.Devel /path/to/linksider.exe
```
