### PR TITLE
Revert "flatpak: Use `master` runtime version"

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -8,11 +8,11 @@ jobs:
     name: "build-packages"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/bottlesdevs/flatpak-github-actions:gnome-nightly-with-wine
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
       options: --privileged
     steps:
     - uses: actions/checkout@v4
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: bottles.flatpak
         manifest-path: build-aux/com.usebottles.bottles.Devel.json

--- a/build-aux/com.usebottles.bottles.Devel.json
+++ b/build-aux/com.usebottles.bottles.Devel.json
@@ -4,7 +4,7 @@
     "runtime": "org.gnome.Platform",
     "base": "org.winehq.Wine",
     "base-version": "stable-24.08",
-    "runtime-version": "master",
+    "runtime-version": "47",
     "command": "bottles",
     "finish-args": [
         "--allow=devel",
@@ -33,11 +33,11 @@
     "add-extensions": {
         "org.gnome.Platform.Compat.i386": {
             "directory": "lib/i386-linux-gnu",
-            "version": "master"
+            "version": "47"
         },
         "org.gnome.Platform.Compat.i386.Debug": {
             "directory": "lib/debug/lib/i386-linux-gnu",
-            "version": "master",
+            "version": "47",
             "no-autodownload": true
         },
         "com.valvesoftware.Steam.CompatibilityTool": {


### PR DESCRIPTION
As discussed internally, it was a rushed and nondemocratic decision
to apply this commit without asking anybody else.