### PR TITLE
feat: enable steamrt4 for Proton 11+

### DIFF
--- a/bottles/backend/managers/runtime.py
+++ b/bottles/backend/managers/runtime.py
@@ -130,6 +130,13 @@ class RuntimeManager:
             return available_runtimes
 
         lookup = {
+            "steamrt4": {
+                "name": "steamrt4",
+                "entry_point": os.path.join(
+                    steam_manager.steam_path,
+                    "steamapps/common/SteamLinuxRuntime_4/_v2-entry-point",
+                ),
+            },
             "sniper": {
                 "name": "sniper",
                 "entry_point": os.path.join(

--- a/bottles/backend/utils/steam.py
+++ b/bottles/backend/utils/steam.py
@@ -86,7 +86,9 @@ class SteamUtils:
         data = SteamUtils.parse_vdf(f.read())
         tool_appid = data.get("manifest", {}).get("require_tool_appid", {})
 
-        if "1628350" in tool_appid:
+        if "4183110" in tool_appid:
+            runtime = "steamrt4"
+        elif "1628350" in tool_appid:
             runtime = "sniper"
         elif "1391110" in tool_appid:
             runtime = "soldier"

--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -856,9 +856,14 @@ class WineCommand:
             _picked = {}
 
             if _rs:
-                if "sniper" in _rs.keys() and "sniper" in self.runner_runtime:
+                if "steamrt4" in _rs.keys() and "steamrt4" in self.runner_runtime:
                     """
-                    Sniper is the default runtime used by Proton version >= 8.0
+                    Steam Linux Runtime 4 (steamrt4) is the default runtime used by Proton version >= 11.0
+                    """
+                    _picked = _rs["steamrt4"]
+                elif "sniper" in _rs.keys() and "sniper" in self.runner_runtime:
+                    """
+                    Sniper is the default runtime used by Proton version >= 8.0 and < 11.0
                     """
                     _picked = _rs["sniper"]
                 elif "soldier" in _rs.keys() and "soldier" in self.runner_runtime:


### PR DESCRIPTION
# Description
Any bottle using a Proton 11-based runner that requires the Steam Runtime will currently use the incorrect scout 1.0 runtime, as the `"require_tool_appid" "4183110"` line that these runners specify in the `toolmanifest.vdf` file is not referenced in the current build (65.0 and 65.1).


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Steam Runtime 4 shares a similar structure as the Sniper and Soldier runtimes, so I don't anticipate this PR itself introducing new bugs.

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [x] While the bottle was using a Proton 11 runner (GE Proton 11-3) with Steam Runtime enabled, I launched an application and observed that it was using Steam Runtime 4 (steamapps/common/SteamLinuxRuntime_4/_v2-entry-point) in the terminal.