### PR TITLE
fix: incorrect gamescope installation command

### DIFF
--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -156,7 +156,7 @@ class PreferencesView(Adw.PreferencesPage):
             _not_available
         )
         self._install_commands = {
-            "gamescope": "flatpak install --user com.obsproject.Studio.Plugin.OBSVkCapture",
+            "gamescope": "flatpak install --user org.freedesktop.Platform.VulkanLayer.gamescope",
             "vkbasalt": "flatpak install --user org.freedesktop.Platform.VulkanLayer.vkBasalt",
             "mangohud": "flatpak install --user org.freedesktop.Platform.VulkanLayer.MangoHud",
             "obsvkc": "flatpak install --user com.obsproject.Studio.Plugin.OBSVkCapture",


### PR DESCRIPTION
# Description
Fixed gamescope installation tooltip showing install instructions for OBSVkCapture instead of gamescope 

Fixes #4218 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

