### PR TITLE
feat: share USB devices with dedicated sandboxes

### DIFF
--- a/bottles/backend/managers/sandbox.py
+++ b/bottles/backend/managers/sandbox.py
@@ -26,7 +26,8 @@ from typing import Optional
 
 FLATPAK_INFO = "/.flatpak-info"
 FLATPAK_SHARE_INPUT = 1 << 5
-FLATPAK_SHARE_INPUT_VERSION = (1, 17, 1)
+FLATPAK_SHARE_USB = 1 << 6
+FLATPAK_SHARE_DEVICES_VERSION = (1, 17, 1)
 
 
 class SandboxManager:
@@ -52,6 +53,7 @@ class SandboxManager:
         share_sound: bool = True,
         share_gpu: bool = True,
         share_input: bool = False,
+        share_usb: bool = False,
     ):
         self.envs = envs
         self.chdir = chdir
@@ -65,12 +67,13 @@ class SandboxManager:
         self.share_sound = share_sound
         self.share_gpu = share_gpu
         self.share_input = share_input
+        self.share_usb = share_usb
         self.__uid = os.environ.get("UID", "1000")
 
     @staticmethod
-    def supports_input_devices() -> bool:
+    def _supports_device(device: str, path: str) -> bool:
         if "FLATPAK_ID" not in os.environ:
-            return os.path.isdir("/dev/input")
+            return os.path.isdir(path)
 
         try:
             info = ConfigParser(interpolation=None)
@@ -83,9 +86,17 @@ class SandboxManager:
         except (KeyError, ValueError):
             return False
 
-        return version >= FLATPAK_SHARE_INPUT_VERSION and bool(
-            {"all", "input"}.intersection(devices)
+        return version >= FLATPAK_SHARE_DEVICES_VERSION and bool(
+            {"all", device}.intersection(devices)
         )
+
+    @classmethod
+    def supports_input_devices(cls) -> bool:
+        return cls._supports_device("input", "/dev/input")
+
+    @classmethod
+    def supports_usb_devices(cls) -> bool:
+        return cls._supports_device("usb", "/dev/bus/usb")
 
     def __get_bwrap(self, cmd: str):
         _cmd = ["bwrap"]
@@ -124,6 +135,9 @@ class SandboxManager:
 
         if not self.share_input and os.path.isdir("/dev/input"):
             _cmd.append("--tmpfs /dev/input")
+
+        if not self.share_usb and os.path.isdir("/dev/bus/usb"):
+            _cmd.append("--tmpfs /dev/bus/usb")
 
         if self.share_display:
             _cmd.append("--dev-bind /dev/video0 /dev/video0")
@@ -175,6 +189,9 @@ class SandboxManager:
 
         if self.share_input and self.supports_input_devices():
             _cmd.append(f"--sandbox-flag={FLATPAK_SHARE_INPUT}")
+
+        if self.share_usb and self.supports_usb_devices():
+            _cmd.append(f"--sandbox-flag={FLATPAK_SHARE_USB}")
 
         if self.clear_env:
             clean_env = " ".join(

--- a/bottles/backend/models/config.py
+++ b/bottles/backend/models/config.py
@@ -89,6 +89,7 @@ class BottleSandboxParams(DictCompatMixIn):
     share_net: bool = False
     share_sound: bool = False
     share_input: bool = False
+    share_usb: bool = False
     # share_host_ro: bool = True  # TODO: implement, requires the Bottles runtime (next) for a minimal sandbox
     # share_gpu: bool = True  # TODO: implement
     # share_paths_ro: List[str] = field(default_factory=lambda: [])  # TODO: implement

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -1021,6 +1021,7 @@ class WineCommand:
             share_net=self.config.Sandbox.share_net,
             share_sound=self.config.Sandbox.share_sound,
             share_input=self.config.Sandbox.share_input,
+            share_usb=self.config.Sandbox.share_usb,
         )
 
     def run(self) -> Result[Optional[str]]:

--- a/bottles/frontend/ui/dialog-sandbox.blp
+++ b/bottles/frontend/ui/dialog-sandbox.blp
@@ -48,6 +48,16 @@ template $SandboxDialog: Adw.Window {
             valign: center;
           }
         }
