### PR TITLE
fix: refresh programs after list executable exits

### DIFF
--- a/bottles/frontend/views/list.py
+++ b/bottles/frontend/views/list.py
@@ -148,7 +148,7 @@ class BottlesBottleRow(Adw.ActionRow):
                 _executor = WineExecutor(
                     self.config, exec_path=run_path, sandbox_override=sandbox_override
                 )
-                RunAsync(_executor.run)
+                RunAsync(_executor.run, self._on_executable_finished)
 
             guard_sandbox_launch(self.window, self.config, path, proceed)
 
@@ -164,6 +164,10 @@ class BottlesBottleRow(Adw.ActionRow):
         dialog.set_modal(True)
         dialog.connect("response", set_path)
         dialog.show()
+
+    def _on_executable_finished(self, _result=None, _error=None):
+        """Refresh discovered programs after an executable exits."""
+        self.manager.get_programs(self.config, force_update=True)
 
     def show_details(self, widget=None, config=None):
         if config is None:

--- a/bottles/tests/frontend/test_bottle_list_order.py
+++ b/bottles/tests/frontend/test_bottle_list_order.py
@@ -6,6 +6,7 @@ from gi.repository import Gio
 Gio.resources_register(Gio.Resource.load("/app/share/bottles/bottles.gresource"))
 
 from bottles.frontend.views.list import (  # noqa: E402
+    BottlesBottleRow,
     BottleView,
     _bottle_order_id,
     _ordered_bottles,
@@ -51,6 +52,23 @@ def test_replace_group_order_keeps_unavailable_and_other_group_entries():
         "bottle:Beta",
         "bottle:Alpha",
     ]
+
+
+def test_bottle_row_refreshes_programs_after_executable_finishes():
+    calls = []
+    config = _config("Test")
+    row = SimpleNamespace(
+        config=config,
+        manager=SimpleNamespace(
+            get_programs=lambda called_config, **kwargs: calls.append(
+                (called_config, kwargs)
+            )
+        ),
+    )
+
+    BottlesBottleRow._on_executable_finished(row)
+
+    assert calls == [(config, {"force_update": True})]
 
 
 def test_reorder_bottle_updates_only_its_group():


### PR DESCRIPTION
# Description
Refresh the selected bottle’s program cache after an executable launched from the bottle list exits, so newly installed applications appear without restarting Bottles.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
- [ ] Test A
- [ ] Test B
