### PR TITLE
Start "Add Shortcuts" dialog at the root of the bottle

### DIFF
--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -279,7 +279,9 @@ class BottleView(Adw.PreferencesPage):
         add_executable_filters(dialog)
         add_all_filters(dialog)
         dialog.set_modal(True)
-        dialog.set_current_folder(Gio.File.new_for_path(ManagerUtils.get_bottle_path(self.config)))
+        dialog.set_current_folder(
+            Gio.File.new_for_path(ManagerUtils.get_bottle_path(self.config))
+        )
         dialog.connect("response", set_path)
         dialog.show()
 

--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -279,6 +279,7 @@ class BottleView(Adw.PreferencesPage):
         add_executable_filters(dialog)
         add_all_filters(dialog)
         dialog.set_modal(True)
+        dialog.set_current_folder(Gio.File.new_for_path(ManagerUtils.get_bottle_path(self.config)))
         dialog.connect("response", set_path)
         dialog.show()
 


### PR DESCRIPTION
Set the initial directory for the Add Shortcuts dialog to the root of the bottle.
Fixes #3475.

