### PR TITLE
fix[closes #4645]: expand cabinet source wildcards

### DIFF
--- a/bottles/backend/cabextract.py
+++ b/bottles/backend/cabextract.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import fnmatch
+import glob
 import os
 import shutil
 import subprocess
@@ -63,13 +65,29 @@ class CabExtract:
         return self.__extract()
 
     def __checks(self):
-        if not os.path.exists(self.path) and "*" not in self.path:
+        if not os.path.exists(self.path) and not glob.has_magic(self.path):
             logging.error(f"Cab file {self.path} not found")
             return False
 
         return True
 
+    @staticmethod
+    def __matching_files(destination: str, expected: str) -> dict:
+        return {
+            os.path.join(root, name): os.lstat(os.path.join(root, name)).st_ctime_ns
+            for root, _, names in os.walk(destination)
+            for name in names
+            if fnmatch.fnmatch(name.lower(), expected)
+        }
+
     def __extract(self) -> bool:
+        paths = [self.path]
+        if not os.path.exists(self.path) and glob.has_magic(self.path):
+            paths = sorted(glob.glob(self.path))
+        if not paths:
+            logging.error(f"Cab file {self.path} not found")
+            return False
+
         if not os.path.exists(self.destination):
             os.makedirs(self.destination)
 
@@ -81,17 +99,26 @@ class CabExtract:
                     preventing broken symlinks
                     """
                     file_path = os.path.join(self.destination, file)
-                    if os.path.exists(file_path):
+                    if os.path.lexists(file_path):
                         if os.path.islink(file_path):
                             os.unlink(file_path)
 
-                    command = [
-                        self.cabextract_bin,
-                        "-F", f"*{file}*",
-                        "-d", self.destination,
-                        "-q", self.path,
-                    ]
-                    subprocess.run(command, check=False)
+                    expected = file.split("/")[-1].lower()
+                    for matched in self.__matching_files(self.destination, expected):
+                        if os.path.islink(matched):
+                            os.unlink(matched)
+                    files_before = self.__matching_files(self.destination, expected)
+                    for path in paths:
+                        command = [
+                            self.cabextract_bin,
+                            "-F",
+                            f"*{file}*",
+                            "-d",
+                            self.destination,
+                            "-q",
+                            path,
+                        ]
+                        subprocess.run(command, check=True)
 
                     if len(file.split("/")) > 1:
                         _file = file.split("/")[-1]
@@ -101,13 +128,23 @@ class CabExtract:
                                 os.path.join(self.destination, _dir, _file),
                                 os.path.join(self.destination, _file),
                             )
+
+                    if (
+                        self.__matching_files(self.destination, expected)
+                        == files_before
+                    ):
+                        logging.error(f"Cannot find extracted file: {file}")
+                        return False
             else:
-                command_list = [
-                    self.cabextract_bin,
-                    "-d", self.destination,
-                    "-q", self.path,
-                ]
-                subprocess.run(command_list, check=False)
+                for path in paths:
+                    command_list = [
+                        self.cabextract_bin,
+                        "-d",
+                        self.destination,
+                        "-q",
+                        path,
+                    ]
+                    subprocess.run(command_list, check=True)
 
             logging.info(f"Cabinet {self.name} extracted successfully")
             return True

--- a/bottles/tests/backend/test_cabextract.py
+++ b/bottles/tests/backend/test_cabextract.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+from bottles.backend import cabextract as cabextract_module
+from bottles.backend.cabextract import CabExtract
+
+
+def test_extract_expands_cab_wildcards(monkeypatch, tmp_path: Path) -> None:
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    archives = [archive_dir / "first.cab", archive_dir / "second.cab"]
+    for archive in archives:
+        archive.touch()
+
+    commands = []
+    def extract(command, check):
+        assert check is True
+        commands.append(command)
+        (Path(command[command.index("-d") + 1]) / "xaudio2_0.dll").touch()
+
+    monkeypatch.setattr(cabextract_module.subprocess, "run", extract)
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert extractor.run(
+        str(archive_dir / "*.cab"),
+        files=["xaudio*.dll"],
+        destination=str(tmp_path / "output"),
+    )
+    assert [Path(command[-1]) for command in commands] == archives
+
+
+def test_extract_rejects_unmatched_cab_wildcard(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        cabextract_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: None,
+    )
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert not extractor.run(
+        str(tmp_path / "*.cab"), destination=str(tmp_path / "output")
+    )
+
+
+def test_extract_rejects_unmatched_file_filter(monkeypatch, tmp_path: Path) -> None:
+    archive = tmp_path / "archive.cab"
+    archive.touch()
+    monkeypatch.setattr(
+        cabextract_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: None,
+    )
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert not extractor.run(
+        str(archive),
+        files=["missing*.dll"],
+        destination=str(tmp_path / "output"),
+    )
+
+
+def test_extract_does_not_accept_preexisting_filtered_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    archive = tmp_path / "archive.cab"
+    archive.touch()
+    destination = tmp_path / "output"
+    destination.mkdir()
+    (destination / "xaudio2_0.dll").touch()
+    monkeypatch.setattr(
+        cabextract_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: None,
+    )
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert not extractor.run(
+        str(archive), files=["xaudio*.dll"], destination=str(destination)
+    )
+
+
+def test_extract_replaces_broken_matching_symlink(
+    monkeypatch, tmp_path: Path
+) -> None:
+    archive = tmp_path / "archive.cab"
+    archive.touch()
+    destination = tmp_path / "output"
+    destination.mkdir()
+    missing_target = tmp_path / "missing.dll"
+    output = destination / "xaudio2_0.dll"
+    output.symlink_to(missing_target)
+
+    def extract(command, check):
+        assert check is True
+        assert not output.is_symlink()
+        output.write_bytes(b"native")
+
+    monkeypatch.setattr(cabextract_module.subprocess, "run", extract)
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert extractor.run(
+        str(archive), files=["xaudio*.dll"], destination=str(destination)
+    )
+    assert output.read_bytes() == b"native"
+    assert not missing_target.exists()
+
+
+def test_extract_accepts_literal_path_with_glob_characters(
+    monkeypatch, tmp_path: Path
+) -> None:
+    archive = tmp_path / "archive[1].cab"
+    archive.touch()
+    commands = []
+    monkeypatch.setattr(
+        cabextract_module.subprocess,
+        "run",
+        lambda command, check: commands.append((command, check)),
+    )
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert extractor.run(str(archive), destination=str(tmp_path / "output"))
+    assert commands[0][0][-1] == str(archive)
+    assert commands[0][1] is True
+
+
+def test_extract_reports_subprocess_failure(monkeypatch, tmp_path: Path) -> None:
+    archive = tmp_path / "archive.cab"
+    archive.touch()
+
+    def fail(_command, check):
+        assert check is True
+        raise cabextract_module.subprocess.CalledProcessError(1, "cabextract")
+
+    monkeypatch.setattr(cabextract_module.subprocess, "run", fail)
+    extractor = CabExtract()
+    extractor.cabextract_bin = "cabextract"
+
+    assert not extractor.run(str(archive), destination=str(tmp_path / "output"))


### PR DESCRIPTION
- [#4645](https://github.com/bottlesdevs/Bottles/issues/4645) Installing dependency "xact" does not make bottle use native xaudio2_0.dll