### PR TITLE
Jetbrains logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Due to GNOME Builder limitations, Builder cannot build Bottles for the time bein
 This project follows the [GNOME Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct). You are expected to follow it in all Bottles spaces, such as this repository, the project's social media, messenger chats and forums. Bigotry and harassment will not be tolerated.
 
 ## Sponsors
-<a href="https://www.jetbrains.com/?from=bottles"><img height="55" src="https://unifiedban.solutions/static/images/jetbrains-logos/jetbrains.png" /></a>&nbsp;&nbsp;&nbsp;
+<a href="https://www.jetbrains.com/?from=bottles"><img height="55" src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png" /></a>&nbsp;&nbsp;&nbsp;
 <a href="https://www.gitbook.com/?ref=bottles"><img height="55" src="https://www.gitbook.com/cdn-cgi/image/height=55,fit=contain,dpr=1,format=auto/https%3A%2F%2F2775338190-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FNkEGS7hzeqa35sMXQZ4X%252Flogo%252FTO5E3RjWKeaJmYYWMGWV%252Fspaces_gitbook_avatar-rectangle.png%3Falt%3Dmedia%26token%3Da34e957e-f044-4bee-abee-23946d2e9cfb" /></a>&nbsp;&nbsp;&nbsp;
 <a href="https://www.linode.com/?from=bottles"><img height="48" src="https://usebottles.com/uploads/linode-brand.png" /></a>&nbsp;&nbsp;&nbsp;
 <a href="https://appwrite.io?from=bottles"><img height="48" src="https://usebottles.com/uploads/built-with-appwrite.svg" /></a>

--- a/README.md
+++ b/README.md
@@ -71,8 +71,25 @@ Due to GNOME Builder limitations, Builder cannot build Bottles for the time bein
 This project follows the [GNOME Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct). You are expected to follow it in all Bottles spaces, such as this repository, the project's social media, messenger chats and forums. Bigotry and harassment will not be tolerated.
 
 ## Sponsors
-<a href="https://www.jetbrains.com/?from=bottles"><img height="55" src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png" /></a>&nbsp;&nbsp;&nbsp;
-<a href="https://www.gitbook.com/?ref=bottles"><img height="55" src="https://www.gitbook.com/cdn-cgi/image/height=55,fit=contain,dpr=1,format=auto/https%3A%2F%2F2775338190-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FNkEGS7hzeqa35sMXQZ4X%252Flogo%252FTO5E3RjWKeaJmYYWMGWV%252Fspaces_gitbook_avatar-rectangle.png%3Falt%3Dmedia%26token%3Da34e957e-f044-4bee-abee-23946d2e9cfb" /></a>&nbsp;&nbsp;&nbsp;
-<a href="https://www.linode.com/?from=bottles"><img height="48" src="https://usebottles.com/uploads/linode-brand.png" /></a>&nbsp;&nbsp;&nbsp;
-<a href="https://appwrite.io?from=bottles"><img height="48" src="https://usebottles.com/uploads/built-with-appwrite.svg" /></a>
-<a href="https://hyperbit.it?from=bottles"><img height="48" src="https://hyperbit.it-mil-1.linodeobjects.com/assets/full_dark_logo/HyperBit_Dark_Extended_Logo.png"/></a>
+
+<p align="center">
+  <a href="https://www.jetbrains.com/?from=bottles">
+    <img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png" width="200" />
+  </a>
+  <br><br>
+  <a href="https://www.gitbook.com/?ref=bottles">
+    <img src="https://www.gitbook.com/cdn-cgi/image/height=55,fit=contain,dpr=1,format=auto/https%3A%2F%2F2775338190-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FNkEGS7hzeqa35sMXQZ4X%252Flogo%252FTO5E3RjWKeaJmYYWMGWV%252Fspaces_gitbook_avatar-rectangle.png%3Falt%3Dmedia%26token%3Da34e957e-f044-4bee-abee-23946d2e9cfb" width="200" />
+  </a>
+  <br><br>
+  <a href="https://www.linode.com/?from=bottles">
+    <img src="https://usebottles.com/uploads/linode-brand.png" width="200" />
+  </a>
+  <br><br>
+  <a href="https://appwrite.io?from=bottles">
+    <img src="https://usebottles.com/uploads/built-with-appwrite.svg" width="200" />
+  </a>
+  <br>
+  <a href="https://hyperbit.it?from=bottles">
+    <img src="https://hyperbit.it-mil-1.linodeobjects.com/assets/full_dark_logo/HyperBit_Dark_Extended_Logo.png" width="200" />
+  </a>
+</p>


### PR DESCRIPTION
# Description
This pull request updates the sponsors section in the README.
It fixes the broken JetBrains logo link by replacing it with the official one and changes the layout to a centered, vertical format with consistent logo sizes for improved visual clarity and alignment.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Verified that the JetBrains logo now displays correctly in the sponsors section.
- Checked the README preview on GitHub to confirm that all sponsor logos are centered, evenly sized, and visually consistent on both a Full HD screen and a mobile phone.

# Before:
![Screenshot From 2025-07-05 13-06-44](https://github.com/user-attachments/assets/779a179b-a758-483e-baac-f6ad6de985a4)

# After:
![Screenshot From 2025-07-05 13-07-13](https://github.com/user-attachments/assets/560b8fd9-7b66-414b-8af2-70c349c55deb)

