### PR TITLE
fix: refresh bottle list on the main thread after deletion

### DIFF
--- a/bottles/backend/managers/manager.py
+++ b/bottles/backend/managers/manager.py
@@ -2789,7 +2789,10 @@ class Manager(metaclass=Singleton):
         path = ManagerUtils.get_bottle_path(config)
         subprocess.run(["rm", "-rf", path], stdout=subprocess.DEVNULL)
 
-        self.update_bottles(silent=True)
+        # The UI invokes delete_bottle in a worker thread. Refresh only the
+        # backend state here; its RunAsync callback rebuilds the GTK list on
+        # the main loop.
+        self.check_bottles(silent=True)
 
         logging.info(f"Deleted the bottle in: {path}")
         return True

--- a/bottles/tests/backend/manager/test_manager.py
+++ b/bottles/tests/backend/manager/test_manager.py
@@ -67,8 +67,9 @@ def test_delete_sandboxed_bottle_does_not_restart_wine(
     wineboot = mocker.patch.object(manager_module, "WineBoot")
     wineserver = mocker.patch.object(manager_module, "WineServer").return_value
     library = mocker.patch.object(manager_module, "LibraryManager").return_value
+    signal_send = mocker.patch.object(manager_module.SignalManager, "send")
     manager = object.__new__(Manager)
-    manager.update_bottles = mocker.Mock()
+    manager.check_bottles = mocker.Mock()
 
     assert manager.delete_bottle(config) is True
     assert not bottle_path.exists()
@@ -76,6 +77,8 @@ def test_delete_sandboxed_bottle_does_not_restart_wine(
     wineserver.force_kill.assert_called_once_with()
     wineserver.wait.assert_not_called()
     library.remove_bottle_entries.assert_called_once_with("Sandboxed")
+    manager.check_bottles.assert_called_once_with(silent=True)
+    signal_send.assert_not_called()
 
 
 def test_check_runners_discovers_external_steam_proton(tmp_path, monkeypatch):

--- a/bottles/tests/frontend/test_delete_bottle.py
+++ b/bottles/tests/frontend/test_delete_bottle.py
@@ -37,6 +37,7 @@ class FakeDialog:
 @pytest.fixture
 def harness(monkeypatch):
     events = []
+    callbacks = []
     dialog = FakeDialog(events)
 
     monkeypatch.setattr(
@@ -47,11 +48,11 @@ def harness(monkeypatch):
             ResponseAppearance=SimpleNamespace(DESTRUCTIVE=object()),
         ),
     )
-    monkeypatch.setattr(
-        bottle_details,
-        "RunAsync",
-        lambda *_args, **_kwargs: events.append("delete"),
-    )
+    def run_async(*_args, **kwargs):
+        events.append("delete")
+        callbacks.append(kwargs["callback"])
+
+    monkeypatch.setattr(bottle_details, "RunAsync", run_async)
     monkeypatch.setattr(
         bottle_details.GLib,
         "idle_add",
@@ -64,15 +65,15 @@ def harness(monkeypatch):
         window=SimpleNamespace(
             page_list=SimpleNamespace(
                 disable_bottle=lambda _config: events.append("navigate"),
-                update_bottles_list=lambda: None,
+                update_bottles_list=lambda: events.append("refresh"),
             )
         ),
     )
-    return view, dialog, events
+    return view, dialog, events, callbacks
 
 
 def test_delete_closes_the_dialog_before_leaving_the_page(harness):
-    view, dialog, events = harness
+    view, dialog, events, _callbacks = harness
 
     BottleView._BottleView__confirm_delete(view, None)
     dialog.response(dialog, "ok")
@@ -83,9 +84,22 @@ def test_delete_closes_the_dialog_before_leaving_the_page(harness):
 
 
 def test_cancelling_delete_only_closes_the_dialog(harness):
-    view, dialog, events = harness
+    view, dialog, events, callbacks = harness
 
     BottleView._BottleView__confirm_delete(view, None)
     dialog.response(dialog, "cancel")
 
     assert events == ["destroy"]
+    assert callbacks == []
+
+
+def test_delete_refreshes_list_from_async_callback(harness):
+    view, dialog, events, callbacks = harness
+
+    BottleView._BottleView__confirm_delete(view, None)
+    dialog.response(dialog, "ok")
+    assert "refresh" not in events
+
+    callbacks[0](True, None)
+
+    assert events[-1] == "refresh"


### PR DESCRIPTION
Refreshes the bottle list from the asynchronous completion callback so GTK updates stay on the main loop.