### PR TITLE
feat: detect Unreal Engine bootstrapper in Eagle and suggest the shipping binary

### DIFF
--- a/bottles/backend/managers/eagle.py
+++ b/bottles/backend/managers/eagle.py
@@ -634,6 +634,7 @@ class EagleManager:
 
             self._send_step("Scanning directory structure...")
 
+            ue_shipping_exe = None
             exe_base = basename.rsplit(".", 1)[0]
             runtimeconfig = f"{exe_base}.runtimeconfig.json"
             deps_json = f"{exe_base}.deps.json"
@@ -657,6 +658,32 @@ class EagleManager:
                 if "Unreal" not in insights["Engines"]:
                     insights["Engines"].append("Unreal")
                     self._send_step("[Engines] Unreal Engine")
+
+                is_root_launcher = os.path.exists(os.path.join(exe_dir, "Engine"))
+                if (is_root_launcher
+                        and "shipping" not in basename.lower()
+                        and os.path.getsize(executable_path) < 1_048_576):
+                    self._send_step("[!] Unreal Engine bootstrapper detected – searching for shipping binary...")
+                    try:
+                        with os.scandir(exe_dir) as it:
+                            for entry in it:
+                                if not entry.is_dir():
+                                    continue
+                                for arch in ("Win64", "Win32"):
+                                    binaries_path = os.path.join(entry.path, "Binaries", arch)
+                                    if not os.path.isdir(binaries_path):
+                                        continue
+                                    for f in os.listdir(binaries_path):
+                                        if f.lower().endswith(f"-{arch.lower()}-shipping.exe"):
+                                            ue_shipping_exe = os.path.join(binaries_path, f)
+                                            self._send_step(f"[Engines] Shipping binary found: {f}")
+                                            break
+                                    if ue_shipping_exe:
+                                        break
+                                if ue_shipping_exe:
+                                    break
+                    except OSError:
+                        pass
 
             if os.path.exists(os.path.join(exe_dir, "renpy")):
                 if "Ren'Py" not in insights["Engines"]:
@@ -848,6 +875,19 @@ class EagleManager:
                 suggestions.append({"key": "virtual_desktop", "value": False, "label": "Virtual Desktop (DPI)"})
 
             messages = []
+
+            if ue_shipping_exe:
+                messages.append({
+                    "name": "Unreal Engine Bootstrapper",
+                    "description": (
+                        "This is the Unreal Engine launcher, not the game binary. "
+                        "It runs a VC++ prerequisite check that often fails in Wine even when "
+                        "the runtime is correctly installed, causing a misleading error dialog. "
+                        "Add the shipping binary directly to avoid this."
+                    ),
+                    "severity": "high",
+                    "context": [ue_shipping_exe],
+                })
 
             # Generalized patrns and hints
             warns = flat_insights.get("Warning", [])

--- a/bottles/frontend/views/eagle.py
+++ b/bottles/frontend/views/eagle.py
@@ -412,12 +412,13 @@ class EagleView(Gtk.Box):
                     description = item.get("description", "")
                     context = item.get("context", [])
                     source = item.get("source", "")
+                    is_ue_bootstrapper = (name == "Unreal Engine Bootstrapper")
 
                     details_list = []
                     if source and source != "Main Executable":
                         details_list.append(f"Source: {source}")
                     
-                    if context:
+                    if context and not is_ue_bootstrapper:
                         ctx_str = ", ".join(context[:5])
                         if len(context) > 5:
                             ctx_str += "..."
@@ -462,6 +463,14 @@ class EagleView(Gtk.Box):
                 icon = Gtk.Image.new_from_icon_name(icon_name)
                 row.add_prefix(icon)
                 self.list_warnings.append(row)
+
+                if isinstance(item, dict) and is_ue_bootstrapper and context:
+                    shipping_path = context[0]
+                    switch_row = Adw.SwitchRow()
+                    switch_row.set_title(_("Use shipping binary instead"))
+                    switch_row.set_subtitle(os.path.basename(shipping_path))
+                    switch_row._ue_shipping_exe = shipping_path
+                    self.list_warnings.append(switch_row)
         else:
             self.group_warnings.set_visible(False)
 
@@ -519,6 +528,14 @@ class EagleView(Gtk.Box):
             row = row.get_next_sibling()
 
         path = self.target_path
+        child = self.list_warnings.get_first_child()
+        while child:
+            if hasattr(child, "_ue_shipping_exe"):
+                if child.get_active():
+                    path = child._ue_shipping_exe
+                break
+            child = child.get_next_sibling()
+
         basename = os.path.basename(path)
         _uuid = str(uuid.uuid4())
         


### PR DESCRIPTION
# Description
Unreal Engine games ship with a small launcher whose sole job is to check for prerequisites, before running the real game binary found in Game/Binaries/Win64/Game-Win64-Shipping.exe

This check fails in Wine even when the correct runtime is installed via Bottles' dependency manager, producing a misleading error (pictured). This change makes Eagle recognize this pattern when analyzing Unreal Engine games and suggests to add the shipping binary instead.
<img width="333" height="189" alt="Screenshot From 2026-06-27 01-01-10" src="https://github.com/user-attachments/assets/9c7912b3-305e-4e65-8e53-1698b2930ca3" />
(typical error when running the Unreal launcher)

<img width="930" height="690" alt="Screenshot From 2026-06-27 00-41-16" src="https://github.com/user-attachments/assets/a0cbfe56-7b25-40d9-bc7f-9b6b46ab1405" />
(how the new feature appears in the Eagle analysis)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
