### PR TITLE
fix: preserve hidden files in bottle duplicates

### DIFF
--- a/bottles/backend/managers/backup.py
+++ b/bottles/backend/managers/backup.py
@@ -765,7 +765,6 @@ class BackupManager:
                     shutil.copytree(
                         source_item,
                         destination_item,
-                        ignore=shutil.ignore_patterns(".*"),
                         symlinks=True,
                     )
                 elif os.path.isfile(source_item):

--- a/bottles/tests/backend/manager/test_backup.py
+++ b/bottles/tests/backend/manager/test_backup.py
@@ -120,6 +120,31 @@ def test_full_backup_keeps_existing_filter_behavior(tmp_path):
         assert not any("dosdevices" in name for name in names)
 
 
+def test_duplicate_bottle_preserves_hidden_files(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    drive_c = source / "drive_c"
+    hidden_directory = drive_c / ".hidden-directory"
+    hidden_directory.mkdir(parents=True)
+    (drive_c / ".hidden-file").write_bytes(b"hidden")
+    (hidden_directory / "payload.dat").write_bytes(b"payload")
+    with (source / "bottle.yml").open("w") as config_file:
+        yaml.dump({"Name": "Source", "Path": "Source"}, config_file)
+
+    result = BackupManager._duplicate_bottle_directory(
+        BottleConfig(Name="Source", Path="Source"),
+        str(source),
+        str(destination),
+        "Destination",
+    )
+
+    assert result.status
+    assert (destination / "drive_c/.hidden-file").read_bytes() == b"hidden"
+    assert (
+        destination / "drive_c/.hidden-directory/payload.dat"
+    ).read_bytes() == b"payload"
+
+
 def test_full_backup_is_atomic_when_cancelled_during_file_copy(tmp_path, monkeypatch):
     source = tmp_path / "bottle"
     source.mkdir()


### PR DESCRIPTION
- [#4620](https://github.com/bottlesdevs/Bottles/issues/4620) - [Bug]: Duplicate Bottle does not copy files or folders that are hidden with a dot at the start of their name