### PR TITLE
fix(frontend): populate component selectors after bottle creation

### DIFF
--- a/bottles/frontend/views/list.py
+++ b/bottles/frontend/views/list.py
@@ -409,6 +409,7 @@ class BottleView(Adw.Bin):
 
     def show_page(self, page: str) -> None:
         if config := self.window.manager.local_bottles.get(page):
+            self.window.page_details.view_preferences.update_combo_components()
             self.window.show_details_view(config=config)
 
     def disable_bottle(self, config):


### PR DESCRIPTION
# Description
Populate the component combo models before programmatically opening a newly created bottle. This restores parity with opening a bottle from the list and prevents the component selectors from appearing empty on first open.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
