### PR TITLE
Add minimal playtime tracking frontend

### DIFF
--- a/bottles/frontend/utils/meson.build
+++ b/bottles/frontend/utils/meson.build
@@ -6,6 +6,7 @@ bottles_sources = [
   'gtk.py',
   'common.py',
   'filters.py',
+  'playtime.py',
   'sh.py',
 ]
 

--- a/bottles/frontend/utils/playtime.py
+++ b/bottles/frontend/utils/playtime.py
@@ -1,0 +1,356 @@
+# playtime.py
+#
+# Copyright 2025 Bottles Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Playtime frontend service: retrieval, caching, and formatting of playtime data.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from gettext import gettext as _
+from typing import Dict, Optional, Tuple
+
+from gi.repository import GLib
+
+from bottles.backend.logger import Logger
+from bottles.backend.managers.playtime import _compute_program_id
+
+
+logging = Logger()
+
+
+@dataclass(frozen=True)
+class PlaytimeRecord:
+    """Aggregated playtime data for a program or bottle."""
+
+    bottle_id: str
+    program_id: Optional[str]
+    program_name: str
+    program_path: Optional[str]
+    total_seconds: int
+    sessions_count: int
+    last_played: Optional[datetime]
+
+
+class PlaytimeCache:
+    """Simple in-memory cache with TTL and manual invalidation."""
+
+    def __init__(self, ttl_seconds: int = 30):
+        self.ttl_seconds = ttl_seconds
+        self._cache: Dict[Tuple[str, str], Tuple[PlaytimeRecord, float]] = {}
+
+    def get(self, bottle_id: str, program_id: str) -> Optional[PlaytimeRecord]:
+        key = (bottle_id, program_id)
+        if key in self._cache:
+            record, timestamp = self._cache[key]
+            if time.time() - timestamp < self.ttl_seconds:
+                logging.debug(
+                    f"Playtime cache hit: bottle={bottle_id} program_id={program_id}"
+                )
+                return record
+            else:
+                del self._cache[key]
+                logging.debug(
+                    f"Playtime cache expired: bottle={bottle_id} program_id={program_id}"
+                )
+        return None
+
+    def set(self, bottle_id: str, program_id: str, record: PlaytimeRecord) -> None:
+        key = (bottle_id, program_id)
+        self._cache[key] = (record, time.time())
+        logging.debug(f"Playtime cache set: bottle={bottle_id} program_id={program_id}")
+
+    def invalidate(self, bottle_id: str, program_id: str) -> None:
+        key = (bottle_id, program_id)
+        if key in self._cache:
+            del self._cache[key]
+            logging.debug(
+                f"Playtime cache invalidated: bottle={bottle_id} program_id={program_id}"
+            )
+
+    def clear(self) -> None:
+        self._cache.clear()
+        logging.debug("Playtime cache cleared")
+
+
+class PlaytimeService:
+    """
+    Frontend service for accessing and formatting playtime data.
+
+    Provides caching, retrieval, and human-readable formatting for playtime metrics.
+    """
+
+    def __init__(self, manager):
+        """
+        Initialize the playtime service.
+
+        Args:
+            manager: The Manager instance with playtime_tracker attribute.
+        """
+        self.manager = manager
+        self.cache = PlaytimeCache(ttl_seconds=30)
+
+    def is_enabled(self) -> bool:
+        """Check if playtime tracking is currently enabled."""
+        try:
+            return self.manager.playtime_tracker.enabled
+        except AttributeError:
+            return False
+
+    def get_program_playtime(
+        self, bottle_id: str, bottle_path: str, program_name: str, program_path: str
+    ) -> Optional[PlaytimeRecord]:
+        """
+        Retrieve playtime data for a specific program.
+
+        Args:
+            bottle_id: The bottle identifier.
+            bottle_path: The bottle's full path (for path normalization).
+            program_name: The program display name.
+            program_path: The program executable path (used to compute program_id).
+
+        Returns:
+            PlaytimeRecord if data exists, None otherwise.
+        """
+        if not self.is_enabled():
+            logging.debug("Playtime service: tracking disabled")
+            return None
+
+        program_id = _compute_program_id(bottle_id, bottle_path, program_path)
+        logging.debug(
+            f"Computed program_id: {program_id} for bottle={bottle_id}, path={program_path}"
+        )
+
+        # Check cache first
+        cached = self.cache.get(bottle_id, program_id)
+        if cached is not None:
+            return cached
+
+        # Fetch from backend
+        try:
+            logging.debug(
+                f"Calling backend get_totals(bottle_id={bottle_id}, program_id={program_id})"
+            )
+            data = self.manager.playtime_tracker.get_totals(bottle_id, program_id)
+            logging.debug(f"Backend returned: {data}")
+            if data is None:
+                logging.debug(f"No playtime data found for {program_name}")
+                return None
+
+            record = PlaytimeRecord(
+                bottle_id=data["bottle_id"],
+                program_id=data["program_id"],
+                program_name=data["program_name"],
+                program_path=data.get("program_path"),
+                total_seconds=data["total_seconds"],
+                sessions_count=data["sessions_count"],
+                last_played=(
+                    datetime.fromtimestamp(data["last_played"])
+                    if data["last_played"] is not None
+                    else None
+                ),
+            )
+            logging.debug(f"Created record: {record}")
+            self.cache.set(bottle_id, program_id, record)
+            return record
+        except Exception as e:
+            logging.error(f"Failed to fetch playtime for {program_name}: {e}", exc=e)
+            return None
+
+    def get_bottle_playtime(self, bottle_id: str) -> Optional[PlaytimeRecord]:
+        """
+        Retrieve aggregated playtime data for an entire bottle.
+
+        Aggregates all programs within the bottle client-side.
+
+        Args:
+            bottle_id: The bottle identifier.
+
+        Returns:
+            PlaytimeRecord with aggregated totals, or None if no data.
+        """
+        if not self.is_enabled():
+            return None
+
+        try:
+            programs = self.manager.playtime_tracker.get_all_program_totals(bottle_id)
+            if not programs:
+                return None
+
+            total_seconds = sum(p["total_seconds"] for p in programs)
+            total_sessions = sum(p["sessions_count"] for p in programs)
+            last_played_timestamps = [
+                p["last_played"] for p in programs if p["last_played"] is not None
+            ]
+            last_played = (
+                datetime.fromtimestamp(max(last_played_timestamps))
+                if last_played_timestamps
+                else None
+            )
+
+            # Use first program's bottle_name if available
+            bottle_name = (
+                programs[0].get("bottle_name", bottle_id) if programs else bottle_id
+            )
+
+            return PlaytimeRecord(
+                bottle_id=bottle_id,
+                program_id=None,
+                program_name=bottle_name,
+                program_path=None,
+                total_seconds=total_seconds,
+                sessions_count=total_sessions,
+                last_played=last_played,
+            )
+        except Exception as e:
+            logging.error(
+                f"Failed to aggregate bottle playtime for {bottle_id}: {e}", exc=e
+            )
+            return None
+
+    def invalidate_program(
+        self, bottle_id: str, bottle_path: str, program_path: str
+    ) -> None:
+        """
+        Invalidate cached data for a specific program.
+
+        Args:
+            bottle_id: The bottle identifier.
+            bottle_path: The bottle's full path (for path normalization).
+            program_path: The program executable path.
+        """
+        program_id = _compute_program_id(bottle_id, bottle_path, program_path)
+        self.cache.invalidate(bottle_id, program_id)
+
+    def invalidate_cache(self) -> None:
+        """
+        Clear all cached playtime data.
+
+        Use this when you need to force a refresh of all playtime displays,
+        such as after a program finishes running.
+        """
+        self.cache.clear()
+
+    @staticmethod
+    def format_playtime(total_seconds: int) -> str:
+        """
+        Format playtime duration in human-readable form.
+
+        Uses Python's timedelta for proper time formatting.
+
+        Rules:
+        - < 60s: "<1m"
+        - < 3600s: "MMm"
+        - < 86400s: "Hh MMm"
+        - >= 86400s: "Dd HHh"
+
+        Args:
+            total_seconds: Total accumulated playtime in seconds.
+
+        Returns:
+            Formatted string.
+        """
+        if total_seconds < 60:
+            return "<1m"
+
+        td = timedelta(seconds=total_seconds)
+
+        if total_seconds < 3600:
+            # Less than an hour: show minutes only
+            minutes = td.seconds // 60
+            return f"{minutes}m"
+        elif total_seconds < 86400:
+            # Less than a day: show hours and minutes
+            hours = td.seconds // 3600
+            minutes = (td.seconds % 3600) // 60
+            return f"{hours}h {minutes:02d}m"
+        else:
+            # A day or more: show days and hours
+            days = td.days
+            hours = td.seconds // 3600
+            return f"{days}d {hours:02d}h"
+
+    @staticmethod
+    def format_last_played(last_played: Optional[datetime]) -> str:
+        """
+        Format last played timestamp in human-readable form.
+
+        Rules:
+        - None: "Never"
+        - Today: "Today"
+        - Yesterday: "Yesterday"
+        - < 7 days: "N days ago"
+        - Else: locale-aware date format
+
+        Args:
+            last_played: The datetime of last play session, or None.
+
+        Returns:
+            Formatted string.
+        """
+        if last_played is None:
+            return _("Never")
+
+        now = datetime.now()
+        delta = now - last_played
+
+        # Same day
+        if last_played.date() == now.date():
+            return _("Today")
+
+        # Yesterday
+        if last_played.date() == (now - timedelta(days=1)).date():
+            return _("Yesterday")
+
+        # Within last 7 days
+        if delta.days < 7:
+            # Translators: %d is the number of days
+            return _("%d days ago") % delta.days
+
+        # Older - use locale-aware format
+        # Use locale's default date format via strftime with %x
+        return last_played.strftime("%x")
+
+    def format_subtitle(self, record: Optional[PlaytimeRecord]) -> str:
+        """
+        Generate a formatted subtitle string for display.
+
+        Args:
+            record: The playtime record, or None.
+
+        Returns:
+            Formatted subtitle like "Last Played: Today – Playtime: 1h 23m"
+            or "Never Played" if no data.
+        """
+        if record is None or record.sessions_count == 0:
+            return _("Never Played")
+
+        last_played_str = self.format_last_played(record.last_played)
+        playtime_str = self.format_playtime(record.total_seconds)
+
+        # Escape for Pango markup to handle characters like < and >
+        last_played_escaped = GLib.markup_escape_text(last_played_str)
+        playtime_escaped = GLib.markup_escape_text(playtime_str)
+
+        # Translators: %s placeholders are for date and playtime duration
+        return _("Last Played: %s – Playtime: %s") % (
+            last_played_escaped,
+            playtime_escaped,
+        )

