### PR TITLE
Allow to add valid system environment variable names

### DIFF
--- a/bottles/frontend/utils/gtk.py
+++ b/bottles/frontend/utils/gtk.py
@@ -50,6 +50,29 @@ class GtkUtils:
         return True
 
     @staticmethod
+    def validate_env_var_name(entry, extend=None) -> bool:
+        var_assignment = entry.get_text()
+        if var_assignment and not ShUtils.is_name(var_assignment):
+            GtkUtils.reset_entry_apply_button(entry)
+            entry.add_css_class("error")
+            return False
+
+        if not var_assignment:
+            GtkUtils.reset_entry_apply_button(entry)
+            entry.remove_css_class("error")
+            return False
+
+        if extend is not None:
+            if not extend(var_assignment):
+                GtkUtils.reset_entry_apply_button(entry)
+                entry.add_css_class("error")
+                return False
+
+        entry.set_show_apply_button(True)
+        entry.remove_css_class("error")
+        return True
+
+    @staticmethod
     def reset_entry_apply_button(entry) -> None:
         """
         Reset the apply_button within AdwEntryRow to hide it without disabling

--- a/bottles/frontend/windows/envvars.py
+++ b/bottles/frontend/windows/envvars.py
@@ -224,12 +224,7 @@ class EnvironmentVariablesDialog(Adw.Dialog):
             self.group_vars.add(_entry)
 
     def __validate_inherited(self, *_args):
-        def _is_valid(name: str) -> bool:
-            return bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name))
-
-        self.__valid_inherited_name = GtkUtils.validate_entry(
-            self.entry_new_inherited, _is_valid
-        )
+        self.__valid_inherited_name = GtkUtils.validate_env_var_name(self.entry_new_inherited)
 
     def __toggle_inherited_limit(self, *_args):
         active = self.switch_limit_inherited.get_active()


### PR DESCRIPTION
# Description
Fixes #4275 which prevents user from adding inherited environment variables.

I used the existing method as a template to add a new one.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [x] Input few variable names containing a space or containing/ending in `=`: should display error, prevent adding to the list
- [x] Input and add a few valid variable names: should succeed and appear on the list of var names
- [x] Clearing the input field: should reset the appearance of the field (can't add an empty name)

Behavior after this fix:
<img width="389" height="119" alt="Previously required invalid input, now fails the validity check." src="https://github.com/user-attachments/assets/f18f023e-67e1-48c9-8d4c-9355784a999e" />
<img width="389" height="119" alt="Valid input which didn't previously pass the check." src="https://github.com/user-attachments/assets/7411c1de-8c6b-40c7-ae2e-25698b0cf659" />
