### PR TITLE
Add wayland option in launch options

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -1127,6 +1127,7 @@ class Manager(metaclass=Singleton):
                     "pulseaudio_latency": _program.get("pulseaudio_latency"),
                     "virtual_desktop": _program.get("virtual_desktop"),
                     "winebridge": _program.get("winebridge"),
+                    "wayland": _program.get("wayland"),
                     "removed": _program.get("removed"),
                     "id": _program.get("id"),
                 }

--- a/bottles/backend/wine/executor.py
+++ b/bottles/backend/wine/executor.py
@@ -60,6 +60,7 @@ class WineExecutor:
         program_gamescope: Optional[bool] = None,
         program_virt_desktop: Optional[bool] = None,
         program_winebridge: Optional[bool] = None,
+        program_wayland: Optional[bool] = None,
         sandbox_override: Optional[str] = None,
     ):
         logging.info("Launching an executable…")
@@ -125,6 +126,12 @@ class WineExecutor:
         ):
             self.environment["GAMESCOPE"] = "1" if program_gamescope else "0"
 
+        if (
+            program_wayland is not None
+            and program_wayland != getattr(self.config.Parameters, "wayland", False)
+        ):
+            self.environment["WAYLAND"] = "1" if program_wayland else "0"
+
         if env_dll_overrides:
             if "WINEDLLOVERRIDES" in self.environment:
                 self.environment["WINEDLLOVERRIDES"] += ";" + ";".join(
@@ -183,6 +190,7 @@ class WineExecutor:
             program_gamescope=program.get("gamescope"),
             program_virt_desktop=program.get("virtual_desktop"),
             program_winebridge=program.get("winebridge"),
+            program_wayland=program.get("wayland"),
             sandbox_override=sandbox_override,
         ).run()
 

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -90,8 +90,8 @@ class WineEnv:
         return key in self.__env
 
 
-def apply_wayland_preferences(env: "WineEnv", params) -> None:
-    if not getattr(params, "wayland", False):
+def apply_wayland_preferences(env: "WineEnv", wayland_activated: bool) -> None:
+    if not wayland_activated:
         return
     if DisplayUtils.display_server_type() != "wayland":
         return
@@ -517,7 +517,12 @@ class WineCommand:
             # Wine arch
             env.add("WINEARCH", arch)
 
-        apply_wayland_preferences(env, params)
+        wayland_activated = (
+            environment.get("WAYLAND") == "1"
+            if "WAYLAND" in environment
+            else getattr(params, "wayland", False)
+        )
+        apply_wayland_preferences(env, wayland_activated)
 
         return env.get()["envs"]
 

--- a/bottles/frontend/ui/dialog-launch-options.blp
+++ b/bottles/frontend/ui/dialog-launch-options.blp
@@ -228,6 +228,15 @@ template $LaunchOptionsDialog: Adw.Window {
             valign: center;
           }
         }
+
+        Adw.ActionRow action_wayland {
+          title: _("Wayland (Experimental)");
+          activatable-widget: switch_wayland;
+
+          Switch switch_wayland {
+            valign: center;
+          }
+        }
       }
     }
   }

--- a/bottles/frontend/windows/launchoptions.py
+++ b/bottles/frontend/windows/launchoptions.py
@@ -54,6 +54,7 @@ class LaunchOptionsDialog(Adw.Window):
     switch_winebridge = Gtk.Template.Child()
     switch_gamescope = Gtk.Template.Child()
     switch_virt_desktop = Gtk.Template.Child()
+    switch_wayland = Gtk.Template.Child()
     action_dxvk = Gtk.Template.Child()
     action_vkd3d = Gtk.Template.Child()
     action_nvapi = Gtk.Template.Child()
@@ -61,6 +62,7 @@ class LaunchOptionsDialog(Adw.Window):
     action_gamescope = Gtk.Template.Child()
     action_cwd = Gtk.Template.Child()
     action_virt_desktop = Gtk.Template.Child()
+    action_wayland = Gtk.Template.Child()
     # endregion
 
     __default_pre_script_msg = _("Choose a script which should be executed before run.")
@@ -116,6 +118,7 @@ class LaunchOptionsDialog(Adw.Window):
         self.toggled["gamescope"] = False
         self.toggled["virtual_desktop"] = False
         self.toggled["winebridge"] = False
+        self.toggled["wayland"] = False
 
         # connect signals
         self.btn_save.connect("clicked", self.__save)
