### PR TITLE
Make bottles list sorted alphanumerically

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -1311,7 +1311,7 @@ class Manager(metaclass=Singleton):
             if config.Parameters.dxvk_nvapi:
                 NVAPIComponent.check_bottle_nvngx(real_path, config)
 
-        for b in bottles:
+        for b in sorted(bottles):
             """
             For each bottle add the path name to the `local_bottles` variable
             and append the config.


### PR DESCRIPTION
# Description
This will make the bottles listed in the main list sorted alphanumerically instead of random.

Fixes #3418, and (partly) #3563 and #2822

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Apply fix and see the Bottles list. The correct one will also get used when clicked. Newly created Bottles will also appear in the correct space.