### PR TITLE
frontend/ui: Remove underline character from main menu items

### DIFF
--- a/bottles/frontend/ui/window.blp
+++ b/bottles/frontend/ui/window.blp
@@ -77,34 +77,34 @@ template $BottlesWindow: Adw.ApplicationWindow {
 menu primary_menu {
   section {
     item {
-      label: _("_Import…");
+      label: _("Import…");
       action: "app.import";
     }
 
     item {
-      label: _("_Journal");
+      label: _("Journal");
       action: "app.journal";
     }
   }
 
   section {
     item {
-      label: _("_Preferences");
+      label: _("Preferences");
       action: "app.preferences";
     }
 
     item {
-      label: _("_Keyboard Shortcuts");
+      label: _("Keyboard Shortcuts");
       action: "win.show-help-overlay";
     }
 
     item {
-      label: _("_Help");
+      label: _("Help");
       action: "app.help";
     }
 
     item {
-      label: _("_About Bottles");
+      label: _("About Bottles");
       action: "app.about";
     }
   }


### PR DESCRIPTION
# Description
Remove underline character from main menu items.

It does not seem to be supported for these items (just like the use-underline property) and causes issues with translations.

Fixes #4057.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Build Bottles and verify that these strings are now correctly translated in non-English locales (that are 100% translated on Weblate and synced with the Bottles Git repo).