@@ -140,6 +143,9 @@ class LaunchOptionsDialog(Adw.Window):
         self.global_winebridge = program_winebridge = getattr(
             config.Parameters, "winebridge", True
         )
+        self.global_wayland = program_wayland = getattr(
+            config.Parameters, "wayland", False
+        )
 
         if self.program.get("dxvk") is not None:
             program_dxvk = self.program.get("dxvk")
@@ -159,6 +165,9 @@ class LaunchOptionsDialog(Adw.Window):
         if self.program.get("winebridge") is not None:
             program_winebridge = self.program.get("winebridge")
             self.action_winebridge.set_subtitle(self.__msg_override)
+        if self.program.get("wayland") is not None:
+            program_wayland = self.program.get("wayland")
+            self.action_wayland.set_subtitle(self.__msg_override)
 
         self.switch_dxvk.set_active(program_dxvk)
         self.switch_vkd3d.set_active(program_vkd3d)
@@ -166,6 +175,7 @@ class LaunchOptionsDialog(Adw.Window):
         self.switch_gamescope.set_active(program_gamescope)
         self.switch_virt_desktop.set_active(program_virt_desktop)
         self.switch_winebridge.set_active(program_winebridge)
+        self.switch_wayland.set_active(program_wayland)
 
         self.switch_dxvk.connect(
             "state-set", self.__check_override, self.action_dxvk, "dxvk"
@@ -187,6 +197,9 @@ class LaunchOptionsDialog(Adw.Window):
         )
         self.switch_winebridge.connect(
             "state-set", self.__check_override, self.action_winebridge, "winebridge"
+        )
+        self.switch_wayland.connect(
+            "state-set", self.__check_override, self.action_wayland, "wayland"
         )
 
         if program.get("pre_script") not in ("", None):
@@ -234,6 +247,7 @@ class LaunchOptionsDialog(Adw.Window):
         program_gamescope = self.switch_gamescope.get_state()
         program_virt_desktop = self.switch_virt_desktop.get_state()
         program_winebridge = self.switch_winebridge.get_state()
+        program_wayland = self.switch_wayland.get_state()
 
         self.__set_override("dxvk", program_dxvk, self.global_dxvk)
         self.__set_override("vkd3d", program_vkd3d, self.global_vkd3d)
@@ -243,6 +257,7 @@ class LaunchOptionsDialog(Adw.Window):
             "virtual_desktop", program_virt_desktop, self.global_virt_desktop
         )
         self.__set_override("winebridge", program_winebridge, self.global_winebridge)
+        self.__set_override("wayland", program_wayland, self.global_wayland)
         self.program["arguments"] = self.entry_arguments.get_text()
         self.program["arguments_enabled"] = self.switch_arguments.get_active()
 
@@ -394,12 +409,14 @@ class LaunchOptionsDialog(Adw.Window):
         self.switch_gamescope.set_active(self.global_gamescope)
         self.switch_virt_desktop.set_active(self.global_virt_desktop)
         self.switch_winebridge.set_active(self.global_winebridge)
+        self.switch_wayland.set_active(self.global_wayland)
         self.action_dxvk.set_subtitle("")
         self.action_vkd3d.set_subtitle("")
         self.action_nvapi.set_subtitle("")
         self.action_gamescope.set_subtitle("")
         self.action_virt_desktop.set_subtitle("")
         self.action_winebridge.set_subtitle("")
+        self.action_wayland.set_subtitle("")
         self.__set_disabled_switches()
         for name in self.toggled:
             self.toggled[name] = None

--- a/bottles/tests/backend/wine/test_executor.py
+++ b/bottles/tests/backend/wine/test_executor.py
@@ -65,6 +65,8 @@ def test_run_program_substitutes_placeholders(monkeypatch):
         program_gamescope=None,
         program_virt_desktop=None,
         program_winebridge=None,
+        program_wayland=None,
+        sandbox_override=None,
     ):
         # mimic original __init__ contract enough for run() stub
         self.config = config


### PR DESCRIPTION
# Description
This PR adds a wayland option per-executable in the launch settings.
It is useful if the global wayland settings is useful for most executables in a bottle, except a few (white screen, crash)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- Create a new bottle
- Enable wayland globaly on the bottle
- Add an executable with "Add shortcuts"
- In launch option, toggle off the new wayland option.
- Launch the executable