### PR TITLE
Add support for the Dynamic Launcher portal

### DIFF
--- a/bottles/backend/managers/installer.py
+++ b/bottles/backend/managers/installer.py
@@ -478,7 +478,7 @@ class InstallerManager:
         # create Desktop entry
         bottles_icons_path = os.path.join(ManagerUtils.get_bottle_path(config), "icons")
         icon_path = os.path.join(bottles_icons_path, executable.get("icon"))
-        ManagerUtils.create_desktop_entry(_config, _program, False, icon_path)
+        ManagerUtils.create_desktop_entry(_config, _program, False, icon_path, True)
 
         if is_final:
             step_fn()

--- a/bottles/backend/utils/imagemagick.py
+++ b/bottles/backend/utils/imagemagick.py
@@ -85,4 +85,4 @@ class ImageMagickUtils:
             cmd += " -flatten"
 
         cmd += f" '{dest}'"
-        subprocess.Popen(["bash", "-c", cmd])
+        subprocess.run(["bash", "-c", cmd])

--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -23,6 +23,8 @@ from glob import glob
 
 import icoextract  # type: ignore [import-untyped]
 
+from bottles.backend.params import APP_ID
+
 from bottles.backend.globals import Paths
 from bottles.backend.logger import Logger
 from bottles.backend.models.config import BottleConfig
@@ -30,6 +32,11 @@ from bottles.backend.models.result import Result
 from bottles.backend.state import SignalManager, Signals
 from bottles.backend.utils.generic import get_mime
 from bottles.backend.utils.imagemagick import ImageMagickUtils
+
+import uuid
+from gi.repository import GLib, Gio, Gtk, Xdp, XdpGtk4
+
+portal = Xdp.Portal()
 
 logging = Logger()
 
@@ -210,6 +217,7 @@ class ManagerUtils:
         skip_icon: bool = False,
         custom_icon: str = "",
         use_xdp: bool = False,
+        window: Gtk.Window = None,
     ) -> bool:
         if not os.path.exists(Paths.applications) and not use_xdp:
             return False
@@ -265,41 +273,49 @@ class ManagerUtils:
                 f.write(f"Exec={cmd_legacy} -b '{config.get('Name')}'\n")
 
             return True
-        '''
-        WIP: the following code is not working yet, it raises an error:
-             GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod
-        import uuid
-        from gi.repository import Gio, Xdp
 
-        portal = Xdp.Portal()
+        def prepare_install_cb (self, result):
+            ret = portal.dynamic_launcher_prepare_install_finish(result)
+            id = f"{config.get('Name')}.{program.get('name')}"
+            sum_type = GLib.ChecksumType.SHA1
+            exec = "bottles-cli run -p {} -b '{}' -- %u".format(
+                shlex.quote(program.get('name')), config.get('Name')
+            )
+            portal.dynamic_launcher_install(
+                ret["token"],
+                "{}.App_{}.desktop".format(
+                    APP_ID, GLib.compute_checksum_for_string(sum_type, id, -1)
+                ),
+                """[Desktop Entry]
+                Exec={}
+                Type=Application
+                Terminal=false
+                Categories=Application;
+                Comment=Launch {} using Bottles.
+                StartupWMClass={}""".format(
+                    exec, program.get("name"), program.get("name")
+                )
+                #TODO: Desktop Actions Configure missing
+                #[Desktop Action Configure]
+                #Name=Configure in Bottles
+                #Exec={}
+            )
+        #TODO: Require xdp>=1.20.1
         if icon == "com.usebottles.bottles-program":
-            _icon = Gio.BytesIcon.new(icon.encode("utf-8"))
+            icon += ".svg"
+            _icon = Gio.File.new_for_uri(
+                f"resource:/com/usebottles/bottles/icons/scalable/apps/{icon}"
+            )
         else:
-            _icon = Gio.FileIcon.new(Gio.File.new_for_path(icon))
-        icon_v = _icon.serialize()
-        token = portal.dynamic_launcher_request_install_token(program.get("name"), icon_v)
-        portal.dynamic_launcher_install(
-            token,
-            f"com.usebottles.bottles.{config.get('Name')}.{program.get('name')}.{str(uuid.uuid4())}.desktop",
-            """
-            [Desktop Entry]
-            Exec={}
-            Type=Application
-            Terminal=false
-            Categories=Application;
-            Comment=Launch {} using Bottles.
-            Actions=Configure;
-            [Desktop Action Configure]
-            Name=Configure in Bottles
-            Exec={}
-            """.format(
-                f"{cmd_cli} run -p {shlex.quote(program.get('name'))} -b '{config.get('Path')}'",
-                program.get("name"),
-                f"{cmd_legacy} -b '{config.get('Name')}'"
-            ).encode("utf-8")
-        )
-        '''
-        return False
+            _icon = Gio.File.new_for_path(icon)
+        icon_v = Gio.BytesIcon.new(_icon.load_bytes()[0]).serialize()
+        portal.dynamic_launcher_prepare_install(XdpGtk4.parent_new_gtk(window),
+                                                program.get("name"), icon_v,
+                                                Xdp.LauncherType.APPLICATION,
+                                                None, True, False, None,
+                                                prepare_install_cb)
+        #TODO: Rework to delay showing the toast
+        return True
 
     @staticmethod
     def browse_wineprefix(wineprefix: dict):

