### PR TITLE
fix: invalid method call when changing the "update-date" preference

### DIFF
--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -210,7 +210,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             Adw.StyleManager.get_default().set_color_scheme(Adw.ColorScheme.DEFAULT)
 
     def __toggle_update_date(self, widget, state):
-        self.window.page_list.update_bottles()
+        self.window.page_list.update_bottles_list()
 
     def __toggle_rc(self, widget, state):
         self.ui_update()


### PR DESCRIPTION
# Description
In the preferences view, the handler for the `changed::update-date` signal called an unknown method `update_bottles()`. This method appears to have been renamed to `update_bottles_list()`, so this might be an oversight during a refactor.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By building and running the flatpak locally, toggling  the "Show update date" preference on and off, and verifying that the update date is toggled correctly in the bottles list and that no `AttributeError` is raised.