--- a/bottles/frontend/widgets/program.py
+++ b/bottles/frontend/widgets/program.py
@@ -345,3 +345,32 @@ class ProgramEntry(Adw.ActionRow):
             program_name=self.program["name"],
             program_path=self.program["path"],
         )
+
+    def update_playtime(self, playtime_service):
+        """
+        Update the program subtitle with playtime information.
+        
+        Args:
+            playtime_service: Instance of PlaytimeService to fetch and format data.
+        """
+        if not playtime_service or not playtime_service.is_enabled():
+            return
+
+        program_path = self.program.get("path", "")
+        if not program_path:
+            return
+
+        try:
+            # Use bottle name as bottle_id, matching what backend uses
+            bottle_id = self.config.Name
+            bottle_path = self.config.Path
+            
+            record = playtime_service.get_program_playtime(
+                bottle_id, bottle_path, self.program["name"], program_path
+            )
+            subtitle = playtime_service.format_subtitle(record)
+            self.set_subtitle(subtitle)
+        except Exception as e:
+            from bottles.backend.logger import Logger
+            logging = Logger()
+            logging.error(f"Failed to update playtime for {self.program['name']}: {e}", exc=e)

--- a/bottles/tests/frontend/test_playtime_service.py
+++ b/bottles/tests/frontend/test_playtime_service.py
@@ -1,0 +1,101 @@
+"""Unit tests for playtime frontend service."""
+
+import tempfile
+from datetime import datetime, timedelta
+
+from bottles.backend.managers.playtime import ProcessSessionTracker
+from bottles.frontend.utils.playtime import PlaytimeService
+
+
+class MockManager:
+    """Mock manager for testing."""
+
+    def __init__(self, tracker):
+        self.playtime_tracker = tracker
+
+
+def test_format_playtime():
+    """Test playtime formatting rules."""
+    assert PlaytimeService.format_playtime(30) == "<1m"
+    assert PlaytimeService.format_playtime(60) == "1m"
+    assert PlaytimeService.format_playtime(150) == "2m"
+    assert PlaytimeService.format_playtime(3599) == "59m"
+    assert PlaytimeService.format_playtime(3600) == "1h 00m"
+    assert PlaytimeService.format_playtime(3660) == "1h 01m"
+    assert PlaytimeService.format_playtime(7325) == "2h 02m"
+    assert PlaytimeService.format_playtime(86400) == "1d 00h"
+    assert PlaytimeService.format_playtime(90000) == "1d 01h"
+    assert PlaytimeService.format_playtime(180000) == "2d 02h"
+
+
+def test_format_last_played():
+    """Test last played date formatting with i18n support."""
+    now = datetime.now()
+
+    # These now return translated strings, but we can still test the logic
+    result_none = PlaytimeService.format_last_played(None)
+    assert "never" in result_none.lower() or result_none == "Never"
+    
+    result_today = PlaytimeService.format_last_played(now)
+    assert "today" in result_today.lower() or result_today == "Today"
+    
+    result_yesterday = PlaytimeService.format_last_played(now - timedelta(days=1))
+    assert "yesterday" in result_yesterday.lower() or result_yesterday == "Yesterday"
+    
+    result_2days = PlaytimeService.format_last_played(now - timedelta(days=2))
+    assert "2" in result_2days and ("day" in result_2days.lower() or result_2days == "2 days ago")
+    
+    result_6days = PlaytimeService.format_last_played(now - timedelta(days=6))
+    assert "6" in result_6days and ("day" in result_6days.lower() or result_6days == "6 days ago")
+
+    # Old dates now use locale-aware format (%x)
+    old_date = now - timedelta(days=10)
+    result_old = PlaytimeService.format_last_played(old_date)
+    # Just verify it returns a non-empty string (format depends on locale)
+    assert len(result_old) > 0
+
+
+def test_format_subtitle_with_data():
+    """Test subtitle formatting with valid data and i18n."""
+    from bottles.frontend.utils.playtime import PlaytimeRecord
+
+    record = PlaytimeRecord(
+        bottle_id="b1",
+        program_id="p1",
+        program_name="Game",
+        program_path="/path",
+        total_seconds=7325,
+        sessions_count=3,
+        last_played=datetime.now(),
+    )
+
+    service = PlaytimeService(MockManager(None))
+    subtitle = service.format_subtitle(record)
+    # Verify it contains the key elements (i18n strings may vary)
+    assert "2h 02m" in subtitle  # Playtime format is not translated
+    # Just verify the subtitle has content
+    assert len(subtitle) > 10
+
+
+def test_format_subtitle_never_played():
+    """Test subtitle formatting with no data and i18n."""
+    service = PlaytimeService(MockManager(None))
+    result = service.format_subtitle(None)
+    # i18n string may vary, but should contain "never" and "played"
+    assert "never" in result.lower() or "played" in result.lower()
+
+
+def test_service_disabled_returns_none():
+    """Test that disabled service returns None."""
+    with tempfile.TemporaryDirectory() as tmp:
+        import os
+
+        db_path = os.path.join(tmp, "test.db")
+        tracker = ProcessSessionTracker(db_path=db_path, enabled=False)
+        manager = MockManager(tracker)
+        service = PlaytimeService(manager)
+
+        assert not service.is_enabled()
+        result = service.get_program_playtime("b1", "/bottle", "Game", "/path/game.exe")
+        assert result is None
+        tracker.shutdown()

