### PR TITLE
fix: drastically slow startup and UI freezes with many programs/library entries

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -98,6 +98,7 @@ class Manager(metaclass=Singleton):
     nvapi_available = []
     latencyflex_available = []
     local_bottles: Dict[str, BottleConfig] = {}
+    _programs_cache: Dict[str, List[dict]] = {}
     supported_runtimes = {}
     supported_winebridge = {}
     supported_wine_runners = {}
@@ -1037,6 +1038,10 @@ class Manager(metaclass=Singleton):
         if config is None:
             return []
 
+        cache_key = config.Name
+        if cache_key in self._programs_cache:
+            return self._programs_cache[cache_key]
+
         bottle = ManagerUtils.get_bottle_path(config)
         winepath = WinePath(config)
         results = glob(f"{bottle}/drive_c/users/*/Desktop/*.lnk", recursive=True)
@@ -1174,6 +1179,7 @@ class Manager(metaclass=Singleton):
                 if app["name"] not in programs_names:
                     installed_programs.append(app)
 
+        self._programs_cache[cache_key] = installed_programs
         return installed_programs
 
     def check_bottles(self, silent: bool = False):
@@ -1185,6 +1191,7 @@ class Manager(metaclass=Singleton):
 
         # Empty local bottles
         self.local_bottles = {}
+        self._programs_cache = {}
 
         def process_bottle(bottle):
             _name = bottle
@@ -1387,6 +1394,9 @@ class Manager(metaclass=Singleton):
         config.dump(os.path.join(bottle_path, "bottle.yml"))
 
         config.Update_Date = str(datetime.now())
+
+        if scope == "External_Programs":
+            self._programs_cache.pop(config.Name, None)
 
         if config.Environment == "Steam":
             self.steam_manager.update_bottle(config)

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -1147,32 +1147,32 @@ class Manager(metaclass=Singleton):
                     )
                     found.append(executable_name)
 
-            win_steam_manager = SteamManager(config, is_windows=True)
+        win_steam_manager = SteamManager(config, is_windows=True)
 
-            if (
-                self.settings.get_boolean("steam-programs")
-                and win_steam_manager.is_steam_supported
-            ):
-                programs_names = [p.get("name", "") for p in installed_programs]
-                for app in win_steam_manager.get_installed_apps_as_programs():
-                    if app["name"] not in programs_names:
-                        installed_programs.append(app)
+        if (
+            self.settings.get_boolean("steam-programs")
+            and win_steam_manager.is_steam_supported
+        ):
+            programs_names = [p.get("name", "") for p in installed_programs]
+            for app in win_steam_manager.get_installed_apps_as_programs():
+                if app["name"] not in programs_names:
+                    installed_programs.append(app)
 
-            if self.settings.get_boolean(
-                "epic-games"
-            ) and EpicGamesStoreManager.is_epic_supported(config):
-                programs_names = [p.get("name", "") for p in installed_programs]
-                for app in EpicGamesStoreManager.get_installed_games(config):
-                    if app["name"] not in programs_names:
-                        installed_programs.append(app)
+        if self.settings.get_boolean(
+            "epic-games"
+        ) and EpicGamesStoreManager.is_epic_supported(config):
+            programs_names = [p.get("name", "") for p in installed_programs]
+            for app in EpicGamesStoreManager.get_installed_games(config):
+                if app["name"] not in programs_names:
+                    installed_programs.append(app)
 
-            if self.settings.get_boolean(
-                "ubisoft-connect"
-            ) and UbisoftConnectManager.is_uconnect_supported(config):
-                programs_names = [p.get("name", "") for p in installed_programs]
-                for app in UbisoftConnectManager.get_installed_games(config):
-                    if app["name"] not in programs_names:
-                        installed_programs.append(app)
+        if self.settings.get_boolean(
+            "ubisoft-connect"
+        ) and UbisoftConnectManager.is_uconnect_supported(config):
+            programs_names = [p.get("name", "") for p in installed_programs]
+            for app in UbisoftConnectManager.get_installed_games(config):
+                if app["name"] not in programs_names:
+                    installed_programs.append(app)
 
         return installed_programs
 


### PR DESCRIPTION
# Description
Bottles becomes extremely slow (multiple minutes) and completely unresponsive during startup and program-related operations (e.g. renaming) when a bottle has many installed programs. GNOME reports the window as "not responding" during these periods.

Two issues were found in `Manager.get_programs()`:

1. **Third-party store detection was inside the `.lnk` iteration loop.** The Steam, Epic Games, and Ubisoft Connect store checks (including `SteamManager` construction with filesystem I/O) were incorrectly indented inside the `for program in results:` loop, causing them to run once per `.lnk` file instead of once per call. With ~20 shortcuts, this meant ~20 redundant `SteamManager` instantiations.

2. **`get_programs()` was called repeatedly with no caching.** Each `LibraryEntry` widget calls `get_programs()` independently during initialization, so N library entries meant N full filesystem scans of the same bottle. A programs cache on the `Manager` singleton (keyed by bottle name) now ensures the expensive scan runs only once per bottle. The cache is invalidated when bottles are refreshed (`check_bottles()`) or when programs are modified (`update_config` with `External_Programs` scope).



## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Startup with a bottle containing ~20 programs and multiple library entries — previously took 2+ minutes with a completely frozen UI, now completes in seconds
- [x] Renaming a program — previously caused a long UI freeze, now responsive
- [x] Verified programs still appear correctly in library and bottle details views
- [x] Verified cache invalidation: adding/removing/renaming programs refreshes correctly
