### PR TITLE
fix: add `XCURSOR_SIZE` to the default inherited environment

### DIFF
--- a/bottles/backend/models/samples.py
+++ b/bottles/backend/models/samples.py
@@ -21,6 +21,7 @@ class Samples:
         "XAUTHORITY",
         "XDG_RUNTIME_DIR",
         "XMODIFIERS",
+        "XCURSOR_SIZE",
     ]
     environments = {
         "gaming": {


### PR DESCRIPTION
# Description

Adds `XCURSOR_SIZE` to the default system environment variables.

This fixes an issue where X11 applications may use an incorrect cursor size when a custom cursor pack is configured. Setting `XCURSOR_SIZE` in the default system environment ensures that applications use the configured cursor size.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unfortunately I couldn't test this change because Bottles doesn't include a nix flake.

I have tested adding `XCURSOR_SIZE` manually via the GUI however on Bottles 65.4.
