### PR TITLE
manager: fix crash when encountering 0-byte ghost files

### DIFF
--- a/bottles/backend/managers/component.py
+++ b/bottles/backend/managers/component.py
@@ -165,14 +165,21 @@ class ComponentManager:
         temp_dest = os.path.join(Paths.temp, file)
         just_downloaded = False
 
-        if os.path.isfile(os.path.join(Paths.temp, existing_file)):
+        file_path = os.path.join(Paths.temp, existing_file)
+        if os.path.isfile(file_path):
             """
             Check if the file already exists in the /temp directory.
-            If so, then skip the download process and set the update_func
-            to completed.
+            If it's a 0-byte empty file, remove it to allow a fresh download.
+            Otherwise, skip the download.
             """
-            logging.warning(f"File [{existing_file}] already exists in temp, skipping.")
-        else:
+            if os.path.getsize(file_path) == 0:
+                logging.warning(f"File [{existing_file}] is a 0-byte empty file. Removing to force re-download.")
+                os.remove(file_path)
+            else:
+                logging.warning(f"File [{existing_file}] already exists in temp, skipping.")
+                return Result(True)
+        
+        if not os.path.isfile(file_path):
             """
             As some urls can be redirect, we need to take care of this
             and make sure to use the final url. This check should be


### PR DESCRIPTION
# Description
This PR addresses a logic flaw where 0-byte (empty) files in the temp directory are treated as valid, completed downloads. When a download is interrupted or fails prematurely, it can leave an empty file. On subsequent attempts, the `ComponentManager` sees the file exists, skips the download process, and passes the empty file to the extraction logic, causing a crash or "file not found" error during extraction.

This change ensures that if a file exists but is 0 bytes, it is removed and a fresh download is triggered.

Fixes #4418

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I verified the fix by manually simulating a corrupted/interrupted download state within a Flatpak development environment.

- [x] **Test A: Ghost File Recovery**
    1. Manually created a 0-byte file: `touch ~/.var/app/com.usebottles.bottles.Devel/data/bottles/temp/d3dx9.tar.xz`
    2. Attempted to install the `d3dx9` dependency through the UI.
    3. Verified via logs that the 0-byte file was detected, removed, and a fresh 18.7MiB download was initiated.