### PR TITLE
[Bug]: avoid Manager startup side effects during CLI launches

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -130,7 +130,7 @@ class Manager(metaclass=Singleton):
         self.data_mgr = DataManager()
         _offline = True
 
-        if check_connection:
+        if check_connection and not self.is_cli:
             _offline = not self.utils_conn.check_connection()
 
         # validating user-defined Paths.bottles
@@ -328,7 +328,8 @@ class Manager(metaclass=Singleton):
             enabled=playtime_enabled,
             heartbeat_interval=playtime_interval if playtime_interval > 0 else 60,
         )
-        tracker.recover_open_sessions()
+        if not self.is_cli:
+            tracker.recover_open_sessions()
         self.playtime_tracker = tracker
 
     def _on_playtime_enabled_changed(self, _settings, _key) -> None:

--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -130,7 +130,7 @@ class Manager(metaclass=Singleton):
         self.data_mgr = DataManager()
         _offline = True
 
-        if check_connection and not self.is_cli:
+        if check_connection and not self.utils_conn.force_offline:
             _offline = not self.utils_conn.check_connection()
 
         # validating user-defined Paths.bottles

--- a/bottles/backend/utils/gsettings_stub.py
+++ b/bottles/backend/utils/gsettings_stub.py
@@ -10,6 +10,11 @@ class GSettingsStub:
         return False
 
     @staticmethod
+    def get_int(key: str) -> int:
+        logging.warning(f"Stub GSettings key {key}=0")
+        return 0
+
+    @staticmethod
     def get_string(key: str) -> str:
         logging.warning(f"Stub GSettings key {key}='default'")
         return "default"

--- a/bottles/tests/backend/integration/playtime/test_recovery.py
+++ b/bottles/tests/backend/integration/playtime/test_recovery.py
@@ -123,32 +123,38 @@ def test_recovery_same_bottle_different_programs(manager):
 
 def test_cli_manager_init_does_not_recover_live_sessions(temp_xdg_home, test_settings_stub):
     Manager._instances.pop(Manager, None)
-    manager = Manager(g_settings=test_settings_stub, check_connection=False, is_cli=True)
-    tracker = manager.playtime_tracker
-    assert tracker is not None
+    manager = None
+    other_manager = None
 
-    sid = tracker.start_session(
-        bottle_id="b1",
-        bottle_name="Bottle",
-        bottle_path="/bottle",
-        program_name="Game",
-        program_path="C:/Game/game.exe",
-    )
+    try:
+        manager = Manager(g_settings=test_settings_stub, check_connection=False, is_cli=True)
+        tracker = manager.playtime_tracker
+        assert tracker is not None
 
-    Manager._instances.pop(Manager, None)
-    other_manager = Manager(
-        g_settings=test_settings_stub,
-        check_connection=False,
-        is_cli=True,
-    )
+        sid = tracker.start_session(
+            bottle_id="b1",
+            bottle_name="Bottle",
+            bottle_path="/bottle",
+            program_name="Game",
+            program_path="C:/Game/game.exe",
+        )
 
-    con = sqlite3.connect(other_manager.playtime_tracker.db_path)
-    cur = con.cursor()
-    cur.execute("SELECT status FROM sessions WHERE id=?", (sid,))
-    assert cur.fetchone()[0] == "running"
+        Manager._instances.pop(Manager, None)
+        other_manager = Manager(
+            g_settings=test_settings_stub,
+            check_connection=False,
+            is_cli=True,
+        )
 
-    tracker.shutdown()
-    other_manager.playtime_tracker.shutdown()
-    Manager._instances.pop(Manager, None)
+        con = sqlite3.connect(other_manager.playtime_tracker.db_path)
+        cur = con.cursor()
+        cur.execute("SELECT status FROM sessions WHERE id=?", (sid,))
+        assert cur.fetchone()[0] == "running"
+    finally:
+        if manager and getattr(manager, "playtime_tracker", None):
+            manager.playtime_tracker.shutdown()
+        if other_manager and getattr(other_manager, "playtime_tracker", None):
+            other_manager.playtime_tracker.shutdown()
+        Manager._instances.pop(Manager, None)
 
 

--- a/bottles/tests/backend/integration/playtime/test_recovery.py
+++ b/bottles/tests/backend/integration/playtime/test_recovery.py
@@ -4,6 +4,7 @@ import sqlite3
 import time
 from freezegun import freeze_time
 
+from bottles.backend.managers.manager import Manager
 from bottles.backend.managers.playtime import ProcessSessionTracker
 
 
@@ -118,5 +119,36 @@ def test_recovery_same_bottle_different_programs(manager):
     # Two totals rows for the bottle
     cur.execute("SELECT COUNT(*) FROM playtime_totals WHERE bottle_id=?", ("b1",))
     assert cur.fetchone()[0] == 2
+
+
+def test_cli_manager_init_does_not_recover_live_sessions(temp_xdg_home, test_settings_stub):
+    Manager._instances.pop(Manager, None)
+    manager = Manager(g_settings=test_settings_stub, check_connection=False, is_cli=True)
+    tracker = manager.playtime_tracker
+    assert tracker is not None
+
+    sid = tracker.start_session(
+        bottle_id="b1",
+        bottle_name="Bottle",
+        bottle_path="/bottle",
+        program_name="Game",
+        program_path="C:/Game/game.exe",
+    )
+
+    Manager._instances.pop(Manager, None)
+    other_manager = Manager(
+        g_settings=test_settings_stub,
+        check_connection=False,
+        is_cli=True,
+    )
+
+    con = sqlite3.connect(other_manager.playtime_tracker.db_path)
+    cur = con.cursor()
+    cur.execute("SELECT status FROM sessions WHERE id=?", (sid,))
+    assert cur.fetchone()[0] == "running"
+
+    tracker.shutdown()
+    other_manager.playtime_tracker.shutdown()
+    Manager._instances.pop(Manager, None)
 
 

