### PR TITLE
fix[closes #4557]: clean up desktop entries when removing programs

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -147,7 +147,9 @@ class Manager(metaclass=Singleton):
 
         # validating user-defined Paths.bottles
         if user_bottles_path := self.data_mgr.get(UserDataKeys.CustomBottlesPath):
-            is_portal_path = "/run/user/" in user_bottles_path and "/doc/" in user_bottles_path
+            is_portal_path = (
+                "/run/user/" in user_bottles_path and "/doc/" in user_bottles_path
+            )
             if is_portal_path:
                 # a transient document portal path is not usable across sessions
                 # and makes startup crash when it is no longer accessible
@@ -852,15 +854,16 @@ class Manager(metaclass=Singleton):
         missing_installation = len(winebridge) == 0 or not installed_identifier
         needs_latest = False
         if latest_supported:
-            needs_latest = (
-                missing_installation
-                or _is_newer(latest_supported, installed_identifier)
+            needs_latest = missing_installation or _is_newer(
+                latest_supported, installed_identifier
             )
 
         return latest_supported, installed_identifier, needs_latest
 
     def winebridge_update_status(self) -> dict:
-        latest_supported, installed_identifier, needs_latest = self.__winebridge_status()
+        latest_supported, installed_identifier, needs_latest = (
+            self.__winebridge_status()
+        )
         return {
             "latest_supported": latest_supported,
             "installed_identifier": installed_identifier,
@@ -871,7 +874,9 @@ class Manager(metaclass=Singleton):
     def check_winebridge(
         self, install_latest: bool = True, update: bool = False
     ) -> bool:
-        latest_supported, installed_identifier, needs_latest = self.__winebridge_status()
+        latest_supported, installed_identifier, needs_latest = (
+            self.__winebridge_status()
+        )
 
         can_install = install_latest or update
         if can_install and needs_latest and latest_supported:
@@ -1714,7 +1719,9 @@ class Manager(metaclass=Singleton):
 
         if not latencyflex:
             # if no latencyflex is specified, use the first one from available
-            latencyflex = self.latencyflex_available[0] if self.latencyflex_available else ""
+            latencyflex = (
+                self.latencyflex_available[0] if self.latencyflex_available else ""
+            )
         latencyflex_name = latencyflex
 
         # define bottle parameters
@@ -2238,9 +2245,7 @@ class Manager(metaclass=Singleton):
             return None
 
         latest = self.__get_latest_supported(self.supported_winebridge)
-        installed = (
-            self.winebridge_available[0] if self.winebridge_available else None
-        )
+        installed = self.winebridge_available[0] if self.winebridge_available else None
         if not latest or not self.__is_version_newer(latest, installed):
             return None
 
@@ -2292,9 +2297,7 @@ class Manager(metaclass=Singleton):
         match = re.search(r"\d+(?:[.-]\d+)+", normalized)
         if not match:
             return normalized, ()
-        version = tuple(
-            int(part) for part in re.split(r"[.-]", match.group(0))
-        )
+        version = tuple(int(part) for part in re.split(r"[.-]", match.group(0)))
         family = normalized[: match.start()] + normalized[match.end() :]
         return family, version
 
@@ -2396,6 +2399,9 @@ class Manager(metaclass=Singleton):
             return False
 
         logging.info("Removing applications installed with the bottle…")
+        for program in config.External_Programs.values():
+            ManagerUtils.remove_desktop_entry(config, program)
+
         for inst in glob(f"{Paths.applications}/{config.Name}--*"):
             os.remove(inst)
 
@@ -2470,6 +2476,7 @@ class Manager(metaclass=Singleton):
         # dxvk, vkd3d and nvapi require Vulkan to be present on the host.
         if not remove and component in ("dxvk", "vkd3d", "nvapi"):
             from bottles.backend.utils.vulkan import VulkanUtils
+
             if not VulkanUtils.check_support():
                 logging.warning(
                     f"Skipping {component} installation: Vulkan is not available on this system."
@@ -2482,17 +2489,29 @@ class Manager(metaclass=Singleton):
                 )
 
         if component == "dxvk":
-            _version = version or config.DXVK or (self.dxvk_available[0] if self.dxvk_available else "")
+            _version = (
+                version
+                or config.DXVK
+                or (self.dxvk_available[0] if self.dxvk_available else "")
+            )
             if not _version:
                 return Result(status=False, message=_("No DXVK version available."))
             manager = DXVKComponent(_version)
         elif component == "vkd3d":
-            _version = version or config.VKD3D or (self.vkd3d_available[0] if self.vkd3d_available else "")
+            _version = (
+                version
+                or config.VKD3D
+                or (self.vkd3d_available[0] if self.vkd3d_available else "")
+            )
             if not _version:
                 return Result(status=False, message=_("No VKD3D version available."))
             manager = VKD3DComponent(_version)
         elif component == "nvapi":
-            _version = version or config.NVAPI or (self.nvapi_available[0] if self.nvapi_available else "")
+            _version = (
+                version
+                or config.NVAPI
+                or (self.nvapi_available[0] if self.nvapi_available else "")
+            )
             if not _version:
                 return Result(status=False, message=_("No NVAPI version available."))
             manager = NVAPIComponent(_version)
@@ -2501,9 +2520,13 @@ class Manager(metaclass=Singleton):
             if not _version:
                 if len(self.latencyflex_available) == 0:
                     self.check_latencyflex(install_latest=True)
-                _version = self.latencyflex_available[0] if self.latencyflex_available else ""
+                _version = (
+                    self.latencyflex_available[0] if self.latencyflex_available else ""
+                )
             if not _version:
-                return Result(status=False, message=_("No LatencyFleX version available."))
+                return Result(
+                    status=False, message=_("No LatencyFleX version available.")
+                )
             manager = LatencyFleXComponent(_version)
         else:
             return Result(
@@ -2560,7 +2583,9 @@ class Manager(metaclass=Singleton):
                 state = p.get_state()
 
                 if name != "wineserver" and state != "Z":
-                    logging.info(f"Prefix {prefix} is active (e.g. {name}), protecting.")
+                    logging.info(
+                        f"Prefix {prefix} is active (e.g. {name}), protecting."
+                    )
                     protected_prefixes.add(prefix)
                     break
 

--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -21,6 +21,7 @@ from gettext import gettext as _
 from typing import Optional
 
 import icoextract  # type: ignore [import-untyped]
+import gi
 
 from bottles.backend.params import APP_ID
 
@@ -32,6 +33,8 @@ from bottles.backend.state import SignalManager, Signals
 from bottles.backend.utils.generic import get_mime
 from bottles.backend.utils.imagemagick import ImageMagickUtils
 
+gi.require_version("Xdp", "1.0")
+# ruff: noqa: E402
 from gi.repository import GLib, Gio, Xdp
 
 portal = Xdp.Portal()
@@ -306,13 +309,7 @@ class ManagerUtils:
 
         def create_manual_fallback(icon_path, exec_cmd):
             """Create desktop entry manually when portal is unavailable."""
-            safe_name = "".join(
-                [c for c in program.get("name") if c.isalnum() or c in ("-", "_")]
-            )
-            safe_bottle = "".join(
-                [c for c in config.get("Name") if c.isalnum() or c in ("-", "_")]
-            )
-            filename = f"bottles-{safe_bottle}-{safe_name}.desktop"
+            filename = ManagerUtils.get_desktop_entry_filename(config, program)
             content = (
                 f"[Desktop Entry]\n"
                 f"Exec={exec_cmd}\n"
@@ -371,15 +368,10 @@ class ManagerUtils:
                 create_manual_fallback(icon, exec_cmd)
                 return
 
-            launcher_id = f"{config.get('Name')}.{program.get('name')}"
-            sum_type = GLib.ChecksumType.SHA1
             try:
                 portal.dynamic_launcher_install(
                     ret["token"],
-                    "{}.App_{}.desktop".format(
-                        APP_ID,
-                        GLib.compute_checksum_for_string(sum_type, launcher_id, -1),
-                    ),
+                    ManagerUtils.get_desktop_entry_id(config, program),
                     """[Desktop Entry]
                     Exec={}
                     Type=Application
@@ -421,6 +413,60 @@ class ManagerUtils:
             None,
             prepare_install_cb,
         )
+
+    @staticmethod
+    def get_desktop_entry_id(config, program: dict):
+        launcher_id = f"{config.get('Name')}.{program.get('name')}"
+        return "{}.App_{}.desktop".format(
+            APP_ID,
+            GLib.compute_checksum_for_string(
+                GLib.ChecksumType.SHA1,
+                launcher_id,
+                -1,
+            ),
+        )
+
+    @staticmethod
+    def get_desktop_entry_filename(config, program: dict):
+        safe_name = "".join(
+            [c for c in program.get("name") if c.isalnum() or c in ("-", "_")]
+        )
+        safe_bottle = "".join(
+            [c for c in config.get("Name") if c.isalnum() or c in ("-", "_")]
+        )
+        return f"bottles-{safe_bottle}-{safe_name}.desktop"
+
+    @staticmethod
+    def remove_desktop_entry(config, program: dict):
+        desktop_entry_id = ManagerUtils.get_desktop_entry_id(config, program)
+        try:
+            portal.dynamic_launcher_uninstall(desktop_entry_id)
+            logging.info(f"Desktop entry removed: {desktop_entry_id}")
+        except GLib.Error as e:
+            logging.debug(f"Failed to remove desktop entry {desktop_entry_id}: {e}")
+
+        desktop_entry_filename = ManagerUtils.get_desktop_entry_filename(
+            config, program
+        )
+        entry_paths = [
+            os.path.join(
+                os.path.expanduser("~/.local/share/applications"),
+                desktop_entry_filename,
+            )
+        ]
+        desktop_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP)
+        if desktop_dir:
+            entry_paths.append(os.path.join(desktop_dir, desktop_entry_filename))
+
+        for entry_path in entry_paths:
+            if not os.path.exists(entry_path):
+                continue
+
+            try:
+                os.remove(entry_path)
+                logging.info(f"Desktop entry removed: {entry_path}")
+            except OSError as e:
+                logging.warning(f"Failed to remove desktop entry {entry_path}: {e}")
 
     @staticmethod
     def browse_wineprefix(wineprefix: dict):

--- a/bottles/frontend/widgets/program.py
+++ b/bottles/frontend/widgets/program.py
@@ -44,6 +44,7 @@ from bottles.frontend.windows.rename import RenameDialog
 
 from typing import Optional
 
+
 # noinspection PyUnusedLocal
 @Gtk.Template(resource_path="/com/usebottles/bottles/program-entry.ui")
 class ProgramEntry(Adw.ActionRow):
@@ -449,9 +450,15 @@ class ProgramEntry(Adw.ActionRow):
 
     def uninstall_program(self, _widget):
         uninstaller = Uninstaller(self.config)
+
+        def update(_result=False, _error=False):
+            if not _error:
+                ManagerUtils.remove_desktop_entry(self.config, self.program)
+            self.update_programs()
+
         RunAsync(
             task_func=uninstaller.from_name,
-            callback=self.update_programs,
+            callback=update,
             name=self.program["name"],
         )
 
@@ -478,6 +485,7 @@ class ProgramEntry(Adw.ActionRow):
         ).data["config"]
 
     def remove_program(self, _widget=None):
+        ManagerUtils.remove_desktop_entry(self.config, self.program)
         self.config = self.manager.update_config(
             config=self.config,
             key=self.program["id"],
@@ -540,13 +548,14 @@ class ProgramEntry(Adw.ActionRow):
                 "name": self.program["name"],
                 "executable": self.program["executable"],
                 "path": self.program["path"],
-            }
+            },
         )
 
         def _on_desktop_entry_created(data: Optional[Result] = None) -> None:
             self.window.show_toast(
                 _('Desktop Entry created for "{0}"').format(self.program["name"])
             )
+
         SignalManager.connect(Signals.DesktopEntryCreated, _on_desktop_entry_created)
 
     def add_to_library(self, _widget):

--- a/bottles/tests/backend/utils/test_manager.py
+++ b/bottles/tests/backend/utils/test_manager.py
@@ -1,0 +1,26 @@
+"""Unit tests for ManagerUtils."""
+
+from bottles.backend.models.config import BottleConfig
+from bottles.backend.utils import manager
+from bottles.backend.utils.manager import ManagerUtils
+
+
+def test_desktop_entry_id_matches_dynamic_launcher_format(monkeypatch):
+    monkeypatch.setattr(manager, "APP_ID", "com.usebottles.bottles")
+    config = BottleConfig(Name="Issue4557Test")
+    program = {"name": "Issue4557Dummy"}
+
+    assert (
+        ManagerUtils.get_desktop_entry_id(config, program)
+        == "com.usebottles.bottles.App_1e37a76b8f4de7c4a872eedb8dcb800172bb98c6.desktop"
+    )
+
+
+def test_desktop_entry_filename_sanitizes_bottle_and_program_names():
+    config = BottleConfig(Name="Test Bottle!")
+    program = {"name": "Game Name!.exe"}
+
+    assert (
+        ManagerUtils.get_desktop_entry_filename(config, program)
+        == "bottles-TestBottle-GameNameexe.desktop"
+    )


### PR DESCRIPTION
# Description
Bottles creates desktop entries for programs through the XDG Desktop Portal Dynamic Launcher API, with a manual `.desktop` fallback when the portal is unavailable.

Previously, those desktop entries were not cleaned up when:
  - a program was removed from a bottle
  - a program was uninstalled
  - a bottle was deleted

This adds cleanup for portal-created desktop entries and the manual fallback files.

Fixes #4557

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  - [x] Reproduced the bug on stable Bottles by creating a desktop entry for a dummy executable, removing the program from the bottle, and confirming the `.desktop` file remained in `~/.local/share/xdg-desktop-portal/applications`
  - [x] Reproduced the bug on stable Bottles by deleting the whole bottle and confirming the `.desktop` file remained
  - [x] Built and installed `com.usebottles.bottles.Devel` from this branch
  - [x] Verified the fix by repeating the same flows and confirming the `.desktop` file was removed for both program
  removal and bottle deletion
  - [x] Ran unit tests and lint checks

Commands run:
```bash
  python -m pytest bottles/tests/backend/utils/test_manager.py
  uvx ruff==0.8.2 check bottles/backend/utils/manager.py bottles/frontend/widgets/program.py bottles/backend/
  managers/manager.py bottles/tests/backend/utils/test_manager.py
  uvx ruff==0.8.2 format --check bottles/backend/utils/manager.py bottles/frontend/widgets/program.py bottles/
  backend/managers/manager.py bottles/tests/backend/utils/test_manager.py
```

Media:

 - Stable reproductions (bugged): 

https://github.com/user-attachments/assets/0de920ad-a513-451c-9dc8-9e65bd5448ed

https://github.com/user-attachments/assets/fe522922-f63a-440f-812a-aee8e81fedd9

 - Devel verification (fix): 

https://github.com/user-attachments/assets/37f94a5e-603b-4932-8fe9-c816821a9d2d