### PR TITLE
fix: normalize duplicate bottle paths and handle copy failures

### DIFF
--- a/bottles/backend/managers/backup.py
+++ b/bottles/backend/managers/backup.py
@@ -737,21 +737,40 @@ class BackupManager:
         """
         logging.info(f"Duplicating bottle: {config.Name} as {name}")
 
-        sanitized_name = pathvalidate.sanitize_filename(name, platform="universal")
+        if not name.strip():
+            return Result(status=False, message=_("Bottle name cannot be empty."))
+
+        sanitized_name = pathvalidate.sanitize_filename(
+            name.replace(" ", "-"), platform="universal"
+        )
+        if not sanitized_name:
+            return Result(status=False, message=_("Bottle name is not valid."))
+
         source_path = ManagerUtils.get_bottle_path(config)
         destination_path = os.path.join(Paths.bottles, sanitized_name)
 
+        duplicate_name = name
+        suffix = 1
+        while os.path.lexists(destination_path):
+            duplicate_name = f"{name}__{suffix}"
+            destination_path = os.path.join(
+                Paths.bottles, f"{sanitized_name}__{suffix}"
+            )
+            suffix += 1
+
         return BackupManager._duplicate_bottle_directory(
-            config, source_path, destination_path, name
+            config, source_path, destination_path, duplicate_name
         )
 
     @staticmethod
     def _duplicate_bottle_directory(
         config: BottleConfig, source_path: str, destination_path: str, new_name: str
     ) -> Result:
+        destination_created = False
+        duplicate_succeeded = False
         try:
-            if not os.path.exists(destination_path):
-                os.makedirs(destination_path)
+            os.makedirs(destination_path)
+            destination_created = True
             for item in [
                 "drive_c",
                 "system.reg",
@@ -780,7 +799,11 @@ class BackupManager:
                 yaml.dump(config_data, config_file, indent=4)
 
             logging.info(f"Bottle duplicated successfully as {new_name}.")
+            duplicate_succeeded = True
             return Result(status=True)
-        except (FileNotFoundError, PermissionError, OSError) as e:
+        except (OSError, shutil.Error) as e:
             logging.error(f"Error duplicating bottle: {e}")
-            return Result(status=False)
+            return Result(status=False, message=str(e))
+        finally:
+            if destination_created and not duplicate_succeeded:
+                shutil.rmtree(destination_path, ignore_errors=True)

--- a/bottles/frontend/ui/dialog-duplicate.blp
+++ b/bottles/frontend/ui/dialog-duplicate.blp
@@ -35,6 +35,7 @@ template $DuplicateDialog: Adw.Window {
       [end]
       Button btn_duplicate {
         label: _("Duplicate");
+        sensitive: false;
 
         styles [
           "suggested-action",
@@ -92,6 +93,16 @@ template $DuplicateDialog: Adw.Window {
         child: Adw.StatusPage page_duplicated {
           icon-name: "object-select-symbolic";
           title: _("Bottle Duplicated");
+        };
+      }
+
+      StackPage {
+        name: "page_failed";
+
+        child: Adw.StatusPage page_failed {
+          icon-name: "dialog-error-symbolic";
+          title: _("Bottle Duplication Failed");
+          description: _("The bottle could not be duplicated.");
         };
       }
     }

--- a/bottles/frontend/windows/duplicate.py
+++ b/bottles/frontend/windows/duplicate.py
@@ -15,9 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import time
+from gettext import gettext as _
 
 from gi.repository import Adw, GLib, Gtk
+
 from bottles.backend.managers.backup import BackupManager
 from bottles.backend.utils.threading import RunAsync
 from bottles.frontend.utils.gtk import GtkUtils
@@ -33,6 +34,7 @@ class DuplicateDialog(Adw.Window):
     btn_duplicate = Gtk.Template.Child()
     stack_switcher = Gtk.Template.Child()
     progressbar = Gtk.Template.Child()
+    page_failed = Gtk.Template.Child()
 
     # endregion
 
@@ -57,8 +59,9 @@ class DuplicateDialog(Adw.Window):
             self.pulse_id = None
 
     def __check_entry_name(self, *_args):
-        is_duplicate = self.entry_name.get_text() in self.parent.manager.local_bottles
-        if is_duplicate:
+        name = self.entry_name.get_text()
+        is_invalid = not name.strip() or name in self.parent.manager.local_bottles
+        if is_invalid:
             self.entry_name.add_css_class("error")
             self.btn_duplicate.set_sensitive(False)
         else:
@@ -90,7 +93,15 @@ class DuplicateDialog(Adw.Window):
         if self.pulse_id:
             GLib.source_remove(self.pulse_id)
             self.pulse_id = None
-        # TODO: handle result.status == False
+
+        if error or result is None or not result.status:
+            message = str(error) if error else result.message if result else ""
+            self.page_failed.set_description(
+                message or _("The bottle could not be duplicated.")
+            )
+            self.stack_switcher.set_visible_child_name("page_failed")
+            return
+
         self.parent.manager.update_bottles()
         self.stack_switcher.set_visible_child_name("page_duplicated")
 

--- a/bottles/tests/backend/manager/test_backup.py
+++ b/bottles/tests/backend/manager/test_backup.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tarfile
 from concurrent.futures import CancelledError
 from pathlib import Path
@@ -7,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from bottles.backend.globals import Paths
 from bottles.backend.managers.backup import BackupManager
 from bottles.backend.models.config import BottleConfig
 from bottles.backend.state import SignalManager, Task, TaskManager
@@ -143,6 +145,102 @@ def test_duplicate_bottle_preserves_hidden_files(tmp_path):
     assert (
         destination / "drive_c/.hidden-directory/payload.dat"
     ).read_bytes() == b"payload"
+
+
+def test_duplicate_bottle_replaces_spaces_in_destination_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(Paths, "bottles", str(tmp_path))
+    source = tmp_path / "Source"
+    (source / "drive_c").mkdir(parents=True)
+    with (source / "bottle.yml").open("w") as config_file:
+        yaml.dump({"Name": "Source", "Path": "Source"}, config_file)
+
+    result = BackupManager.duplicate_bottle(
+        BottleConfig(Name="Source", Path="Source"), "Destination Bottle"
+    )
+
+    assert result.status
+    assert (tmp_path / "Destination-Bottle").is_dir()
+    assert not (tmp_path / "Destination Bottle").exists()
+    with (tmp_path / "Destination-Bottle/bottle.yml").open() as config_file:
+        duplicate_config = yaml.load(config_file)
+    assert duplicate_config["Name"] == "Destination Bottle"
+
+
+def test_duplicate_bottle_appends_next_available_suffix(tmp_path, monkeypatch):
+    monkeypatch.setattr(Paths, "bottles", str(tmp_path))
+    source = tmp_path / "Source"
+    (source / "drive_c").mkdir(parents=True)
+    with (source / "bottle.yml").open("w") as config_file:
+        yaml.dump({"Name": "Source", "Path": "Source"}, config_file)
+
+    for destination_name in ("Destination-Bottle", "Destination-Bottle__1"):
+        destination = tmp_path / destination_name
+        destination.mkdir()
+        (destination / "marker").write_text("existing")
+
+    result = BackupManager.duplicate_bottle(
+        BottleConfig(Name="Source", Path="Source"), "Destination Bottle"
+    )
+
+    assert result.status
+    assert (tmp_path / "Destination-Bottle/marker").read_text() == "existing"
+    assert (tmp_path / "Destination-Bottle__1/marker").read_text() == "existing"
+    with (tmp_path / "Destination-Bottle__2/bottle.yml").open() as config_file:
+        duplicate_config = yaml.load(config_file)
+    assert duplicate_config["Name"] == "Destination Bottle__2"
+
+
+def test_duplicate_bottle_rejects_empty_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(Paths, "bottles", str(tmp_path))
+
+    result = BackupManager.duplicate_bottle(
+        BottleConfig(Name="Source", Path="Source"), "   "
+    )
+
+    assert not result.status
+    assert not list(tmp_path.iterdir())
+
+
+def test_duplicate_bottle_does_not_overwrite_existing_destination(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    (source / "drive_c").mkdir(parents=True)
+    destination.mkdir()
+    marker = destination / "marker"
+    marker.write_text("existing")
+
+    result = BackupManager._duplicate_bottle_directory(
+        BottleConfig(Name="Source", Path="Source"),
+        str(source),
+        str(destination),
+        "Destination",
+    )
+
+    assert not result.status
+    assert marker.read_text() == "existing"
+
+
+def test_duplicate_bottle_removes_partial_destination_after_failure(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    (source / "drive_c").mkdir(parents=True)
+
+    def fail_copytree(*_args, **_kwargs):
+        raise shutil.Error("copy failed")
+
+    monkeypatch.setattr(shutil, "copytree", fail_copytree)
+
+    result = BackupManager._duplicate_bottle_directory(
+        BottleConfig(Name="Source", Path="Source"),
+        str(source),
+        str(destination),
+        "Destination",
+    )
+
+    assert not result.status
+    assert not destination.exists()
 
 
 def test_full_backup_is_atomic_when_cancelled_during_file_copy(tmp_path, monkeypatch):

--- a/bottles/tests/frontend/test_duplicate.py
+++ b/bottles/tests/frontend/test_duplicate.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+from gi.repository import Gio
+
+bottles_resource = Gio.Resource.load("/app/share/bottles/bottles.gresource")
+bottles_resource._register()
+
+from bottles.backend.models.result import Result  # noqa: E402
+from bottles.frontend.windows.duplicate import DuplicateDialog  # noqa: E402
+
+
+class EntryStub:
+    def __init__(self, text):
+        self.text = text
+        self.css_classes = set()
+
+    def get_text(self):
+        return self.text
+
+    def add_css_class(self, css_class):
+        self.css_classes.add(css_class)
+
+    def remove_css_class(self, css_class):
+        self.css_classes.discard(css_class)
+
+
+@pytest.mark.parametrize(
+    ("name", "existing_names", "expected_sensitive"),
+    (
+        ("", {}, False),
+        ("   ", {}, False),
+        ("Existing", {"Existing": object()}, False),
+        ("New Bottle", {}, True),
+    ),
+)
+def test_duplicate_name_validation(name, existing_names, expected_sensitive):
+    dialog = SimpleNamespace(
+        entry_name=EntryStub(name),
+        btn_duplicate=SimpleNamespace(
+            set_sensitive=lambda value: setattr(dialog, "sensitive", value)
+        ),
+        parent=SimpleNamespace(manager=SimpleNamespace(local_bottles=existing_names)),
+    )
+
+    DuplicateDialog._DuplicateDialog__check_entry_name(dialog)
+
+    assert dialog.sensitive is expected_sensitive
+    assert ("error" in dialog.entry_name.css_classes) is not expected_sensitive
+
+
+def _make_finish_dialog():
+    dialog = SimpleNamespace(
+        pulse_id=None,
+        parent=SimpleNamespace(
+            manager=SimpleNamespace(
+                update_bottles=lambda: setattr(dialog, "updated", True)
+            )
+        ),
+        page_failed=SimpleNamespace(
+            set_description=lambda value: setattr(dialog, "failure_message", value)
+        ),
+        stack_switcher=SimpleNamespace(
+            set_visible_child_name=lambda value: setattr(dialog, "page", value)
+        ),
+        updated=False,
+        failure_message=None,
+        page=None,
+    )
+    return dialog
+
+
+def test_duplicate_finish_shows_success_and_refreshes_bottles():
+    dialog = _make_finish_dialog()
+
+    DuplicateDialog.finish.__wrapped__(dialog, Result(status=True))
+
+    assert dialog.updated
+    assert dialog.page == "page_duplicated"
+    assert dialog.failure_message is None
+
+
+@pytest.mark.parametrize(
+    ("result", "error", "expected_message"),
+    (
+        (Result(status=False, message="copy failed"), None, "copy failed"),
+        (None, RuntimeError("disk full"), "disk full"),
+    ),
+)
+def test_duplicate_finish_shows_failure_without_refreshing_bottles(
+    result, error, expected_message
+):
+    dialog = _make_finish_dialog()
+
+    DuplicateDialog.finish.__wrapped__(dialog, result, error)
+
+    assert not dialog.updated
+    assert dialog.page == "page_failed"
+    assert dialog.failure_message == expected_message


### PR DESCRIPTION
Prevents duplicate copies from overwriting an existing bottle, removes partial copies after failures and reports the error in the dialog.