### PR TITLE
component: Schedule progress to run on main loop

### DIFF
--- a/bottles/frontend/widgets/component.py
+++ b/bottles/frontend/widgets/component.py
@@ -93,6 +93,10 @@ class ComponentEntry(Adw.ActionRow):
 
             return self.update_progress(status=Status.FAILED)
 
+        @GtkUtils.run_in_main_loop
+        def async_func(*args, **kwargs):
+            return self.update_progress(*args, **kwargs)
+
         self.btn_download.set_visible(False)
         self.btn_cancel.set_visible(False)  # TODO: unimplemented
         self.box_download_status.set_visible(True)
@@ -102,7 +106,7 @@ class ComponentEntry(Adw.ActionRow):
             callback=async_callback,
             component_type=self.component_type,
             component_name=self.name,
-            func=self.update_progress,
+            func=async_func,
         )
 
     def uninstall(self, widget):


### PR DESCRIPTION
# Description
The download progress is reported from a thread and Gtk is not thread-safe. This fixes issues with the UI breaking when downloading runners/components.

Fixes #3578
Fixes #3553
Fixes #3629

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
The issue can be more easily reproduced by downloading a big runner like proton-ge. The UI would often freeze, and sometimes all widgets would disappear. Program crashes also reported by users, but I could never reproduce a crash.
