### PR TITLE
fix: applies user agents to allow access to repos

### DIFF
--- a/bottles/backend/managers/repository.py
+++ b/bottles/backend/managers/repository.py
@@ -191,6 +191,7 @@ class RepositoryManager:
                             c.setopt(c.TIMEOUT, 10)
                             c.setopt(c.NOPROGRESS, False)
                             c.setopt(c.XFERINFOFUNCTION, self.__curl_progress)
+                            c.setopt(pycurl.USERAGENT,f"Bottles/{APP_VERSION}")
                             self.__perform_index_request(c, buffer)
                             response_code = c.getinfo(c.RESPONSE_CODE)
                         except pycurl.error as e:

--- a/bottles/backend/repos/repo.py
+++ b/bottles/backend/repos/repo.py
@@ -25,6 +25,7 @@ import pycurl
 from bottles.backend.globals import Paths
 from bottles.backend.logger import Logger
 from bottles.backend.state import EventManager, Events
+from bottles.backend.params import APP_VERSION
 from bottles.backend.utils import yaml
 from bottles.backend.utils.threading import RunAsync
 
@@ -82,6 +83,7 @@ class Repo:
                 c.setopt(c.URL, index)
                 c.setopt(c.FOLLOWLOCATION, True)
                 c.setopt(c.WRITEDATA, buffer)
+                c.setopt(pycurl.USERAGENT,f"Bottles/{APP_VERSION}")
                 c.setopt(pycurl.CONNECTTIMEOUT, 10)
                 c.setopt(pycurl.TIMEOUT, 30)
                 c.perform()
@@ -129,6 +131,7 @@ class Repo:
                 c.setopt(c.URL, url)
                 c.setopt(c.FOLLOWLOCATION, True)
                 c.setopt(c.WRITEDATA, buffer)
+                c.setopt(pycurl.USERAGENT,f"Bottles/{APP_VERSION}")
                 c.setopt(pycurl.CONNECTTIMEOUT, 10)
                 c.setopt(pycurl.TIMEOUT, 30)
                 c.perform()


### PR DESCRIPTION
# Description
A recent backend change on the proxy server prevented Bottles from accessing the component files, often citing HTTP 403 errors in the terminal. While this didn't result in any errors to the UI, users end up using the fallback cached version without the latest updates.

After playing whack-a-mole for a bit, I found Bottles using this User Agent string: `PycURL/7.45.6 libcurl/8.12.1-DEV OpenSSL/3.5.7 zlib/1.3.1 brotli/1.2.0 libssh2/1.11.1_DEV nghttp2/1.64.0`. The Cloudflare endpoint is rejecting this string and returning error 1010/HTTP 403. Attached a modified pycURL output of an attempt to download Soda-11.0-6 (removed IP addresses and specific ray data), after forcing verbose mode.

```
> GET /repo/components//runners/wine/soda-11.0-6.yml HTTP/2
Host: proxy.usebottles.com
User-Agent: PycURL/7.45.6 libcurl/8.12.1-DEV OpenSSL/3.5.7 zlib/1.3.1 brotli/1.2.0 libssh2/1.11.1_DEV nghttp2/1.64.0
Accept: */*

* Request completely sent off
< HTTP/2 403 
< date: Thu, 27 Aug 2026 04:19:42 GMT
< content-type: text/plain; charset=UTF-8
< content-length: 17
< cache-control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
< expires: Thu, 01 Jan 1970 00:00:01 GMT
< referrer-policy: same-origin
< x-frame-options: SAMEORIGIN
< report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=<redacted>"}]}
< nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
< server: cloudflare
< cf-ray: <redacted cf ray>
< alt-svc: h3=":443"; ma=86400
< 
* Connection #0 to host proxy.usebottles.com left intact
```

Fixes #4738 
I supressed the 403s after adding user agent strings (`Bottles/APP_VERSION`) to three pycurl requests., but left the existing solution at `bottles/backend/downloader.py` as-is.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
* Launched the application UI, and attempted to download Soda-11.0-6.
* Verified that the user agent was the cause by running cURL commands:
What Bottles currently executes: `curl -v -A "PycURL/7.45.6 libcurl/8.12.1-DEV OpenSSL/3.5.7 zlib/1.3.1 brotli/1.2.0 libssh2/1.11.1_DEV nghttp2/1.64.0" 'https://proxy.usebottles.com/repo/components/index.yml'`
What this PR will execute: `curl -v -A "Bottles/66.9" "https://proxy.usebottles.com/repo/components/index.yml"`