### PR TITLE
fix: UI uses shutdown/reboot functions

### DIFF
--- a/bottles/backend/wine/wineboot.py
+++ b/bottles/backend/wine/wineboot.py
@@ -16,7 +16,7 @@ class WineBoot(WineProgram):
         if status == -2:
             return self.nv_stop_all_processes()
 
-        states = {-1: "force", 0: "-k", 1: "-r", 2: "-s", 3: "-u", 4: "-i"}
+        states = {-1: "force", 0: "-k", 1: "-r", 2: "-s", 3: "-u", 4: "-i", 5: "-e", 11: "-e -f -k -r", 12: "-e -f -k -s"}
         envs = {
             "WINEDEBUG": "-all",
             "DISPLAY": ":3.0",
@@ -30,7 +30,8 @@ class WineBoot(WineProgram):
         if status in (-1, 0) and self.config.Parameters.sandbox:
             self.__terminate_sandbox()
 
-        if status == 0 and not WineServer(self.config).is_alive():
+        # No need to spin up the wineserver if we are trying to stop processes
+        if status in (0, 1, 2, 11, 12) and not WineServer(self.config).is_alive():
             logging.info("There is no running wineserver.")
             return
 
@@ -69,6 +70,9 @@ class WineBoot(WineProgram):
 
     def init(self):
         return self.send_status(4)
+
+    def end_session(self):
+        return self.send_status(5)
 
     def __terminate_sandbox(self):
         from bottles.backend.managers.sandbox import SandboxManager

--- a/bottles/frontend/ui/details-bottle.blp
+++ b/bottles/frontend/ui/details-bottle.blp
@@ -101,13 +101,13 @@ Popover pop_power {
     }
 
     $GtkModelButton btn_shutdown {
-      tooltip-text: _("Simulate a Windows system shutdown.");
       text: _("Shutdown");
+      tooltip-text: _("Simulate a Windows system shutdown");
     }
 
     $GtkModelButton btn_reboot {
-      tooltip-text: _("Simulate a Windows system reboot.");
       text: _("Reboot");
+      tooltip-text: _("Simulate a Windows system reboot");
     }
   }
 }

--- a/bottles/frontend/views/bottle_details.py
+++ b/bottles/frontend/views/bottle_details.py
@@ -1006,6 +1006,18 @@ the Bottles preferences or choose a new one to run applications."
             dialog.set_response_appearance("ok", Adw.ResponseAppearance.DESTRUCTIVE)
             dialog.connect("response", handle_response)
             dialog.present()
+        elif status == 1:
+            """ 
+            Intercepting 'wineboot -r' (state 1) to send 'wineboot -e -f -k -r' (state 11) instead.
+            Attempts to gracefully close applications before executing the Wine reboot
+            """
+            RunAsync(wineboot.send_status, callback=reset, status=11)
+        elif status == 2:
+            """ 
+            Intercepting 'wineboot -s' (state 2) to send 'wineboot -e -f -k -s' (state 12) instead.
+            Attempts to gracefully close applications before executing the Wine shutdown
+            """
+            RunAsync(wineboot.send_status, callback=reset, status=12)
 
     def __set_steam_rules(self):
         status = False if self.config.Environment == "Steam" else True


### PR DESCRIPTION
# Description
The "shutdown" and "reboot" options are currently placebos, as `wineboot.py` only responds to states -2 (stop all processes via the system), and 0 (stop all processes via wineboot's `-k` command).

This PR fixes #4702:
1. Fixes the existing tooltips for the two options that were not appearing

<img width="376" height="218" alt="image" src="https://github.com/user-attachments/assets/c943f939-55ce-4c66-824b-78d70f391a9a" />


2. Adds functionality to the "Shutdown" and "Reboot" functions so that a shutdown and reboot command is issued...

...But simply providing wineboot with a `-s` or `-r` flag alone doesn't really do what the tooltips say they do:
`Simulate a Windows system shutdown`
`Simulate a Windows system reboot`

I would imagine that most users expect the running applications to be closed during a shutdown, as gracefully as possible. This should likely prove useful for an application-based bottle, where a shutdown/reboot blocker would normally create a prompt for the user to save their files if they had unsaved work.

So I have added an "enhanced" state in `wineboot.py` that combines several command options for wineboot:
`11: -e -f -k -r`, and `12: -e -f -k -s`, based on the existing `1: '-r'`, and `2: '-s'`

What these flags do:
1. Attempt to gracefully end running processes
2. If the exit couldn't be achieved gracefully, or in a timely matter, wine issues an additional prompt asking if the user wants to forcefully exit
3. Kills any remaining processes (e.g. background processes, or others that ignore the shutdown command)
4. Stops the wineserver (`-s`), or updates the prefix registries/whatever else simulating a Windows reboot entails (`-r`). Closed applications are not restored after the reboot command is completed.
https://gitlab.winehq.org/wine/wine/-/wikis/Commands/wineboot

The benefit for adding `-e -f` rather than just `-k -s` alone is if the running application issues blockers. An application prompt allows users to take action before the shutdown process continues. Ignore that for about 5 seconds, and an additional Wine prompt should ask if the user would want to terminate the process (demonstrated below using an unsaved LibreOffice Writer document running through a bottle). Canceling the two prompts will (predictably) abort the shutdown process.

<img width="1395" height="730" alt="image" src="https://github.com/user-attachments/assets/16bdff73-38f5-4d93-bb46-4983201cdea1" />

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
In any bottle (runner agnostic), open an application, then use the shutdown or reboot commands from the UI. A command with the `-e -f -k -r/s` should be issued in the terminal, followed by the running applications starting the exit process.

**It needs to be said that some background processes (especially the ones that start on startup) have a chance of lingering after the use of the shutdown/reboot commands**. But I think it's more that the application I tried using (Smilegate's STOVE client sometimes closes halfway) for this test is... uncooperative.

Edit: Did more testing, the client is still finicky, but this is more of a wine/proton issue than a bottles issue.