### PR TITLE
fix[closes #4803]: restore snapshots page

### DIFF
--- a/bottles/frontend/ui/details-versioning.blp
+++ b/bottles/frontend/ui/details-versioning.blp
@@ -1,76 +1,90 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $DetailsVersioning: Adw.PreferencesPage {
-  Adw.PreferencesPage pref_page {
+template $DetailsVersioning: Adw.Bin {
+  Box {
+    orientation: vertical;
+
     Adw.Banner banner_dirty {
       title: _("You have unsaved changes. Create a snapshot to save them.");
       revealed: false;
       button-label: _("Create Snapshot");
     }
 
-    Adw.PreferencesGroup {
-      Adw.ComboRow combo_branch {
-        title: _("Branch");
-        subtitle: _("Switch to another workspace.");
-        model: StringList str_list_branch {};
+    Adw.PreferencesPage pref_page {
+      Adw.PreferencesGroup {
+        Adw.ComboRow combo_branch {
+          title: _("Branch");
+          subtitle: _("Switch to another workspace.");
 
-        [suffix]
-        Button btn_manage_branches {
-          tooltip-text: _("Manage Branches");
-          valign: center;
-          icon-name: "document-edit-symbolic";
-          styles [ "flat" ]
-        }
+          model: StringList str_list_branch {};
 
-        [suffix]
-        Button btn_add_branch {
-          tooltip-text: _("Create new Branch");
-          valign: center;
-          icon-name: "list-add-symbolic";
-          styles [ "flat" ]
+          [suffix]
+          Button btn_manage_branches {
+            tooltip-text: _("Manage Branches");
+            valign: center;
+            icon-name: "document-edit-symbolic";
+
+            styles [
+              "flat",
+            ]
+          }
+
+          [suffix]
+          Button btn_add_branch {
+            tooltip-text: _("Create new Branch");
+            valign: center;
+            icon-name: "list-add-symbolic";
+
+            styles [
+              "flat",
+            ]
+          }
         }
       }
-    }
 
-    Adw.PreferencesGroup {
-      Box box_spinner {
-        orientation: vertical;
-        halign: center;
-        valign: center;
-        spacing: 12;
-        margin-top: 24;
-        margin-bottom: 24;
-        visible: false;
-
-        Spinner spinner {
-          width-request: 32;
-          height-request: 32;
+      Adw.PreferencesGroup {
+        Box box_spinner {
+          orientation: vertical;
           halign: center;
-        }
+          valign: center;
+          spacing: 12;
+          margin-top: 24;
+          margin-bottom: 24;
+          visible: false;
 
-        Label label_spinner {
-          label: _("Switching branch…");
-          styles [ "dim-label" ]
+          Spinner spinner {
+            width-request: 32;
+            height-request: 32;
+            halign: center;
+          }
+
+          Label label_spinner {
+            label: _("Switching branch...");
+
+            styles [
+              "dim-label",
+            ]
+          }
+        }
+      }
+
+      Adw.PreferencesGroup {
+        ListBox list_states {
+          selection-mode: none;
+
+          styles [
+            "boxed-list",
+          ]
         }
       }
     }
 
-    Adw.PreferencesGroup {
-      ListBox list_states {
-        selection-mode: none;
-
-        styles [
-          "boxed-list",
-        ]
-      }
+    Adw.StatusPage status_page {
+      icon-name: "preferences-system-time-symbolic";
+      title: _("No Snapshots Found");
+      description: _("Create your first snapshot to start saving states of your preferences.");
     }
-  }
-
-  Adw.StatusPage status_page {
-    icon-name: "preferences-system-time-symbolic";
-    title: _("No Snapshots Found");
-    description: _("Create your first snapshot to start saving states of your preferences.");
   }
 }
 

--- a/bottles/frontend/views/bottle_versioning.py
+++ b/bottles/frontend/views/bottle_versioning.py
@@ -31,7 +31,7 @@ from bottles.frontend.windows.versioning_manage_branches import VersioningManage
 
 
 @Gtk.Template(resource_path="/com/usebottles/bottles/details-versioning.ui")
-class VersioningView(Adw.PreferencesPage):
+class VersioningView(Adw.Bin):
     __gtype_name__ = "DetailsVersioning"
     __registry = []
 
@@ -286,4 +286,3 @@ class VersioningView(Adw.PreferencesPage):
             config=self.config,
             message=message,
         )
-

--- a/bottles/tests/frontend/test_versioning_view.py
+++ b/bottles/tests/frontend/test_versioning_view.py
@@ -1,0 +1,68 @@
+# ruff: noqa: E402
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import gi
+import pytest
+
+gi.require_version("Adw", "1")
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Adw, Gio, GLib, Gtk
+
+blueprint_compiler = shutil.which("blueprint-compiler")
+resource_bundle = Path(
+    os.environ.get("BOTTLES_TEST_RESOURCE", "/app/share/bottles/bottles.gresource")
+)
+if blueprint_compiler is None or not resource_bundle.is_file():
+    pytest.skip("Bottles Flatpak test resources are required", allow_module_level=True)
+
+resource_dir = tempfile.TemporaryDirectory(prefix="bottles-versioning-view-")
+source_root = Path(__file__).resolve().parents[3]
+subprocess.run(
+    [
+        blueprint_compiler,
+        "compile",
+        str(source_root / "bottles/frontend/ui/details-versioning.blp"),
+        "--output",
+        str(Path(resource_dir.name) / "details-versioning.ui"),
+    ],
+    check=True,
+)
+os.environ["G_RESOURCE_OVERLAYS"] = f"/com/usebottles/bottles={resource_dir.name}"
+
+Gio.resources_register(Gio.Resource.load(str(resource_bundle)))
+
+from bottles.backend.models.config import BottleConfig
+from bottles.frontend.views.bottle_versioning import VersioningView
+
+
+def test_empty_snapshot_page_is_visible():
+    config = BottleConfig()
+    config.Versioning = True
+    details = SimpleNamespace(
+        window=SimpleNamespace(
+            manager=SimpleNamespace(versioning_manager=object()),
+        ),
+    )
+    view = VersioningView(details, config)
+    view.status_page.set_visible(True)
+    view.pref_page.set_visible(False)
+    window = Gtk.Window(child=view)
+    window.set_default_size(640, 480)
+    window.present()
+
+    context = GLib.MainContext.default()
+    while context.pending():
+        context.iteration(False)
+
+    assert isinstance(view, Adw.Bin)
+    assert view.status_page.get_mapped()
+    assert view.status_page.get_width() > 0
+    assert view.status_page.get_height() > 0
+    window.destroy()


### PR DESCRIPTION
Fixes #4803

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Compiled the Blueprint with GNOME SDK 49 and 50
- [x] Verified the empty snapshot page maps at 642x296 under Xvfb on both runtimes