### PR TITLE
Revert "Remove NVIDIA Flatpak Workaround"

### DIFF
--- a/bottles/backend/utils/vulkan.py
+++ b/bottles/backend/utils/vulkan.py
@@ -19,6 +19,7 @@ import os
 from glob import glob
 import shutil
 import subprocess
+import filecmp
 
 
 class VulkanUtils:
@@ -45,7 +46,17 @@ class VulkanUtils:
 
             for file in _files:
                 if "nvidia" in file.lower():
-                    loaders["nvidia"] += [file]
+                    # Workaround for nvidia flatpak bug: https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/112
+                    should_skip = False
+                    for nvidia_loader in loaders["nvidia"]:
+                        try:
+                            if filecmp.cmp(nvidia_loader, file):
+                                should_skip = True
+                                continue
+                        except:
+                            pass
+                    if not should_skip:
+                        loaders["nvidia"] += [file]
                 elif "amd" in file.lower() or "radeon" in file.lower():
                     loaders["amd"] += [file]
                 elif "intel" in file.lower():


### PR DESCRIPTION
# Description
This reverts commit 5fcd13efe174a9512e9e67b7462aa2f648e170cf  (#3726).

The NVIDIA Flatpak driver has reverted its GL32 extension changes (flathub/org.freedesktop.Platform.GL.nvidia#350) which in turn requires the original workaround from 5627b5b7cc5ad2666391daf5db0c8a707af14c7f.

Other references: flathub/org.freedesktop.Platform.GL.nvidia#112 and flathub/org.freedesktop.Platform.GL.nvidia#331

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
In the debug information, under `Graphics -> vendors -> nvidia -> icd`, there will be a list of Vulkan `.json` files.
- [X] Using the latest version of `Bottles` from Flathub shows only the `x86_64` file
- [X] Using my branch's build of `Bottles` **still** shows only the `x86_64` file
