### PR TITLE
fix: don't override wine lib or gstreamer paths if using sys-wine

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -329,19 +329,20 @@ class WineCommand:
             ]
             gst_libs = ["lib/gstreamer-1.0", "lib32/gstreamer-1.0"]
 
-        for lib in runner_libs:
-            _path = os.path.join(runner_path, lib)
-            if os.path.exists(_path):
-                ld.append(_path)
+        if not config.Runner.startswith("sys-"):
+            for lib in runner_libs:
+                _path = os.path.join(runner_path, lib)
+                if os.path.exists(_path):
+                    ld.append(_path)
 
-        # Embedded GStreamer environment variables
-        if not env.has("BOTTLES_USE_SYSTEM_GSTREAMER") and not return_steam_env:
-            gst_env_path = []
-            for lib in gst_libs:
-                if os.path.exists(os.path.join(runner_path, lib)):
-                    gst_env_path.append(os.path.join(runner_path, lib))
-            if len(gst_env_path) > 0:
-                env.add("GST_PLUGIN_SYSTEM_PATH", ":".join(gst_env_path), override=True)
+            # Embedded GStreamer environment variables
+            if not env.has("BOTTLES_USE_SYSTEM_GSTREAMER") and not return_steam_env:
+                gst_env_path = []
+                for lib in gst_libs:
+                    if os.path.exists(os.path.join(runner_path, lib)):
+                        gst_env_path.append(os.path.join(runner_path, lib))
+                if len(gst_env_path) > 0:
+                    env.add("GST_PLUGIN_SYSTEM_PATH", ":".join(gst_env_path), override=True)
 
         # DXVK environment variables
         if params.dxvk and not return_steam_env:


### PR DESCRIPTION
# Description
I noticed that in the `get_env` function of winecommand.py, some environment variables will be set to an invalid path if the runner is set to sys-wine-*. The `runner_path` that is appended to the library paths in the function of  is set based on `runner_path = ManagerUtils.get_runner_path(config.Runner)`, but `ManagerUtils.get_runner_path(config.Runner)` does not return a valid path (instead just returning the runner name) if sys-wine-* is in use.

## Type of change
- [*] Bug fix