### PR TITLE
Drop deprecated vars

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -366,6 +366,10 @@ class WineCommand:
             env.add("STAGING_SHARED_MEMORY", "1")
             env.add("__GL_SHADER_DISK_CACHE", "1")
             env.add(
+                "__GL_SHADER_DISK_CACHE_PATH",
+                os.path.join(bottle, "cache", "gl_shader"),
+            )
+            env.add(
                 "MESA_SHADER_CACHE_DIR", os.path.join(bottle, "cache", "mesa_shader")
             )
 

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -361,17 +361,10 @@ class WineCommand:
         if params.dxvk and not return_steam_env:
             env.add("WINE_LARGE_ADDRESS_AWARE", "1")
             env.add(
-                "DXVK_STATE_CACHE_PATH", os.path.join(bottle, "cache", "dxvk_state")
+                "DXVK_SHADER_CACHE_PATH", os.path.join(bottle, "cache", "dxvk_shader")
             )
             env.add("STAGING_SHARED_MEMORY", "1")
             env.add("__GL_SHADER_DISK_CACHE", "1")
-            env.add(
-                "__GL_SHADER_DISK_CACHE_SKIP_CLEANUP", "1"
-            )  # should not be needed anymore
-            env.add(
-                "__GL_SHADER_DISK_CACHE_PATH",
-                os.path.join(bottle, "cache", "gl_shader"),
-            )
             env.add(
                 "MESA_SHADER_CACHE_DIR", os.path.join(bottle, "cache", "mesa_shader")
             )


### PR DESCRIPTION
# Description
DXVK_STATE_CACHE_PATH is no longer used in the current DXVK, so it has been replaced with DXVK_SHADER_CACHE_PATH.

__GL_SHADER_DISK_CACHE_SKIP_CLEANUP is obsolete in modern Mesa.

__GL_SHADER_DISK_CACHE_PATH is obsolete in modern systems, as it is handled through Mesa via MESA_SHADER_CACHE_DIR

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
It has not been tested, but nothing should break.
