### PR TITLE
Fix delete bottle not removing placeholder folder

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -1544,11 +1544,11 @@ class Manager(metaclass=Singleton):
                 library_manager.remove_from_library(_uuid)
 
         if config.Custom_Path:
-            logging.info("Removing placeholder…")
+            logging.info("Removing placeholder folder…")
             with contextlib.suppress(FileNotFoundError):
-                os.remove(
+                shutil.rmtree(
                     os.path.join(
-                        Paths.bottles, os.path.basename(config.Path), "placeholder.yml"
+                        Paths.bottles, os.path.basename(config.Path)
                     )
                 )
 


### PR DESCRIPTION
Fixes #3912  

When deleting bottles with custom paths delete bottle doesn't remove the placeholder folder thus when we try to create a bottle with the same name in the same custom path it results in an error.

![image](https://github.com/user-attachments/assets/2779c15a-0075-40f2-9f52-6e8d1f618c10)

With this fix the whole placeholder folder is removed and the bug is no longer present.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
