### PR TITLE
fix: prevent `MANGOHUD_CONFIG` from blocking the user config file

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -410,7 +410,7 @@ class WineCommand:
             env.add("MANGOHUD", "1")
             env.add("MANGOHUD_DLSYM", "1")
             if not params.mangohud_display_on_game_start:
-                env.add("MANGOHUD_CONFIG", "no_display")
+                env.add("MANGOHUD_CONFIG", "read_cfg,no_display")
 
         # vkBasalt environment variables
         if params.vkbasalt and not self.minimal:


### PR DESCRIPTION
# Description
Currently, when “Display On Game Start” is disabled, `MANGOHUD_CONFIG=no_display` is set, which causes the user’s own config file, such as `~/.config/MangoHud/MangoHud.conf`, to be ignored.

This usually isn’t the expected behavior, and it’s also inconsistent with what happens when the option is enabled. We should use `MANGOHUD_CONFIG=read_cfg,no_display` instead.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