--- a/bottles/tests/backend/manager/test_manager.py
+++ b/bottles/tests/backend/manager/test_manager.py
@@ -47,3 +47,34 @@ def test_manager_cli_skips_connection_check(mocker):
 
     Manager(is_cli=True)
     check_connection.assert_not_called()
+
+
+def test_manager_forced_offline_setting_skips_connection_check(mocker):
+    class ForcedOfflineSettings(GSettingsStub):
+        @staticmethod
+        def get_boolean(key: str) -> bool:
+            if key == "force-offline":
+                return True
+            return GSettingsStub.get_boolean(key)
+
+    class EmptyChecksResult:
+        data = {}
+
+    check_connection = mocker.patch.object(
+        ConnectionUtils,
+        "check_connection",
+        autospec=True,
+        return_value=True,
+    )
+    checks = mocker.patch.object(
+        Manager,
+        "checks",
+        autospec=True,
+        return_value=EmptyChecksResult(),
+    )
+
+    manager = Manager(g_settings=ForcedOfflineSettings(), is_cli=False)
+
+    assert manager.utils_conn.force_offline is True
+    check_connection.assert_not_called()
+    checks.assert_called_once()

--- a/bottles/tests/backend/manager/test_manager.py
+++ b/bottles/tests/backend/manager/test_manager.py
@@ -1,6 +1,7 @@
 """Core Manager tests"""
 
 from bottles.backend.managers.manager import Manager
+from bottles.backend.utils.connection import ConnectionUtils
 from bottles.backend.utils.gsettings_stub import GSettingsStub
 
 
@@ -15,3 +16,20 @@ def test_manager_is_singleton():
 
 def test_manager_default_gsettings_stub():
     assert Manager().settings.get_boolean("anything") is False
+
+
+def test_manager_cli_skips_connection_check(mocker):
+    Manager._instances.pop(Manager, None)
+
+    check_connection = mocker.patch.object(
+        ConnectionUtils,
+        "check_connection",
+        autospec=True,
+        return_value=True,
+    )
+
+    manager = Manager(is_cli=True)
+    check_connection.assert_not_called()
+
+    manager.playtime_tracker.shutdown()
+    Manager._instances.pop(Manager, None)

--- a/bottles/tests/backend/manager/test_manager.py
+++ b/bottles/tests/backend/manager/test_manager.py
@@ -1,8 +1,27 @@
 """Core Manager tests"""
 
+import contextlib
+
+import pytest
+
 from bottles.backend.managers.manager import Manager
 from bottles.backend.utils.connection import ConnectionUtils
 from bottles.backend.utils.gsettings_stub import GSettingsStub
+
+
+@pytest.fixture(autouse=True)
+def reset_manager_singleton():
+    existing = Manager._instances.pop(Manager, None)
+    if existing and getattr(existing, "playtime_tracker", None):
+        with contextlib.suppress(Exception):
+            existing.playtime_tracker.shutdown()
+
+    yield
+
+    existing = Manager._instances.pop(Manager, None)
+    if existing and getattr(existing, "playtime_tracker", None):
+        with contextlib.suppress(Exception):
+            existing.playtime_tracker.shutdown()
 
 
 def test_manager_is_singleton():
@@ -19,8 +38,6 @@ def test_manager_default_gsettings_stub():
 
 
 def test_manager_cli_skips_connection_check(mocker):
-    Manager._instances.pop(Manager, None)
-
     check_connection = mocker.patch.object(
         ConnectionUtils,
         "check_connection",
@@ -28,8 +45,5 @@ def test_manager_cli_skips_connection_check(mocker):
         return_value=True,
     )
 
-    manager = Manager(is_cli=True)
+    Manager(is_cli=True)
     check_connection.assert_not_called()
-
-    manager.playtime_tracker.shutdown()
-    Manager._instances.pop(Manager, None)


### PR DESCRIPTION
# Description
Related #4510

## Summary
CLI entrypoints currently instantiate `Manager` directly. In the `bottles-cli run` case, that means a short-lived CLI invocation can still trigger `Manager` startup work that is useful for the main app lifecycle, but noisy or disruptive for a one-shot launch.

## Why
While reproducing #4510, two startup behaviors stood out:
- the initial connection check still runs even when the connection helper is already in forced offline mode, which produces misleading offline logging during CLI launches
- playtime session recovery can mark sessions as forced even when they still belong to another live Bottles process

## What changed
- skip the initial `check_connection()` call when `Manager` is already in forced offline mode
- skip `recover_open_sessions()` for CLI `Manager` instances
- add the missing `get_int()` fallback to `GSettingsStub`
- harden the affected regression tests around singleton state and CLI session recovery

## How Has This Been Tested?
- [x] `pytest bottles/tests/backend/manager/test_manager.py bottles/tests/backend/integration/playtime/test_recovery.py -q`

## Design note
I kept this change in `Manager` because CLI entrypoints already instantiate `Manager` directly today, and I wanted the smallest safe fix for #4510 without widening bootstrapping changes in the same PR.

## Risks / Follow-ups
- Scoped to `Manager` startup behavior for CLI launches and forced-offline initialization.
- Does not change executor-side Windows path validation warnings.
