### PR TITLE
fix(steam): load BottleConfig from bottle.yml if it exists

### DIFF
--- a/bottles/backend/managers/steam.py
+++ b/bottles/backend/managers/steam.py
@@ -327,7 +327,20 @@ class SteamManager:
                 )
                 continue
 
-            _conf = BottleConfig()
+            _bottle_yml = os.path.join(Paths.steam, _dir_name, "bottle.yml")
+
+            if os.path.isfile(_bottle_yml):
+                _bottle_load = BottleConfig.load(_bottle_yml)
+                if _bottle_load.status and _bottle_load.data:
+                    _conf = _bottle_load.data
+                else:
+                    logging.warning(
+                        f"Failed to load BottleConfig from {_bottle_yml}, creating a new one"
+                    )
+                    _conf = BottleConfig()
+            else:
+                _conf = BottleConfig()
+
             _conf.Name = _acf["AppState"].get("name", "Unknown")
             _conf.Environment = "Steam"
             _conf.CompatData = _dir_name


### PR DESCRIPTION
# Description

> Please include a summary of the change and which issue is fixed (if available).

This PR updates the `list_prefixes` method in `steam.py` to load `BottleConfig` from an existing `bottle.yml` file, if present. This preserves user-defined configuration.

> Please also include relevant motivation and context.

Previously, when adding a shortcut (e.g., a modloader `.exe`) to a Steam prefix, the shortcut would be removed on restart. Investigation showed that the configuration file (`bottle.yml`) was always overwritten at startup, discarding user changes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
> Please describe the tests that you ran to verify your changes.
> Provide instructions so we can reproduce.

1. Launch Bottles
2. Open a Steam prefix
3. Add a shortcut to any `.exe` file
4. Confirm that `~/.var/app/com.usebottles.bottles.Devel/data/bottles/steam/<id>/bottle.yml` reflects the new shortcut
5. Close and relaunch Bottles
6. Verify the result:
    - **Before**: The shortcut disappeared on relaunch.
    - **After**: The shortcut remains after relaunch, confirming the config was preserved.
