### PR TITLE
Don't use templates with a mismatched uuid

### DIFF
--- a/bottles/backend/managers/template.py
+++ b/bottles/backend/managers/template.py
@@ -124,7 +124,7 @@ class TemplateManager:
         for template in templates:
             if os.path.exists(os.path.join(Paths.templates, template, "template.yml")):
                 _manifest = TemplateManager.get_template_manifest(template)
-                if _manifest is not None:
+                if _manifest is not None and _manifest["uuid"] == template:
                     res.append(_manifest)
 
         return res


### PR DESCRIPTION
## Overview
Fixes an issue where incomplete template recreation can leave a template with an older `template.yml` and referencing a non-existent uuid.

Bottles uses the uuid entry in the `template.yml` to build a path to the directory, resulting in  `[Errno 2] No such file or directory` errors when attempting to unpack or delete the template.

Fixes #4405

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description of Bug
1. When creating a bottle prefix using a built-in environment and a template for it exists, the template is unpacked into the bottle prefix directory including the `template.yml` from the template.
2. One of the components in the new bottle config (e.g. DXVK) can differ from the one in the template causing an update.
3. The old template is deleted and a directory for the new template is created with a new uuid.
4. The bottle prefix contents are copied to the new template directory including the previous `template.yml`. This happens because the ignore patterns contain a typo so no `.yml` files are filtered.
5. Other issues can cause the template creation to be interrupted before the new `template.yml` can be written.
6. Now when attempting to create another new bottle prefix in the same environment, unpacking the template (or removing it if out of date) will fail as the template is not located in a directory with the same uuid as in the `template.yml`.

## How Has This Been Tested?
- Modify an existing template's `template.yml` to list a different DXVK version and create a new bottle prefix in the same environment (or use the CLI tool to create the bottle prefix with a different DXVK version). Inspect the new template folder to see if the `bottle.yml` was filtered out (if it exists then `.yml` files are not being filtered).
- Modify an existing template's `template.yml` to have a different uuid and create a new bottle prefix. It should ignore the old template and a create a new one.

## Other notes
- The modified ignore patterns should prevent this specific issue occurring in the future.
- Verifying that the directory uuid matches the `template.yml` fixes issues caused by existing templates with this problem.
- When the uuids don't match, the broken template is simply ignored in line with how the current code ignores templates without a `template.yml`. However this does require users with broken templates to manually remove them to reclaim storage space. Only valid templates can be deleted from the GUI.
