### PR TITLE
Add `StartupWMClass` to the desktop file

### DIFF
--- a/data/com.usebottles.bottles.desktop.in.in
+++ b/data/com.usebottles.bottles.desktop.in.in
@@ -2,6 +2,7 @@
 Name=@APP_NAME@
 Comment=Run Windows software
 Icon=@APP_ID@
+StartupWMClass=@APP_ID@
 Exec=bottles %u
 TryExec=bottles
 Terminal=false


### PR DESCRIPTION
# Description

This should resolve any edge-cases where icon is not shown in Gnome's dash or in other desktop environments, in case there is a regression in compositor recognizing `wmclass` through the desktop filename.

So it's more bulletproof, while not introducing any regressions.

It also respects XDG desktop standards:  
https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html

Fixes #(issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Rename the desktop file to be something else than `$StartupWMClass.desktop`
- Open the app
- Observe that icon in Gnome's dash is just a generic icon
- With `StartupWMClass` modification, this issue is gone