### PR TITLE
chore: Ensure SandboxManager always enables sandbox

### DIFF
--- a/bottles/backend/managers/sandbox.py
+++ b/bottles/backend/managers/sandbox.py
@@ -95,13 +95,12 @@ class SandboxManager:
         return _cmd
 
     def __get_flatpak_spawn(self, cmd: str):
-        _cmd = ["flatpak-spawn"]
+        _cmd = ["flatpak-spawn", "--sandbox"]
 
         if self.envs:
             _cmd += [f"--env={k}={shlex.quote(v)}" for k, v in self.envs.items()]
 
         if self.share_host_ro:
-            _cmd.append("--sandbox")
             _cmd.append("--sandbox-expose-path-ro=/")
 
         if self.chdir:


### PR DESCRIPTION
# Description

This patch should have no effect at runtime, because `share_host_ro` is hard coded as `True`. However, it should remove a footgun.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- Connect a game controller
- Build and run
  ```
  flatpak-builder --install --user --force-clean ./.flatpak-builder/out ./build-aux/com.usebottles.bottles.Dev
  flatpak run com.usebottles.bottles.Devel
  ```
- Enabable "Preferences > Experiments > Sandbox per bottle".
- In a Bottle **disable** "Settings > Dedicated Sandbox"
  - Go to "Legacy Wine Tools > Control Panel > Game Controllers > DInput".
  - Observe how the controller works. => sandbox off
- In a Bottle **enable** "Settings > Dedicated Sandbox"
  - Go to "Legacy Wine Tools > Control Panel > Game Controllers > DInput".
  - Observe how the controller does not work. => sandbox on
  
