### PR TITLE
fix: sync libvkd3d-utils for Proton 11

### DIFF
--- a/bottles/backend/utils/steam.py
+++ b/bottles/backend/utils/steam.py
@@ -117,9 +117,6 @@ class SteamUtils:
         """Sync Proton's WineD3D dependencies into a Bottles prefix."""
         dist_directory = SteamUtils.get_dist_directory(path)
         default_prefix = os.path.join(dist_directory, "share/default_pfx")
-        """
-            libvkd3d-utils-1 was first introduced in Proton 11
-        """
         dlls = ("libvkd3d-1.dll", "libvkd3d-shader-1.dll", "libvkd3d-utils-1.dll")
         directories = [("system32", "system32"), ("syswow64", "syswow64")]
         if arch == "win32":

--- a/bottles/backend/utils/steam.py
+++ b/bottles/backend/utils/steam.py
@@ -117,7 +117,10 @@ class SteamUtils:
         """Sync Proton's WineD3D dependencies into a Bottles prefix."""
         dist_directory = SteamUtils.get_dist_directory(path)
         default_prefix = os.path.join(dist_directory, "share/default_pfx")
-        dlls = ("libvkd3d-1.dll", "libvkd3d-shader-1.dll")
+        """
+            libvkd3d-utils-1 was first introduced in Proton 11
+        """
+        dlls = ("libvkd3d-1.dll", "libvkd3d-shader-1.dll", "libvkd3d-utils-1.dll")
         directories = [("system32", "system32"), ("syswow64", "syswow64")]
         if arch == "win32":
             directories = [("syswow64", "system32")]

--- a/bottles/tests/backend/utils/test_steam.py
+++ b/bottles/tests/backend/utils/test_steam.py
@@ -51,6 +51,30 @@ def test_associated_runtime_is_unknown_without_toolmanifest(tmp_path: Path) -> N
     assert SteamUtils.get_associated_runtime(str(proton_path)) is None
 
 
+def test_sync_proton_vkd3d_copies_wined3d_dependencies(tmp_path: Path) -> None:
+    proton_path = tmp_path / "Proton"
+    default_prefix = proton_path / "files/share/default_pfx/drive_c/windows"
+    prefix = tmp_path / "prefix"
+    dlls = (
+        "libvkd3d-1.dll",
+        "libvkd3d-shader-1.dll",
+        "libvkd3d-utils-1.dll",
+    )
+    for directory in ("system32", "syswow64"):
+        source = default_prefix / directory
+        source.mkdir(parents=True)
+        for dll in dlls:
+            (source / dll).write_bytes(f"{directory}/{dll}".encode())
+
+    SteamUtils.sync_proton_vkd3d(str(proton_path), str(prefix), "win64")
+
+    for directory in ("system32", "syswow64"):
+        for dll in dlls:
+            assert (prefix / "drive_c/windows" / directory / dll).read_bytes() == (
+                f"{directory}/{dll}".encode()
+            )
+
+
 def _write_protonfixes(path: Path, replacement: str) -> None:
     package = path / "protonfixes"
     package.mkdir(parents=True)


### PR DESCRIPTION
# Description
Proton 11 introduced the `libvkd3d-utils-1` library. This PR extends 8871ec7e919b333e2438cbb6530763f2f36f29ec to include this dependency.

Fixes #4644 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Created a new bottle with a Proton 11-based runner and the Steam Runtime enabled, then observed that the three VKD3D libraries were copied into the bottle's `drive_c/windows/system32` and `syswow64` folders when an application was executed
- [x] No errors pertaining to the missing library were logged in the terminal
