### PR TITLE
feat: lazy loading for runner entries

### DIFF
--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -389,7 +389,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
             self.populate_cache_list()
             self.dlls_stack.set_visible_child_name("dlls_list")
 
-        #GLib.idle_add(render)
+        GLib.idle_add(render)
 
         # then refresh once the online or cached catalog has been organized
         EventManager.wait(Events.ComponentsOrganizing)
@@ -833,12 +833,13 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 self.list_dlls.add(expander)
                 self.__registry.append(expander)
 
-    # Renders only when runner is requested
     def __on_runner_expander_expanded(self, expander, _pspec, runner_struct):
         if not expander.get_expanded() or runner_struct["expanded"]:
             return
         for runner_data in runner_struct["expander_queue"]:
-            _entry = ComponentEntry(self.window, runner_data, runner_struct["runner_type"])
+            _entry = ComponentEntry(
+                self.window, runner_data, runner_struct["runner_type"]
+            )
             expander.add_row(_entry)
             self.__registry.append(_entry)
         runner_struct["expanded"] = True
@@ -846,6 +847,9 @@ class PreferencesWindow(Adw.PreferencesDialog):
     def __populate_runners_helper(
         self, runner_type, supported_runners_dict, identifiable_runners_struct
     ):
+        for identifiable_runner in identifiable_runners_struct:
+            identifiable_runner["runner_type"] = runner_type
+
         offline_runners_list = self.manager.get_offline_components(runner_type)
         if self.__display_unstable_candidate():
             for offline_runner_name in offline_runners_list:
@@ -870,7 +874,6 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 continue
 
             for identifiable_runner in identifiable_runners_struct:
-                identifiable_runner["runner_type"] = runner_type
                 if _runner_name.startswith(identifiable_runner["prefix"]):
                     while (
                         identifiable_runner["offline_runners"]
@@ -948,9 +951,9 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "prefix": "soda",
                 "count": 0,
                 "expander": exp_soda,
-                "offline_runners": [], 
+                "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
             {
                 "prefix": "caffe",
@@ -958,7 +961,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_caffe,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
             {
                 "prefix": "vaniglia",
@@ -966,7 +969,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_vaniglia,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
             {
                 "prefix": "kron4ek",
@@ -974,7 +977,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_kron4ek,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
         ]
         deprecated_wine_runners = [
@@ -984,7 +987,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_wine_ge,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
             {
                 "prefix": "lutris",
@@ -992,7 +995,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_lutris,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
         ]
         identifiable_proton_runners = [
@@ -1002,7 +1005,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_protosoda,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
             {
                 "prefix": "proton-cachyos",
@@ -1010,7 +1013,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_proton_cachyos,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
             {
                 "prefix": "ge-proton",
@@ -1018,7 +1021,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_proton_ge,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
         ]
         other_wine_runners = [
@@ -1028,7 +1031,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_other_wine,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
         ]
         other_proton_runners = [
@@ -1038,7 +1041,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "expander": exp_other_proton,
                 "offline_runners": [],
                 "expander_queue": [],
-                "expanded": False
+                "expanded": False,
             },
         ]
 
@@ -1065,8 +1068,11 @@ class PreferencesWindow(Adw.PreferencesDialog):
             if runner["count"] > 0:
                 self.list_runners.add(runner["expander"])
                 self.__registry.append(runner["expander"])
-                # Render the runners when requested
-                runner["expander"].connect("notify::expanded", self.__on_runner_expander_expanded, runner)
+                runner["expander"].connect(
+                    "notify::expanded",
+                    self.__on_runner_expander_expanded,
+                    runner,
+                )
 
         self.installers_stack.set_visible_child_name("installers_list")
 

--- a/bottles/frontend/views/preferences.py
+++ b/bottles/frontend/views/preferences.py
@@ -389,7 +389,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
             self.populate_cache_list()
             self.dlls_stack.set_visible_child_name("dlls_list")
 
-        GLib.idle_add(render)
+        #GLib.idle_add(render)
 
         # then refresh once the online or cached catalog has been organized
         EventManager.wait(Events.ComponentsOrganizing)
@@ -833,6 +833,16 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 self.list_dlls.add(expander)
                 self.__registry.append(expander)
 
+    # Renders only when runner is requested
+    def __on_runner_expander_expanded(self, expander, _pspec, runner_struct):
+        if not expander.get_expanded() or runner_struct["expanded"]:
+            return
+        for runner_data in runner_struct["expander_queue"]:
+            _entry = ComponentEntry(self.window, runner_data, runner_struct["runner_type"])
+            expander.add_row(_entry)
+            self.__registry.append(_entry)
+        runner_struct["expanded"] = True
+
     def __populate_runners_helper(
         self, runner_type, supported_runners_dict, identifiable_runners_struct
     ):
@@ -859,8 +869,8 @@ class PreferencesWindow(Adw.PreferencesDialog):
             if not self.__display_unstable_candidate(supported_runner):
                 continue
 
-            _entry = ComponentEntry(self.window, supported_runner, runner_type)
             for identifiable_runner in identifiable_runners_struct:
+                identifiable_runner["runner_type"] = runner_type
                 if _runner_name.startswith(identifiable_runner["prefix"]):
                     while (
                         identifiable_runner["offline_runners"]
@@ -873,12 +883,9 @@ class PreferencesWindow(Adw.PreferencesDialog):
                         == identifiable_runner["offline_runners"][0][0]
                     ):
                         offline_runner = identifiable_runner["offline_runners"].pop(0)
-                        _offline_entry = ComponentEntry(
-                            self.window, offline_runner, runner_type
-                        )
-                        identifiable_runner["expander"].add_row(_offline_entry)
+                        identifiable_runner["expander_queue"].append(offline_runner)
                         identifiable_runner["count"] += 1
-                    identifiable_runner["expander"].add_row(_entry)
+                    identifiable_runner["expander_queue"].append(supported_runner)
                     identifiable_runner["count"] += 1
                     break
 
@@ -886,10 +893,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
         for identifiable_runner in identifiable_runners_struct:
             while identifiable_runner["offline_runners"]:
                 offline_runner = identifiable_runner["offline_runners"].pop(0)
-                _offline_entry = ComponentEntry(
-                    self.window, offline_runner, runner_type
-                )
-                identifiable_runner["expander"].add_row(_offline_entry)
+                identifiable_runner["expander_queue"].append(offline_runner)
                 identifiable_runner["count"] += 1
 
     def populate_runners_list(self):
@@ -940,24 +944,37 @@ class PreferencesWindow(Adw.PreferencesDialog):
         exp_other_proton = ComponentExpander(_("Other Proton runners"))
 
         identifiable_wine_runners = [
-            {"prefix": "soda", "count": 0, "expander": exp_soda, "offline_runners": []},
+            {
+                "prefix": "soda",
+                "count": 0,
+                "expander": exp_soda,
+                "offline_runners": [], 
+                "expander_queue": [],
+                "expanded": False
+            },
             {
                 "prefix": "caffe",
                 "count": 0,
                 "expander": exp_caffe,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
             {
                 "prefix": "vaniglia",
                 "count": 0,
                 "expander": exp_vaniglia,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
             {
                 "prefix": "kron4ek",
                 "count": 0,
                 "expander": exp_kron4ek,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
         ]
         deprecated_wine_runners = [
@@ -966,12 +983,16 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "count": 0,
                 "expander": exp_wine_ge,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
             {
                 "prefix": "lutris",
                 "count": 0,
                 "expander": exp_lutris,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
         ]
         identifiable_proton_runners = [
@@ -980,18 +1001,24 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "count": 0,
                 "expander": exp_protosoda,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
             {
                 "prefix": "proton-cachyos",
                 "count": 0,
                 "expander": exp_proton_cachyos,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
             {
                 "prefix": "ge-proton",
                 "count": 0,
                 "expander": exp_proton_ge,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
         ]
         other_wine_runners = [
@@ -1000,6 +1027,8 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "count": 0,
                 "expander": exp_other_wine,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
         ]
         other_proton_runners = [
@@ -1008,6 +1037,8 @@ class PreferencesWindow(Adw.PreferencesDialog):
                 "count": 0,
                 "expander": exp_other_proton,
                 "offline_runners": [],
+                "expander_queue": [],
+                "expanded": False
             },
         ]
 
@@ -1034,6 +1065,8 @@ class PreferencesWindow(Adw.PreferencesDialog):
             if runner["count"] > 0:
                 self.list_runners.add(runner["expander"])
                 self.__registry.append(runner["expander"])
+                # Render the runners when requested
+                runner["expander"].connect("notify::expanded", self.__on_runner_expander_expanded, runner)
 
         self.installers_stack.set_visible_child_name("installers_list")
 

--- a/bottles/tests/frontend/test_flatpak.py
+++ b/bottles/tests/frontend/test_flatpak.py
@@ -54,6 +54,79 @@ class FileChooserNativeStub:
         return FolderStub()
 
 
+class ExpanderStub:
+    def __init__(self):
+        self.expanded = False
+        self.rows = []
+
+    def get_expanded(self):
+        return self.expanded
+
+    def add_row(self, row):
+        self.rows.append(row)
+
+
+def test_runner_entries_are_created_on_first_expansion(monkeypatch):
+    entries = []
+    expander = ExpanderStub()
+    runner = {
+        "prefix": "soda",
+        "count": 0,
+        "expander": expander,
+        "offline_runners": [],
+        "expander_queue": [],
+        "expanded": False,
+    }
+    view = SimpleNamespace(
+        window=object(),
+        manager=SimpleNamespace(
+            get_offline_components=lambda _component_type: ["soda-9.0-1"]
+        ),
+        _PreferencesWindow__registry=[],
+        _PreferencesWindow__display_unstable_candidate=lambda *_args: True,
+    )
+
+    monkeypatch.setattr(
+        preferences,
+        "ComponentEntry",
+        lambda _window, component, component_type: entries.append(
+            (component, component_type)
+        ),
+    )
+
+    preferences.PreferencesWindow._PreferencesWindow__populate_runners_helper(
+        view, "runner", {}, [runner]
+    )
+    preferences.PreferencesWindow._PreferencesWindow__on_runner_expander_expanded(
+        view, expander, None, runner
+    )
+    assert entries == []
+
+    expander.expanded = True
+    preferences.PreferencesWindow._PreferencesWindow__on_runner_expander_expanded(
+        view, expander, None, runner
+    )
+    preferences.PreferencesWindow._PreferencesWindow__on_runner_expander_expanded(
+        view, expander, None, runner
+    )
+
+    assert entries == [
+        (
+            [
+                "soda-9.0-1",
+                {
+                    "Installed": True,
+                    "Channel": "unstable",
+                    "Category": "runners",
+                    "Sub-category": "wine",
+                },
+            ],
+            "runner",
+        )
+    ]
+    assert len(expander.rows) == 1
+
+
 def test_filesystem_override_command_uses_current_app_id(monkeypatch):
     monkeypatch.setenv("FLATPAK_ID", "com.usebottles.bottles.Devel")
     monkeypatch.setattr(


### PR DESCRIPTION
# Description
As mentioned in #4717, Bottles takes a while to launch the preferences dialog for the first time, and originally had a memory leak (#4721). The leak was fixed in commit 20c9498, but the first launch was still slow.

Bottles currently generates all of the menu items prior to showing it to the user. This PR changes the behavior so that only the runner headers are generated, and the remainder of the entries for that runner get loaded on demand (lazy loading). Also commented out a duplicate render call, as it didn't offer much benefit during testing.

This results in the dialog launching sooner, with less memory used upfront. 
Resolves #4717 

**AI disclaimer: Used Claude to help optimize this solution**

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Entries with a lot of entries (most evident with Kron4ek) will have a slight delay before the list gets expanded.

# How Has This Been Tested?
Runners can be managed normally (downloading/viewing runner files, deleting runners)
