### PR TITLE
fix: prevent mcsoda from appearing on non-macOS systems (darwin)

### DIFF
--- a/bottles/backend/managers/component.py
+++ b/bottles/backend/managers/component.py
@@ -17,6 +17,7 @@
 
 import contextlib
 import os
+import sys
 import shutil
 import stat
 import tarfile
@@ -162,6 +163,9 @@ class ComponentManager:
 
             if component[1].get("Category") == "runners":
                 if "soda" in component[0].lower() or "caffe" in component[0].lower():
+                    # Mitigation to avoid mcsoda from appearing on non MacOS systems
+                    if "mcsoda" in component[0].lower() and sys.platform != "darwin":
+                        continue
                     if not is_glibc_min_available():
                         logging.warning(
                             f"{component[0]} was found but it requires "


### PR DESCRIPTION
# Description
McSoda s a new runner that is built around macOS. This PR introduces a check and skips these runners on system platforms that do not report `darwin` (macOS).

I opted to skip these entries instead of creating a new category because it was not designed to run on Linux-based systems.

Fixes #4699, fixes #4705 

Edit: "Skip" is more apt than "hide"
Edit 2: Closes both issues that share the same fix

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

* Added the python `sys` library as a new dependency for this file.

# How Has This Been Tested?
Temporarily renamed my bottles directory to force Bottles to "start fresh"

This is the excerpt from the terminal that downloads Soda 11.0-5
```
21:50:55 (WARNING) No managed runners found. 
21:50:55 (INFO) Installing component: [soda-11.0-5]. 
soda-11.0-5-x86_64.tar.xz (100%) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (147.4MiB/147.4MiB - 11.5MiB)

21:51:09 (INFO) Renaming [soda-11.0-5-x86_64.tar.xz] to [soda-11.0-5-x86_64.tar.xz]. 
21:51:17 (INFO) Runners found:
	 - soda-11.0-5
	 - sys-wine-11.0
 
21:51:17 (INFO) Component installed: runner soda-11.0-5 
22:03:07 (INFO) [Shutdown] cleanup starting. 
22:03:07 (INFO) Starting shutdown cleanup … 
```
A side-by-side screenshot of the current stable version (66.7) on the left, and the build with these fixes applied on the right
<img width="1597" height="684" alt="image" src="https://github.com/user-attachments/assets/07243366-bf04-4533-9af9-34ccd2cc7c72" />
