### PR TITLE
fix: lowercase executable name for StartupWMClass

### DIFF
--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -259,7 +259,7 @@ class ManagerUtils:
                     Categories=Application;
                     Comment=Launch {} using Bottles.
                     StartupWMClass={}""".format(
-                        exec, program.get("name"), program.get("name")
+                        exec, program.get("name"), program.get("executable").lower()
                     )
                 )
             except GLib.Error as e:
@@ -269,7 +269,7 @@ class ManagerUtils:
                 safe_name = "".join([c for c in program.get("name") if c.isalnum() or c in ("-", "_")])
                 filename = f"bottles-{config.get('Name')}-{safe_name}.desktop"
                 filepath = os.path.join(desktop_dir, filename)
-                content = f"[Desktop Entry]\nExec={exec}\nType=Application\nTerminal=false\nCategories=Application;\nComment=Launch {program.get('name')} using Bottles.\nStartupWMClass={program.get('name')}\nName={program.get('name')}\nIcon={icon}\n"
+                content = f"[Desktop Entry]\nExec={exec}\nType=Application\nTerminal=false\nCategories=Application;\nComment=Launch {program.get('name')} using Bottles.\nStartupWMClass={program.get('executable').lower()}\nName={program.get('name')}\nIcon={icon}\n"
                 try:
                     with open(filepath, "w") as f:
                         f.write(content)


### PR DESCRIPTION
# Description
Small fix to change StartupWMClass of new desktop entries to match the WM Class of Wine windows for most runners. Before this, GNOME used the Bottles icon for all programs, even with a desktop entry created. Xfce + Docklike Taskbar plugin used a generic icon. Now they should use the correct program icon.

Some runners I tested (soda, proton-EM, ge-proton) always set WM Class to _steam_proton_ when on X11, so this fix does not affect them in that scenario.

Related issues: #2985 #3272 #3430 #3538

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested on GNOME 50.1, Cinnamon 6.6, and Xfce 4.20 with the Docklike Taskbar plugin. Mostly used sys-wine-11.0 and kron4ek-wine-11.7-amd64 runners.
## Steps
- Install a program in a bottle. I used [WinJUPOS](https://jupos.org/gh/download.htm), but any should do.
- Add Desktop Entry from the Programs list in Bottles.
- Launch program.

### Before in GNOME:
`StartupWMClass=WinJUPOS.x64`

<img width="853" height="480" alt="Before screenshot, with the Wine program having a Bottles icon." src="https://github.com/user-attachments/assets/eab4709a-8421-4531-83b8-f7a53f6ee8a8" />

### After:
`StartupWMClass=winjupos.x64.exe`

<img width="853" height="480" alt="After screenshot, with the Wine program having its own icon." src="https://github.com/user-attachments/assets/37c75e9e-c0d9-4a16-a402-a96f1ee6ed04" />