--- a/bottles/frontend/program_row.py
+++ b/bottles/frontend/program_row.py
@@ -306,6 +306,8 @@ class ProgramRow(Adw.ActionRow):
                 "executable": self.program["executable"],
                 "path": self.program["path"],
             },
+            use_xdp=True,
+            window=self.window,
         )
 
     def add_to_library(self, _widget):

--- a/data/data.gresource.xml.in
+++ b/data/data.gresource.xml.in
@@ -3,6 +3,9 @@
   <gresource prefix="/com/usebottles/bottles">
     <file preprocess="xml-stripblanks" alias="appdata">@APP_ID@.metainfo.xml</file>
   </gresource>
+  <gresource prefix="/com/usebottles/bottles/icons/scalable/apps">
+    <file preprocess="xml-stripblanks" alias="com.usebottles.bottles-program.svg">icons/hicolor/scalable/apps/com.usebottles.bottles-program.svg</file>
+  </gresource>
   <gresource prefix="/com/usebottles/bottles/icons/scalable/actions">
     <file preprocess="xml-stripblanks" alias="bottles-steam-symbolic.svg">icons/hicolor/symbolic/apps/bottles-steam-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="external-link-symbolic.svg">icons/hicolor/symbolic/actions/external-link-symbolic.svg</file>


### PR DESCRIPTION
# Description
This adds support for the xdg-desktop-portal [dynamic launcher portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.DynamicLauncher.html), that will allow to install desktop files without the need for manually giving permission with a command or Flatseal. Upon clicking the `Add Desktop Entry` option of a wine installed application, the portal will open a dialog where the user can see the app icon, can change the name and confirm or cancel.

Screenshots:

![Screenshot From 2025-06-13 14-28-31](https://github.com/user-attachments/assets/fa500025-33cd-49ba-8986-052f8afaffa7)
![Screenshot From 2025-06-13 14-29-37](https://github.com/user-attachments/assets/3b7028d5-b3a9-485d-8798-f25332745e52)

What's missing:
- [ ] Support for [Desktop Action Configure] group in the .desktop file, currently the portal requires exactly one group in the .desktop file for security reasons
- [ ] Requiring xdg-desktop-portal version >= 1.20.1, otherwise doesn't work due to https://github.com/flatpak/xdg-desktop-portal/issues/1674
- [ ] Rework to delay showing the toast

Fixes https://github.com/bottlesdevs/Bottles/issues/1366

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Unfortunately, I only managed to test installing the desktop file itself, as I get an error when trying to run apps from the desktop files on main as well:
```
(process:2): GLib-GIO-ERROR **: 15:52:04.166: Settings schema 'com.usebottles.bottles.Devel' is not installed
```
But the created desktop files are otherwise almost identical to the ones from main (bar the configure action) and show up in the app grid just fine \o/