### PR TITLE
Added support for Ghostty

### DIFF
--- a/bottles/backend/utils/terminal.py
+++ b/bottles/backend/utils/terminal.py
@@ -43,6 +43,7 @@ class TerminalUtils:
         # Third party
         ["foot", "%s"],
         ["kitty", "%s"],
+        ["ghostty", "-e %s"]
         ["tilix", "-- %s"],
         # Desktop environments
         ["xfce4-terminal", "-e %s"],
@@ -102,6 +103,8 @@ class TerminalUtils:
             )
             if "ENABLE_BASH" in os.environ:
                 command = " ".join(self.terminal) % (colors, f"bash")
+        elif self.terminal[0] in ["ghostty"]:
+            command = " ".join(self.terminal) % f"{command}"
         elif self.terminal[0] in ["xfce4-terminal"]:
             command = " ".join(self.terminal) % "'sh -c %s'" % f"{command}"
         elif self.terminal[0] in ["kitty", "foot", "konsole", "gnome-terminal"]:


### PR DESCRIPTION
# Description
Added support for running applications using Ghostty.

_Note: I don't know why the other terminals require the 'sh -c' or
'bash -c', but Ghostty calls that already when passing the option '-e'.
It worked fine in my pc without that, but it would be nice if someone
else tested it just to make sure._

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Built and installed
- [ ] Removed EasyTerm (installed by the flatpak builder) and any other terminal emulators from my machine
- [ ] Ran executable checking the "Run in Terminal" option

Worked fine here, but as I mentioned further testing would be nice.