--- a/test_path_normalization.py
+++ b/test_path_normalization.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Quick test to verify path normalization logic."""
+
+# Test the regex-based normalization
+def test_normalize_path():
+    import re
+    
+    test_cases = [
+        # (input_path, expected_output)
+        ("C:\\Program Files\\game.exe", "C:\\Program Files\\game.exe"),  # Already Windows
+        ("/var/home/user/.local/share/bottles/bottles/MyBottle/drive_c/Program Files/game.exe", "C:\\Program Files\\game.exe"),
+        ("/path/to/bottle/drive_d/Games/game.exe", "D:\\Games\\game.exe"),
+        ("/path/dosdevices/c:/windows/system32/cmd.exe", "C:\\windows\\system32\\cmd.exe"),
+        ("/path/dosdevices/e:/data/file.txt", "E:\\data\\file.txt"),
+    ]
+    
+    def normalize(program_path: str) -> str:
+        """Simplified version of _normalize_path_to_windows."""
+        # Already Windows format?
+        if ":" in program_path and "\\" in program_path:
+            return program_path
+        
+        # Convert Unix path to Windows format
+        if "/drive_" in program_path:
+            match = re.search(r"drive_([a-z])/(.+)", program_path)
+            if match:
+                drive = match.group(1).upper()
+                rest = match.group(2).replace("/", "\\")
+                return f"{drive}:\\{rest}"
+        elif "/dosdevices/" in program_path:
+            match = re.search(r"dosdevices/([a-z]):/(.+)", program_path)
+            if match:
+                drive = match.group(1).upper()
+                rest = match.group(2).replace("/", "\\")
+                return f"{drive}:\\{rest}"
+        
+        return program_path
+    
+    print("Testing path normalization:")
+    print("-" * 80)
+    
+    all_passed = True
+    for input_path, expected in test_cases:
+        result = normalize(input_path)
+        passed = result == expected
+        all_passed = all_passed and passed
+        
+        status = "✓ PASS" if passed else "✗ FAIL"
+        print(f"{status}")
+        print(f"  Input:    {input_path}")
+        print(f"  Expected: {expected}")
+        print(f"  Got:      {result}")
+        print()
+    
+    print("-" * 80)
+    if all_passed:
+        print("✓ All tests passed!")
+    else:
+        print("✗ Some tests failed!")
+    
+    return all_passed
+
+if __name__ == "__main__":
+    import sys
+    success = test_normalize_path()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Continues work from #4108

Feel free to change things around. My goal was to just make a minimal UI to surface these values and lay the groundwork for future enhancements.

<img width="930" height="690" alt="Captura de tela de 2025-11-07 13-15-37" src="https://github.com/user-attachments/assets/3b84f514-002e-48de-ba3d-5f8fee04fee9" />
