### PR TITLE
Fix some ICO files not converting to PNG

### DIFF
--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -206,7 +206,9 @@ class ManagerUtils:
                 os.remove(ico_dest)
 
             ico.export_icon(ico_dest_temp)
-            if get_mime(ico_dest_temp) == "image/vnd.microsoft.icon":
+            # Some ICO files are incorrectly identified as TARGA
+            # See https://bugs.astron.com/view.php?id=723
+            if get_mime(ico_dest_temp) in ["image/vnd.microsoft.icon", "image/x-tga"]:
                 if not ico_dest_temp.endswith(".ico"):
                     shutil.move(ico_dest_temp, f"{ico_dest_temp}.ico")
                     ico_dest_temp = f"{ico_dest_temp}.ico"


### PR DESCRIPTION
# Description

Some ICO files are incorrectly identified as TARGA by libmagic file utility, used to obtain the MIME type of the extracted icon from the executable while creating a desktop entry using dynamic launcher portal. They are then assumed to be already PNG, and therefore are not correctly converted, which results in failure to validate the icon by the portal.

While this is a libmagic bug, workaround it by assuming that "image/x-tga" MIME type also indicates ICO files.

See https://bugs.astron.com/view.php?id=723

Helps #4402

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Create a desktop entry for NFS most wanted (2012) (NFS13.exe)