### PR TITLE
Remove NVIDIA Flatpak Workaround

### DIFF
--- a/bottles/backend/utils/vulkan.py
+++ b/bottles/backend/utils/vulkan.py
@@ -19,7 +19,6 @@ import os
 from glob import glob
 import shutil
 import subprocess
-import filecmp
 
 
 class VulkanUtils:
@@ -46,17 +45,7 @@ class VulkanUtils:
 
             for file in _files:
                 if "nvidia" in file.lower():
-                    # Workaround for nvidia flatpak bug: https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/112
-                    should_skip = False
-                    for nvidia_loader in loaders["nvidia"]:
-                        try:
-                            if filecmp.cmp(nvidia_loader, file):
-                                should_skip = True
-                                continue
-                        except:
-                            pass
-                    if not should_skip:
-                        loaders["nvidia"] += [file]
+                    loaders["nvidia"] += [file]
                 elif "amd" in file.lower() or "radeon" in file.lower():
                     loaders["amd"] += [file]
                 elif "intel" in file.lower():


### PR DESCRIPTION
# Description
Removes the workaround implemented specifically for the NVIDIA Flatpak drivers (5627b5b).

Originally, the issue was brought up in flathub/org.freedesktop.Platform.GL.nvidia#112. flathub/org.freedesktop.Platform.GL.nvidia#331 solves the problem on the driver side.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
In the debug information, under `Graphics -> vendors -> nvidia -> icd`, there will be a list of Vulkan `.json` files.
- [X] Using the latest version of `Bottles` from Flathub shows only the `x86_64` file
- [X] Using my branch's build of `Bottles` **still** shows only the `x86_64` file
