### PR TITLE
fix[closes #4622]: handle missing versioning paths

### DIFF
--- a/bottles/backend/managers/versioning.py
+++ b/bottles/backend/managers/versioning.py
@@ -200,24 +200,38 @@ class VersioningManager:
         of the given bottle and return them as a dict.
         """
         if not self.needs_migration(config):
+            bottle_path = ManagerUtils.get_bottle_path(config)
+            empty_data = {
+                "state_id": None,
+                "states": {},
+                "branches": [],
+                "active_branch": "",
+                "dirty": False,
+                "changed_files": 0,
+            }
+            if not os.path.isdir(bottle_path):
+                return Result(status=False, data=empty_data)
             try:
-                repo = FVSRepo(
-                    repo_path=ManagerUtils.get_bottle_path(config),
-                    use_compression=config.Parameters.versioning_compression,
-                )
-                if check_dirty:
-                    repo.check_dirty()
-            except FVSStateNotFound:
-                logging.warning(
-                    "The FVS repository may be corrupted, trying to re-initialize it"
-                )
-                self.re_initialize(config)
-                repo = FVSRepo(
-                    repo_path=ManagerUtils.get_bottle_path(config),
-                    use_compression=config.Parameters.versioning_compression,
-                )
-                if check_dirty:
-                    repo.check_dirty()
+                try:
+                    repo = FVSRepo(
+                        repo_path=bottle_path,
+                        use_compression=config.Parameters.versioning_compression,
+                    )
+                    if check_dirty:
+                        repo.check_dirty()
+                except FVSStateNotFound:
+                    logging.warning(
+                        "The FVS repository may be corrupted, trying to re-initialize it"
+                    )
+                    self.re_initialize(config)
+                    repo = FVSRepo(
+                        repo_path=bottle_path,
+                        use_compression=config.Parameters.versioning_compression,
+                    )
+                    if check_dirty:
+                        repo.check_dirty()
+            except FileNotFoundError:
+                return Result(status=False, data=empty_data)
             return Result(
                 status=True,
                 message=_("States list retrieved successfully!"),

--- a/bottles/tests/backend/manager/test_versioning.py
+++ b/bottles/tests/backend/manager/test_versioning.py
@@ -220,3 +220,57 @@ def test_create_state_keeps_success_result(tmp_path, monkeypatch, snapshot_confi
     }
     assert refreshed == [True]
     assert TaskManager._TASKS == {}
+
+
+def test_list_states_handles_missing_bottle(tmp_path, monkeypatch, snapshot_config):
+    missing_bottle = tmp_path / "missing"
+    snapshot_config.Versioning = False
+
+    monkeypatch.setattr(
+        versioning_module.ManagerUtils,
+        "get_bottle_path",
+        lambda _config: str(missing_bottle),
+    )
+
+    result = VersioningManager(SimpleNamespace()).list_states(snapshot_config)
+
+    assert not result.status
+    assert not missing_bottle.exists()
+    assert result.data == {
+        "state_id": None,
+        "states": {},
+        "branches": [],
+        "active_branch": "",
+        "dirty": False,
+        "changed_files": 0,
+    }
+
+
+def test_list_states_handles_bottle_removed_during_recovery(
+    tmp_path, monkeypatch, snapshot_config
+):
+    bottle = tmp_path / "bottle"
+    bottle.mkdir()
+    snapshot_config.Versioning = False
+    attempts = []
+
+    class RepoStub:
+        def __init__(self, **_kwargs):
+            attempts.append(True)
+            if len(attempts) == 1:
+                raise versioning_module.FVSStateNotFound
+            bottle.rmdir()
+            raise FileNotFoundError
+
+    monkeypatch.setattr(
+        versioning_module.ManagerUtils,
+        "get_bottle_path",
+        lambda _config: str(bottle),
+    )
+    monkeypatch.setattr(versioning_module, "FVSRepo", RepoStub)
+
+    result = VersioningManager(SimpleNamespace()).list_states(snapshot_config)
+
+    assert len(attempts) == 2
+    assert not result.status
+    assert result.data["states"] == {}


### PR DESCRIPTION
- [#4622](https://github.com/bottlesdevs/Bottles/issues/4622) Versioning crashes when a Steam bottle path disappears