### PR TITLE
fix: use correct wine path on 10.2 and above

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -477,7 +477,7 @@ class WineCommand:
         else:
             runner = f"{runner}/bin/wine"
 
-        if arch == "win64":
+        if arch == "win64" and os.path.exists(f"{runner}64"):
             runner = f"{runner}64"
 
         runner = shlex.quote(runner)  # type: ignore


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed (if available).
Please also include relevant motivation and context.

Fixes #3781 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.

I tested it on
- kron4ek-wine-10.2
- kron4ek-wine-9.21
- ge-proton-9-25
