### PR TITLE
fix[closes #3261]: align appstream gettext domain

### DIFF
--- a/bottles/frontend/bottles.py
+++ b/bottles/frontend/bottles.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     from bottles.frontend.utils.localization import apply_ui_language
 
     apply_ui_language(Gio.Settings.new(APP_ID).get_string("ui-language"))
-    gettext.install("bottles", localedir)
+    gettext.install("com.usebottles.bottles", localedir)
 
     data_resource = Gio.Resource.load(data_gresource_path)
     bottles_resource = Gio.Resource.load(bottles_gresource_path)

--- a/bottles/frontend/main.py
+++ b/bottles/frontend/main.py
@@ -72,10 +72,10 @@ locale_dir = path.join(share_dir, "locale")
 if not path.exists(locale_dir):  # development
     locale_dir = path.join(base_dir, "build", "mo")
 
-locale.bindtextdomain("bottles", locale_dir)
-locale.textdomain("bottles")
-gettext.bindtextdomain("bottles", locale_dir)
-gettext.textdomain("bottles")
+locale.bindtextdomain("com.usebottles.bottles", locale_dir)
+locale.textdomain("com.usebottles.bottles")
+gettext.bindtextdomain("com.usebottles.bottles", locale_dir)
+gettext.textdomain("com.usebottles.bottles")
 _ = gettext.gettext
 
 

--- a/data/com.usebottles.bottles.gschema.xml
+++ b/data/com.usebottles.bottles.gschema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schemalist gettext-domain="bottles">
+<schemalist gettext-domain="com.usebottles.bottles">
 	<schema id="@APP_ID@" path="/com/usebottles/bottles/">
     <key type="b" name="flatpak-migration">
       <default>true</default>

--- a/data/com.usebottles.bottles.metainfo.xml.in.in
+++ b/data/com.usebottles.bottles.metainfo.xml.in.in
@@ -67,7 +67,7 @@
       <caption>Installers Page</caption>
     </screenshot>
   </screenshots>
-  <translation type="gettext">@APP_ID@</translation>
+  <translation type="gettext">bottles</translation>
   <content_rating type="oars-1.1"/>
   <url type="homepage">https://usebottles.com</url>
   <url type="bugtracker">https://github.com/bottlesdevs/Bottles/issues</url>

--- a/data/com.usebottles.bottles.metainfo.xml.in.in
+++ b/data/com.usebottles.bottles.metainfo.xml.in.in
@@ -67,7 +67,7 @@
       <caption>Installers Page</caption>
     </screenshot>
   </screenshots>
-  <translation type="gettext">bottles</translation>
+  <translation type="gettext">com.usebottles.bottles</translation>
   <content_rating type="oars-1.1"/>
   <url type="homepage">https://usebottles.com</url>
   <url type="bugtracker">https://github.com/bottlesdevs/Bottles/issues</url>

--- a/po/meson.build
+++ b/po/meson.build
@@ -9,7 +9,7 @@ language_list = fs.read('LINGUAS').strip().split('\n')
 language_list += ['zh_CN', 'zh_HK', 'zh_SG', 'zh_TW']
 
 i18n.gettext(
-	'bottles',
+	'com.usebottles.bottles',
 	install_dir: localedir,
 	preset: 'glib',
 	args: '--from-code=UTF-8',


### PR DESCRIPTION
Reopening of #3261

# Description

The RDNN was specified in appstream data, but the application was using just the application name.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
