### PR TITLE
fix: steam runtime not passing dash arguments

### DIFF
--- a/bottles/backend/wine/winecommand.py
+++ b/bottles/backend/wine/winecommand.py
@@ -840,7 +840,7 @@ class WineCommand:
             if _picked:
                 logging.info(f"Using Steam runtime {_picked['name']}")
                 self.steam_runtime_root = os.path.dirname(_picked["entry_point"])
-                command = f"{_picked['entry_point']} {command}"
+                command = f"{_picked['entry_point']} -- {command}"
             else:
                 logging.warning(
                     "Steam runtime was requested and found but there are no valid combinations"


### PR DESCRIPTION
# Description
Fixes #4683 
**This minor fix changes it so that it now mimics how Steam itself launches games**

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
* Run any application (except easyterm) with a Proton runner with the Steam Runtime enabled, then get Bottles to axe it.
* Play a game that accepts dashed command line arguments after `%command%`, and see if the game responds to it.