### PR TITLE
Fix broken CMD action with xfce4-terminal

### DIFF
--- a/bottles/backend/utils/terminal.py
+++ b/bottles/backend/utils/terminal.py
@@ -103,7 +103,7 @@ class TerminalUtils:
             if "ENABLE_BASH" in os.environ:
                 command = " ".join(self.terminal) % (colors, "bash")
         elif self.terminal[0] in ["xfce4-terminal"]:
-            command = " ".join(self.terminal) % "'sh -c %s'" % f"{command}"
+            command = " ".join(self.terminal) % "\"sh -c %s\"" % f"{command}"
         elif self.terminal[0] in ["kitty", "foot", "konsole", "gnome-terminal"]:
             command = " ".join(self.terminal) % "sh -c %s" % f"{command}"
         else:


### PR DESCRIPTION


# Description

Launching the command line with xfce4-terminal fails due to the snigle quotes. Using escaped quotes instead fixes the issue. 

Fixes the errors below:

```
01:16:28 (INFO) Using Wine Command Line -- launch_terminal 
01:16:28 (INFO) Command: xfce4-terminal -e 'sh -c '/home/spike/.local/share/bottles/runners/soda-9.0-1/bin/wine64 cmd''  xfce4-terminal: Unknown option "cmd"
```
Fixes #(issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The `Command Line` button works for me in xfce4-terminal after this fix 