### PR TITLE
frontend: Added 'Failed adding to Steam Library dialog' in program_row.py' dialog

### DIFF
--- a/bottles/frontend/program_row.py
+++ b/bottles/frontend/program_row.py
@@ -339,6 +339,10 @@ class ProgramRow(Adw.ActionRow):
                 self.window.show_toast(
                     _('"{0}" added to your Steam library').format(self.program["name"])
                 )
+            else:
+                self.window.show_toast(
+                    _('"{0}" failed adding to your Steam library').format(self.program["name"])
+                )
 
         steam_manager = SteamManager(self.config)
         RunAsync(


### PR DESCRIPTION
bottles/frontend/program_row.py

# Description
In the past it dosent give any feedback to the user if it failed adding to the steam library.
(It dosent work if you have Flatpak version of steam)

I read most of the issues and there is no issues for this problem.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Since this isn't a big change I have only built it and tested it on my main distro (OpenSUSE Tumbelweed)
- [x] Building and testing adding to Steam the Flatpak Version.
