### PR TITLE
Fix Chinese locale display names to use standard conventions

### DIFF
--- a/bottles/backend/utils/manager.py
+++ b/bottles/backend/utils/manager.py
@@ -496,9 +496,9 @@ class ManagerUtils:
             _("Slovenian"),
             _("Swedish"),
             _("Turkish"),
-            _("Chinese"),
+            _("Chinese (Simplified)"),
             _("Japanese"),
-            _("Taiwanese"),
+            _("Chinese (Traditional)"),
             _("Korean"),
         ]
 


### PR DESCRIPTION
"Chinese" → "Chinese (Simplified)" (zh_CN)
"Taiwanese" → "Chinese (Traditional)" (zh_TW)

"Taiwanese" is a colloquial term for Taiwanese Minnan Chinese, not Standard Chinese used in Taiwan. The Simplified/Traditional distinction is the established convention in software (and matches zh_Hans/zh_Hant).

Fixes #4547

# Description
Please include a summary of the change and which issue is fixed (if available).
Please also include relevant motivation and context.

Fixes #(issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
