### PR TITLE
Use `string.ascii_uppercase` instead of exhaustive list for drive letters

### DIFF
--- a/bottles/frontend/windows/drives.py
+++ b/bottles/frontend/windows/drives.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from string import ascii_uppercase
+import string
 
 from gi.repository import Gtk, GLib, Adw
 
@@ -93,7 +93,7 @@ class DriveEntry(Adw.ActionRow):
 @Gtk.Template(resource_path="/com/usebottles/bottles/dialog-drives.ui")
 class DrivesDialog(Adw.Window):
     __gtype_name__ = "DrivesDialog"
-    __alphabet = list(ascii_uppercase)
+    __alphabet = list(string.ascii_uppercase)
 
     # region Widgets
     combo_letter = Gtk.Template.Child()

--- a/bottles/frontend/windows/drives.py
+++ b/bottles/frontend/windows/drives.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from string import ascii_uppercase
+
 from gi.repository import Gtk, GLib, Adw
 
 from bottles.backend.wine.drives import Drives
@@ -91,33 +93,7 @@ class DriveEntry(Adw.ActionRow):
 @Gtk.Template(resource_path="/com/usebottles/bottles/dialog-drives.ui")
 class DrivesDialog(Adw.Window):
     __gtype_name__ = "DrivesDialog"
-    __alphabet = [
-        "A",
-        "B",
-        "D",
-        "E",
-        "F",
-        "G",
-        "H",
-        "I",
-        "J",
-        "K",
-        "L",
-        "M",
-        "N",
-        "O",
-        "P",
-        "Q",
-        "R",
-        "S",
-        "T",
-        "U",
-        "V",
-        "W",
-        "X",
-        "Y",
-        "Z",
-    ]
+    __alphabet = list(ascii_uppercase)
 
     # region Widgets
     combo_letter = Gtk.Template.Child()


### PR DESCRIPTION
# Description
Saves... 27 lines of code or so?

# How Has This Been Tested?
![image](https://github.com/user-attachments/assets/28d8aa61-05e7-4e51-a067-e54ad3912ba4)
