### PR TITLE
fix(frontend): honor -e/--executable and -b/--bottle CLI options in GUI

### DIFF
--- a/bottles/frontend/main.py
+++ b/bottles/frontend/main.py
@@ -84,6 +84,7 @@ _ = gettext.gettext
 class Bottles(Adw.Application):
     arg_exe = None
     arg_bottle = None
+    arg_args = None
     dark_provider = None
     journal_window = None
 
@@ -182,6 +183,9 @@ class Bottles(Adw.Application):
         if commands.contains("bottle"):
             self.arg_bottle = commands.lookup_value("bottle").get_string()
 
+        if commands.contains("arguments"):
+            self.arg_args = commands.lookup_value("arguments").get_string()
+
         if not self.arg_exe:
             """
             If no executable is specified, look if it was passed without
@@ -200,6 +204,26 @@ class Bottles(Adw.Application):
         )
         if uri:
             return self.__process_uri(uri)
+
+        if self.arg_exe:
+            if self.arg_bottle:
+                cmd = [
+                    "bottles-cli",
+                    "run",
+                    "-b",
+                    self.arg_bottle,
+                    "-e",
+                    self.arg_exe,
+                ]
+                if self.arg_args:
+                    cmd.extend(["-a", self.arg_args])
+                subprocess.Popen(cmd)
+                return 0
+            from bottles.frontend.windows.bottlepicker import BottlePickerDialog
+
+            dialog = BottlePickerDialog(application=self, arg_exe=self.arg_exe)
+            dialog.present()
+            return 0
 
         self.do_activate()
         return 0


### PR DESCRIPTION
## Description

The GUI frontend (`bottles/frontend/main.py`) registers `--executable` (`-e`), `--bottle` (`-b`), and `--arguments` (`-a`) as command-line options, but `do_command_line()` never acts on them. When users launch the main Bottles app with these flags (e.g., `flatpak run com.usebottles.bottles -e /path/to/game.exe -b my-bottle`), the options are parsed and then silently discarded—the main window opens instead of launching the requested executable.

This is a regression in user expectations because `bottles-cli` handles these same options correctly.

## Root Cause

1. `arg_args` was not declared, and the `"arguments"` option was never read from `commands`.
2. After parsing `-e` and `-b`, the code fell through to `self.do_activate()`, which creates `BottlesWindow`. `BottlesWindow` only accepts `arg_bottle`; it has no parameter for `arg_exe`, so the executable path is lost.

## Changes

- Added `arg_args = None` class variable.
- Parse `"arguments"` in `do_command_line()`.
- When `arg_exe` is set **and** `arg_bottle` is set, launch the executable via `bottles-cli run -b <bottle> -e <exe> [-a <args>]` and return early.
- When `arg_exe` is set **without** `arg_bottle`, show `BottlePickerDialog` (the same behavior already used for URI handling) and return early.
- This prevents the main window from opening when the user explicitly requested a CLI-style launch.

## Verification Steps

1. `flatpak run com.usebottles.bottles -e /path/to/executable.exe`
   - Expected: `BottlePickerDialog` opens to choose a bottle.
2. `flatpak run com.usebottles.bottles -b my-bottle -e /path/to/executable.exe`
   - Expected: Executable launches directly without opening the main window.
3. `flatpak run com.usebottles.bottles -b my-bottle -e /path/to/executable.exe -a "--some-arg"`
   - Expected: Executable launches with the provided arguments.

## Related Issue

Fixes #3606