### PR TITLE
Updating "ga.po" for Direct3D

### DIFF
--- a/po/ga.po
+++ b/po/ga.po
@@ -650,8 +650,8 @@ msgid "DXVK"
 msgstr "DXVK"
 
 #: bottles/frontend/ui/details-preferences.blp:28
-msgid "Improve Direct3D 9/10/11 compatibility by translating it to Vulkan."
-msgstr "Comhoiriúnacht Direct3D 9/10/11 a fheabhsú trína aistriú go Vulkan."
+msgid "Improve Direct3D 8/9/10/11 compatibility by translating it to Vulkan."
+msgstr "Comhoiriúnacht Direct3D 8/9/10/11 a fheabhsú trína aistriú go Vulkan."
 
 #: bottles/frontend/ui/details-preferences.blp:30
 msgid "Updating DXVK, please wait…"


### PR DESCRIPTION
The file "ga.po" was updated to add "8" to "Direct3D 9/10/11" so that "Direct3D 8/9/10/11" is stated.
