### PR TITLE
feat: allow for custom gamescope options

### DIFF
--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -86,6 +86,7 @@ class BottleParams(DictCompatMixIn):
     gamescope_scaling: bool = False
     gamescope_borderless: bool = False
     gamescope_fullscreen: bool = True
+    gamescope_custom_options: str = ""
     sync: str = "wine"
     fsr: bool = False
     fsr_sharpening_strength: int = 2

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -688,6 +688,8 @@ class WineCommand:
             gamescope_cmd = [gamescope_available]
             if return_steam_cmd:
                 gamescope_cmd = ["gamescope"]
+            if params.gamescope_custom_options:
+                gamescope_cmd.append(params.gamescope_custom_options)
             if params.gamescope_fullscreen:
                 gamescope_cmd.append("-f")
             if params.gamescope_borderless:

--- a/bottles/frontend/ui/dialog-gamescope.blp
+++ b/bottles/frontend/ui/dialog-gamescope.blp
@@ -167,6 +167,10 @@ template $GamescopeDialog: Adw.Window {
             ]
           }
         }
+
+        Adw.EntryRow entry_custom_options {
+          title: _("Custom Gamescope Options");
+        }
       }
     }
   }

--- a/bottles/frontend/windows/gamescope.py
+++ b/bottles/frontend/windows/gamescope.py
@@ -30,6 +30,7 @@ class GamescopeDialog(Adw.Window):
     spin_fps_limit = Gtk.Template.Child()
     spin_fps_limit_no_focus = Gtk.Template.Child()
     switch_scaling = Gtk.Template.Child()
+    entry_custom_options = Gtk.Template.Child()
     toggle_borderless = Gtk.Template.Child()
     toggle_fullscreen = Gtk.Template.Child()
     btn_save = Gtk.Template.Child()
@@ -80,6 +81,7 @@ class GamescopeDialog(Adw.Window):
         self.switch_scaling.set_active(parameters.gamescope_scaling)
         self.toggle_borderless.set_active(parameters.gamescope_borderless)
         self.toggle_fullscreen.set_active(parameters.gamescope_fullscreen)
+        self.entry_custom_options.set_text(parameters.gamescope_custom_options)
 
         self.toggle_borderless.handler_unblock_by_func(self.__change_wtype)
         self.toggle_fullscreen.handler_unblock_by_func(self.__change_wtype)
@@ -95,6 +97,7 @@ class GamescopeDialog(Adw.Window):
             "gamescope_scaling": self.switch_scaling.get_active(),
             "gamescope_borderless": self.toggle_borderless.get_active(),
             "gamescope_fullscreen": self.toggle_fullscreen.get_active(),
+            "gamescope_custom_options": self.entry_custom_options.get_text(),
         }
 
         for setting in settings.keys():


### PR DESCRIPTION
# Description
This PR adds a text field to enter custom gamescope options. For example, things like hdr flags and such are not included in the options. Of course one could just add all gamecope options, but I think the current set of options is enough for 98% of users, however some would like to add custom flags, this PR addresses that issue.

Fixes #3495 and #3483

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Add `--hdr-enabled` into custom options and be stunned by inky blacks :)
- [ ] Disable Performance Monitoring and add `--mangoapp` into the custom options, mangohud should display in-game
