### PR TITLE
Added an extra input to gamescope for extra flags

### DIFF
--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -87,6 +87,7 @@ class BottleParams(DictCompatMixIn):
     gamescope_scaling: bool = False
     gamescope_borderless: bool = False
     gamescope_fullscreen: bool = True
+    gamescope_advanced: str = ""
     sync: str = "wine"
     fsr: bool = False
     fsr_sharpening_strength: int = 2

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -640,6 +640,8 @@ class WineCommand:
                 gamescope_cmd.append(f"-W {params.gamescope_window_width}")
             if params.gamescope_window_height > 0:
                 gamescope_cmd.append(f"-H {params.gamescope_window_height}")
+            if params.gamescope_advanced:
+                gamescope_cmd.append(params.gamescope_advanced)
 
         return " ".join(gamescope_cmd)
 

--- a/bottles/frontend/gamescope-dialog.blp
+++ b/bottles/frontend/gamescope-dialog.blp
@@ -168,6 +168,15 @@ template $GamescopeDialog: Adw.Window {
           }
         }
       }
+
+      Adw.PreferencesGroup {
+        title: _("Advanced Settings");
+        description: _("Additional Gamescope flags to be appended.");
+        Adw.EntryRow advanced_options {
+          title: _("flags");
+          show-apply-button: false;
+        }
+      }
     }
   }
 }

--- a/bottles/frontend/gamescope_dialog.py
+++ b/bottles/frontend/gamescope_dialog.py
@@ -32,6 +32,7 @@ class GamescopeDialog(Adw.Window):
     switch_scaling = Gtk.Template.Child()
     toggle_borderless = Gtk.Template.Child()
     toggle_fullscreen = Gtk.Template.Child()
+    advanced_options = Gtk.Template.Child()
     btn_save = Gtk.Template.Child()
     btn_cancel = Gtk.Template.Child()
 
@@ -83,6 +84,8 @@ class GamescopeDialog(Adw.Window):
 
         self.toggle_borderless.handler_unblock_by_func(self.__change_wtype)
         self.toggle_fullscreen.handler_unblock_by_func(self.__change_wtype)
+        
+        self.advanced_options.set_text(parameters.gamescope_advanced)
 
     def __idle_save(self, *_args):
         settings = {
@@ -95,6 +98,7 @@ class GamescopeDialog(Adw.Window):
             "gamescope_scaling": self.switch_scaling.get_active(),
             "gamescope_borderless": self.toggle_borderless.get_active(),
             "gamescope_fullscreen": self.toggle_fullscreen.get_active(),
+            "gamescope_advanced": self.advanced_options.get_text(),
         }
 
         for setting in settings.keys():


### PR DESCRIPTION
# Description
I use gamescope on a few games, to force them into specific resolutions/windows. Sometimes I needed some extra flags, e.g. ```--force-grab-cursor```, to get them to correctly work. As I saw no option in bottles for this, I decided to add a simple text box that allows extra flags to be appended to the gamescope command.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I've played a few different games with the ```--force-grab-cursor``` flag inputted into the box. They ran as expected, with the extra flag applied.