### PR TITLE
feat: Add NTsync option

### DIFF
--- a/bottles/backend/models/samples.py
+++ b/bottles/backend/models/samples.py
@@ -64,6 +64,7 @@ class Samples:
         "ENABLE_VKBASALT": ("vkbasalt", True),
         "WINEESYNC": ("sync", "esync"),
         "WINEFSYNC": ("sync", "fsync"),
+        "WINENTSYNC": ("sync", "ntsync"),
         "GAMESCOPE": ("gamescope", False),
         "DRI_PRIME": ("discrete_gpu", True),
         "__NV_PRIME_RENDER_OFFLOAD": ("discrete_gpu", True),

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -432,6 +432,10 @@ class WineCommand:
         if params.sync == "fsync":
             env.add("WINEFSYNC", "1")
 
+        # NTsync environment variable
+        if params.sync == "ntsync":
+            env.add("WINENTSYNC", "1")
+
         # Wine debug level
         if not return_steam_env:
             debug_level = "fixme-all"

--- a/bottles/frontend/ui/details-preferences.blp
+++ b/bottles/frontend/ui/details-preferences.blp
@@ -190,6 +190,7 @@ template $DetailsPreferences: Adw.PreferencesPage {
           _("System"),
           _("Esync"),
           _("Fsync"),
+          _("NTsync"),
         ]
       };
     }

--- a/bottles/frontend/views/bottle_preferences.py
+++ b/bottles/frontend/views/bottle_preferences.py
@@ -549,6 +549,7 @@ class PreferencesView(Adw.PreferencesPage):
         # self.toggle_sync.set_active(parameters["sync"] == "wine")
         # self.toggle_esync.set_active(parameters["sync"] == "esync")
         # self.toggle_fsync.set_active(parameters["sync"] == "fsync")
+        # self.toggle_ntsync.set_active(parameters["sync"] == "ntsync")
 
         self.switch_discrete.set_active(parameters.discrete_gpu)
 
@@ -635,6 +636,7 @@ class PreferencesView(Adw.PreferencesPage):
             "wine",
             "esync",
             "fsync",
+            "ntsync",
         ]
         for sync in sync_types:
             if sync == parameters.sync:
@@ -695,12 +697,13 @@ class PreferencesView(Adw.PreferencesPage):
 
     def __set_sync_type(self, *_args):
         """
-        Set the sync type (wine, esync, fsync)
+        Set the sync type (wine, esync, fsync, ntsync)
         """
         sync_types = [
             "wine",
             "esync",
             "fsync",
+            "ntsync",
         ]
         self.queue.add_task()
         self.combo_sync.set_sensitive(False)


### PR DESCRIPTION
# Description
This PR simply adds the relevant environemt variable `WINENTSYNC` to enable NT synchronization mechanism on Proton runners and patched WINE runners like TKG ones.

The motivation behind this PR is that the current 3 options for synchrinization do not allow patched WINE runners to take advantage of `NTsync`. This gives users an extra option if they want to use it.

<img width="735" height="610" alt="image" src="https://github.com/user-attachments/assets/2b59b706-3451-42cf-8bf1-5c7c1f446f18" />

## Fixes #(issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested against the old game `Midtown Madness`:
- Mangohud shows `WSYNC  NTsync`

  * Using the new `NTsync` option
     <img width="453" height="327" alt="image" src="https://github.com/user-attachments/assets/2f4d2fed-6835-41b5-9f77-c5b0d8da8a7d" />

  *  Using the default `Fsync` option
     <img width="453" height="327" alt="image" src="https://github.com/user-attachments/assets/efdebe90-587b-490c-b14d-6be0156a081c" />

- Logs from wine/wineserver

  * Using the new `NTsync` option
    ```shell
    23:29:10 (INFO) Session started: id=6 bottle=bottle-user-dev program=Open1560.exe 
    23:29:10 (INFO) Using EasyAntiCheat runtime 
    23:29:10 (INFO) Using BattlEye runtime 
    23:29:10 (INFO) Executing command: /usr/lib/.../Midtown Madness/Open1560.exe' 
    wineserver: NTSync up and running!
    [2026-04-20 23:29:13.110] [MANGOHUD] [info] [blacklist.cpp:83] process 'explorer.exe' is blacklisted in MangoHud
    info:  Game: Open1560.exe
    info:  DXVK: v2.7.1
    ```

  * Using the default `Fsync` option
    ```shell
    23:30:38 (INFO) Fonts directory modified manually, running wineboot to update fonts registry. 
    23:30:38 (INFO) Session started: id=7 bottle=bottle-user-dev program=Open1560.exe 
    23:30:38 (INFO) Using EasyAntiCheat runtime 
    23:30:38 (INFO) Using BattlEye runtime 
    23:30:38 (INFO) Executing command: /usr/lib/.../Midtown Madness/Open1560.exe' 
    fsync: up and running.
    [2026-04-20 23:30:40.556] [MANGOHUD] [info] [blacklist.cpp:83] process 'explorer.exe' is blacklisted in MangoHud
    info:  Game: Open1560.exe
    info:  DXVK: v2.7.1
    ```