+
+        Adw.ActionRow row_usb {
+          title: _("Share USB Devices");
+          subtitle: _("Programs in this bottle can access raw USB devices permitted by the host while enabled.");
+          activatable-widget: switch_usb;
+
+          Switch switch_usb {
+            valign: center;
+          }
+        }
       }
     }
   }

--- a/bottles/frontend/windows/sandbox.py
+++ b/bottles/frontend/windows/sandbox.py
@@ -31,6 +31,8 @@ class SandboxDialog(Adw.Window):
     switch_sound = Gtk.Template.Child()
     row_input = Gtk.Template.Child()
     switch_input = Gtk.Template.Child()
+    row_usb = Gtk.Template.Child()
+    switch_usb = Gtk.Template.Child()
 
     # endregion
 
@@ -48,6 +50,7 @@ class SandboxDialog(Adw.Window):
         self.switch_net.connect("state-set", self.__set_flag, "share_net")
         self.switch_sound.connect("state-set", self.__set_flag, "share_sound")
         self.switch_input.connect("state-set", self.__set_flag, "share_input")
+        self.switch_usb.connect("state-set", self.__set_flag, "share_usb")
 
     def __set_flag(self, widget, state, flag):
         self.config = self.manager.update_config(
@@ -58,8 +61,12 @@ class SandboxDialog(Adw.Window):
         self.switch_net.set_active(config.Sandbox.share_net)
         self.switch_sound.set_active(config.Sandbox.share_sound)
         self.switch_input.set_active(config.Sandbox.share_input)
+        self.switch_usb.set_active(config.Sandbox.share_usb)
         if not SandboxManager.supports_input_devices():
             self.row_input.set_sensitive(False)
             self.row_input.set_subtitle(
                 _("Input devices cannot be shared on this system.")
             )
+        if not SandboxManager.supports_usb_devices():
+            self.row_usb.set_sensitive(False)
+            self.row_usb.set_subtitle(_("USB devices cannot be shared on this system."))

--- a/bottles/tests/backend/manager/test_sandbox.py
+++ b/bottles/tests/backend/manager/test_sandbox.py
@@ -28,6 +28,26 @@ def test_flatpak_input_capability(monkeypatch, tmp_path, version, devices, suppo
     assert SandboxManager.supports_input_devices() is supported
 
 
+@pytest.mark.parametrize(
+    ("version", "devices", "supported"),
+    [
+        ("1.16.6", "all;", False),
+        ("1.17.1", "all;", True),
+        ("1.17.1", "usb;", True),
+        ("1.18.0", "dri;", False),
+    ],
+)
+def test_flatpak_usb_capability(monkeypatch, tmp_path, version, devices, supported):
+    flatpak_info = tmp_path / "flatpak-info"
+    flatpak_info.write_text(
+        f"[Instance]\nflatpak-version={version}\n[Context]\ndevices={devices}\n"
+    )
+    monkeypatch.setenv("FLATPAK_ID", "com.usebottles.bottles")
+    monkeypatch.setattr(sandbox_module, "FLATPAK_INFO", str(flatpak_info))
+
+    assert SandboxManager.supports_usb_devices() is supported
+
+
 def test_flatpak_input_flag_requires_capability(monkeypatch):
     monkeypatch.setenv("FLATPAK_ID", "com.usebottles.bottles")
     monkeypatch.setattr(
@@ -87,6 +107,45 @@ def test_flatpak_clear_environment_quotes_variable_names(monkeypatch):
     assert "'VALUE; touch /tmp/not-run=content'" in command
 
 
+def test_flatpak_usb_flag_requires_capability(monkeypatch):
+    monkeypatch.setenv("FLATPAK_ID", "com.usebottles.bottles")
+    monkeypatch.setattr(
+        SandboxManager,
+        "supports_usb_devices",
+        staticmethod(lambda: False),
+    )
+
+    command = SandboxManager(share_usb=True).get_cmd("true")
+
+    assert "--sandbox-flag=64" not in command
+
+
+def test_flatpak_usb_flag_is_added_when_supported(monkeypatch):
+    monkeypatch.setenv("FLATPAK_ID", "com.usebottles.bottles")
+    monkeypatch.setattr(
+        SandboxManager,
+        "supports_usb_devices",
+        staticmethod(lambda: True),
+    )
+
+    command = SandboxManager(share_usb=True).get_cmd("true")
+
+    assert "--sandbox-flag=64" in command
+
+
+def test_flatpak_usb_flag_is_opt_in_when_supported(monkeypatch):
+    monkeypatch.setenv("FLATPAK_ID", "com.usebottles.bottles")
+    monkeypatch.setattr(
+        SandboxManager,
+        "supports_usb_devices",
+        staticmethod(lambda: True),
+    )
+
+    command = SandboxManager(share_usb=False).get_cmd("true")
+
+    assert "--sandbox-flag=64" not in command
+
+
 def test_bwrap_input_devices_are_opt_in(monkeypatch):
     monkeypatch.delenv("FLATPAK_ID", raising=False)
     monkeypatch.setattr(
@@ -100,6 +159,19 @@ def test_bwrap_input_devices_are_opt_in(monkeypatch):
     assert "--tmpfs /dev/input" not in shared
 
 
+def test_bwrap_usb_devices_are_opt_in(monkeypatch):
+    monkeypatch.delenv("FLATPAK_ID", raising=False)
+    monkeypatch.setattr(
+        "bottles.backend.managers.sandbox.os.path.isdir", lambda _: True
+    )
+
+    restricted = SandboxManager(share_usb=False).get_cmd("true")
+    shared = SandboxManager(share_usb=True).get_cmd("true")
+
+    assert "--tmpfs /dev/bus/usb" in restricted
+    assert "--tmpfs /dev/bus/usb" not in shared
+
+
 def test_input_devices_are_opt_in():
     assert BottleConfig().Sandbox.share_input is False
 
@@ -107,6 +179,18 @@ def test_input_devices_are_opt_in():
 
     assert result.status is True
     assert result.data.Sandbox.share_input is True
+
+
+def test_usb_devices_are_opt_in():
+    assert BottleConfig().Sandbox.share_usb is False
+
+    legacy = BottleConfig._fill_with({"Sandbox": {"share_input": True}})
+    result = BottleConfig._fill_with({"Sandbox": {"share_usb": True}})
+
+    assert legacy.status is True
+    assert legacy.data.Sandbox.share_usb is False
+    assert result.status is True
+    assert result.data.Sandbox.share_usb is True
 
 
 def test_wine_command_passes_input_permission(monkeypatch, tmp_path):
@@ -124,3 +208,20 @@ def test_wine_command_passes_input_permission(monkeypatch, tmp_path):
     sandbox = WineCommand._get_sandbox_manager(command)
 
     assert sandbox.share_input is True
+
+
+def test_wine_command_passes_usb_permission(monkeypatch, tmp_path):
+    command = object.__new__(WineCommand)
+    command.config = BottleConfig(Name="Test", Path=str(tmp_path), Runner="sys-wine")
+    command.config.Sandbox.share_usb = True
+    command.env = {}
+    command.cwd = str(tmp_path)
+    command.runner_runtime = None
+    command.steam_runtime_root = None
+
+    monkeypatch.setattr(ManagerUtils, "get_bottle_path", lambda _config: str(tmp_path))
+    monkeypatch.setattr(ManagerUtils, "get_runner_path", lambda _runner: "sys-wine")
+
+    sandbox = WineCommand._get_sandbox_manager(command)
+
+    assert sandbox.share_usb is True


### PR DESCRIPTION
- [#2811](https://github.com/bottlesdevs/Bottles/issues/2811) - Allow programs in bottles to access certain peripherals.