### PR TITLE
Fix linked whitespace after image badges in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,12 @@
 <br/>
 
 <div align="center">
-  <a href="https://flathub.org/apps/com.usebottles.bottles">
-    <img alt="Flathub" src="https://img.shields.io/flathub/downloads/com.usebottles.bottles" />
-  </a>
-  <a href="https://hosted.weblate.org/engage/bottles">
-    <img src="https://hosted.weblate.org/widgets/bottles/-/bottles/svg-badge.svg" />
-  </a>
-  <a href="https://www.codefactor.io/repository/github/bottlesdevs/bottles/overview/main">
-    <img src="https://www.codefactor.io/repository/github/bottlesdevs/bottles/badge/main" />
-  </a>
-  <a href="https://github.com/bottlesdevs/Bottles/blob/main/LICENSE">
-    <img src="https://img.shields.io/badge/License-GPL--3.0-blue.svg">
-  </a>
+  <a href="https://flathub.org/apps/com.usebottles.bottles"><img alt="Flathub" src="https://img.shields.io/flathub/downloads/com.usebottles.bottles" /></a>
+  <a href="https://hosted.weblate.org/engage/bottles"><img src="https://hosted.weblate.org/widgets/bottles/-/bottles/svg-badge.svg" /></a>
+  <a href="https://www.codefactor.io/repository/github/bottlesdevs/bottles/overview/main"><img src="https://www.codefactor.io/repository/github/bottlesdevs/bottles/badge/main" /></a>
+  <a href="https://github.com/bottlesdevs/Bottles/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-GPL--3.0-blue.svg"></a>
   <br>
-  <a href="https://stopthemingmy.app" title="Please do not theme this app">
-    <img src="https://stopthemingmy.app/badge.svg">
-  </a>
+  <a href="https://stopthemingmy.app" title="Please do not theme this app"><img src="https://stopthemingmy.app/badge.svg"></a>
 
   <hr />
 


### PR DESCRIPTION
# Description
The spaces after the image badges were also having link, thus blue underlines after them.
So I simply fixed it!

### Before:
<img width="871" height="180" alt="image" src="https://github.com/user-attachments/assets/c2972843-ee30-4036-8a22-21fa99271979" />

### After:
<img width="867" height="166" alt="image" src="https://github.com/user-attachments/assets/eef3b048-e60f-4627-b8ab-707b2b719cb5" />

## Type of change
- [x] Documentation Update
