### PR TITLE
fix: rename "Chinese" to "Chinese (Simplified)" and "Taiwanese" to "Chinese (Traditional)" (#4547)

### DIFF
--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -496,9 +496,9 @@ class ManagerUtils:
             _("Slovenian"),
             _("Swedish"),
             _("Turkish"),
-            _("Chinese"),
+            _("Chinese (Simplified)"),
             _("Japanese"),
-            _("Taiwanese"),
+            _("Chinese (Traditional)"),
             _("Korean"),
         ]
 


### PR DESCRIPTION
Fixes #4547

## Problem
- `"Chinese"` is ambiguous — it does not clarify which script/variant
- `"Taiwanese"` is incorrect — it refers to Taiwanese Hokkien, not Standard Chinese written in Traditional script

## Fix
Two string changes in `bottles/backend/utils/manager.py`:

| Before | After |
|---|---|
| `_("Chinese")` | `_("Chinese (Simplified)")` |
| `_("Taiwanese")` | `_("Chinese (Traditional)")` |

## Why this naming
This follows the established convention used by VS Code, LibreOffice, Windows, and most major software — distinguishing by script (Simplified vs Traditional) rather than geography or dialect.