### PR TITLE
useless 'finally' in 'try except'

### DIFF
--- a/bottles/backend/utils/connection.py
+++ b/bottles/backend/utils/connection.py
@@ -106,6 +106,6 @@ class ConnectionUtils:
                 )
             self.last_check = datetime.now()
             self.status = False
-        finally:
-            self.do_check_connection = True
-            return self.status
+        
+        self.do_check_connection = True
+        return self.status


### PR DESCRIPTION
# Description
If the part of 'except' does not have `sys.exit` etc., 'finally' statement is useless. Because code still continues to execute.

And 'return' in ‘finally’ owing to a SyntaxWarning.

e.g. run bottles in cli.
```
bottles/backend/utils/connection.py:111: SyntaxWarning: 'return' in a 'finally' block
```

Fixes #(issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
