### PR TITLE
bottle-row: Set can-target and can-focus to false

### DIFF
--- a/bottles/frontend/check-row.blp
+++ b/bottles/frontend/check-row.blp
@@ -8,5 +8,7 @@ template $CheckRow: Adw.ActionRow {
   [prefix]
   CheckButton check_button {
     valign: center;
+    can-focus: false;
+    can-target: false;
   }
 }


### PR DESCRIPTION
The GtkListBox::row-activated signal only emits when a row is activated, not the child widget. This means, the check button wouldn't trigger the emission of the signal, thereby not updating the NewBottleDialog:selected-environment property.

Fixes https://github.com/bottlesdevs/Bottles/issues/3740